### PR TITLE
Fix CORS configuration to resolve SPA cross-origin errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ tools/
 [Tt]emp/
 .vscode/
 
+# Claude Code local settings (machine-specific permissions)
+.claude/settings.local.json
+
 # Mono auto generated files
 mono_crash.*
 

--- a/src/Web/Startup.cs
+++ b/src/Web/Startup.cs
@@ -30,18 +30,13 @@ public class Startup(IConfiguration configuration)
             );
         services.AddCors(options =>
         {
-            options.AddPolicy("AllowNeurocorp",
+            options.AddPolicy("AllowedOrigins",
                 builder => builder
-                    .SetIsOriginAllowed(origin => new Uri(origin).Host.Contains("neurocorp"))                    
-                    .AllowAnyHeader()
-                    .AllowAnyMethod()
-                    .AllowCredentials());
-        });
-        services.AddCors(options =>
-        {
-            options.AddPolicy("AllowLocalhost",
-                builder => builder
-                    .SetIsOriginAllowed(origin => new Uri(origin).Host.Contains("localhost"))
+                    .SetIsOriginAllowed(origin =>
+                    {
+                        var host = new Uri(origin).Host;
+                        return host.Contains("neurocorp") || host.Contains("localhost");
+                    })
                     .AllowAnyHeader()
                     .AllowAnyMethod()
                     .AllowCredentials());
@@ -74,20 +69,7 @@ public class Startup(IConfiguration configuration)
 
         app.UseHttpsRedirection();
         app.UseRouting();
-        app.UseCors("AllowLocalhost");
-        app.UseCors("AllowNeurocorp");
-        app.Use(async (context, next) =>
-        {
-            if (context.Request.Method == "OPTIONS")
-            {
-                context.Response.Headers.Append("Access-Control-Allow-Origin", "*");
-                context.Response.Headers.Append("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
-                context.Response.Headers.Append("Access-Control-Allow-Headers", "Content-Type, Authorization");
-                context.Response.StatusCode = 204;
-                return;
-            }
-            await next();
-        });
+        app.UseCors("AllowedOrigins");
 
         app.UseAuthorization();
 


### PR DESCRIPTION
Consolidate two separate CORS policies into a single policy allowing both neurocorp and localhost origins. Remove conflicting manual OPTIONS middleware that returned Access-Control-Allow-Origin: * (incompatible with AllowCredentials).