### PR TITLE
Fix ActiveStatus not persisting on PUT updates and add regression tests

### DIFF
--- a/src/Infrastructure/Repositories/CaretakerProfileRepository.cs
+++ b/src/Infrastructure/Repositories/CaretakerProfileRepository.cs
@@ -79,7 +79,7 @@ public class CaretakerProfileRepository(ApplicationDbContext dbContext) :
         if (!string.IsNullOrEmpty(request.LastName)) { userOnFile.LastName = request.LastName; }
         if (!string.IsNullOrEmpty(request.Email)) { userOnFile.Email = request.Email; }
         if (!string.IsNullOrEmpty(request.PhoneNumber)) { userOnFile.PhoneNumber = request.PhoneNumber; }
-        if (!userOnFile.ActiveStatus && userOnFile.ActiveStatus != request.IsActive) { userOnFile.ActiveStatus = request.IsActive; }
+        if (userOnFile.ActiveStatus != request.IsActive) { userOnFile.ActiveStatus = request.IsActive; }
 
         return userOnFile;
     }

--- a/src/Infrastructure/Repositories/EfRepository.cs
+++ b/src/Infrastructure/Repositories/EfRepository.cs
@@ -30,15 +30,15 @@ public class EfRepository<T> : IRepository<T> where T : class
 
     public virtual async Task<T?> GetByIdAsync(int id)
     {
-        _dbContext.Set<T>().AsNoTracking();
         return await _dbContext.Set<T>()
             .FindAsync(id);
     }
 
     public virtual async Task<IReadOnlyList<T>> GetAllAsync()
     {
-        _dbContext.Set<T>().AsNoTracking();
-        return await _dbContext.Set<T>().ToListAsync();
+        return await _dbContext.Set<T>()
+            .AsNoTracking()
+            .ToListAsync();
     }
 
     public virtual async Task UpdateAsync(T entity)

--- a/src/Infrastructure/Repositories/PatientProfileRepository.cs
+++ b/src/Infrastructure/Repositories/PatientProfileRepository.cs
@@ -78,7 +78,7 @@ public class PatientProfileRepository(ApplicationDbContext dbContext) :
         if (!string.IsNullOrEmpty(patientRequest.LastName)) { userOnFile.LastName = patientRequest.LastName; }
         if (!string.IsNullOrEmpty(patientRequest.Email)) { userOnFile.Email = patientRequest.Email; }
         if (!string.IsNullOrEmpty(patientRequest.PhoneNumber)) { userOnFile.PhoneNumber = patientRequest.PhoneNumber; }
-        if (!userOnFile.ActiveStatus && userOnFile.ActiveStatus != patientRequest.ActiveStatus) { userOnFile.ActiveStatus = patientRequest.ActiveStatus; }
+        if (userOnFile.ActiveStatus != patientRequest.ActiveStatus) { userOnFile.ActiveStatus = patientRequest.ActiveStatus; }
 
         return userOnFile;
     }

--- a/src/Infrastructure/Repositories/TherapistProfileRepository.cs
+++ b/src/Infrastructure/Repositories/TherapistProfileRepository.cs
@@ -73,7 +73,7 @@ public class TherapistProfileRepository(ApplicationDbContext dbContext) :
         if (!string.IsNullOrEmpty(therapistRequest.LastName)) { userOnFile.LastName = therapistRequest.LastName; }
         if (!string.IsNullOrEmpty(therapistRequest.Email)) { userOnFile.Email = therapistRequest.Email; }
         if (!string.IsNullOrEmpty(therapistRequest.PhoneNumber)) { userOnFile.PhoneNumber = therapistRequest.PhoneNumber; }
-        if (!userOnFile.ActiveStatus && userOnFile.ActiveStatus != therapistRequest.ActiveStatus) { userOnFile.ActiveStatus = therapistRequest.ActiveStatus; }
+        if (userOnFile.ActiveStatus != therapistRequest.ActiveStatus) { userOnFile.ActiveStatus = therapistRequest.ActiveStatus; }
 
         return userOnFile;
     }

--- a/tests/Infrastructure.Tests/CaretakerProfileRepositoryTests.cs
+++ b/tests/Infrastructure.Tests/CaretakerProfileRepositoryTests.cs
@@ -1,0 +1,71 @@
+using Xunit;
+using Microsoft.EntityFrameworkCore;
+using Neurocorp.Api.Core.BusinessObjects.Patients;
+using Neurocorp.Api.Core.Entities;
+using Neurocorp.Api.Infrastructure.Data;
+using Neurocorp.Api.Infrastructure.Repositories;
+
+namespace Infrastructure.Tests.Repositories;
+
+public class CaretakerProfileRepositoryTests
+{
+    private static DbContextOptions<ApplicationDbContext> CreateInMemoryOptions(string dbName)
+    {
+        return new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: dbName)
+            .Options;
+    }
+
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(true, true)]
+    [InlineData(false, false)]
+    public async Task UpdateAsync_ActiveStatus_IsAlwaysMappedCorrectly(bool initialStatus, bool requestedStatus)
+    {
+        // Arrange
+        var options = CreateInMemoryOptions($"CaretakerActiveStatus_{initialStatus}_{requestedStatus}");
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            context.Caretakers.Add(new Caretaker
+            {
+                Id = 1,
+                Notes = "Test caretaker",
+                User = new User
+                {
+                    Id = 1,
+                    FirstName = "Bob",
+                    LastName = "Jones",
+                    ActiveStatus = initialStatus
+                }
+            });
+            await context.SaveChangesAsync();
+        }
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            var repository = new CaretakerProfileRepository(context);
+            var updateRequest = new CaretakerProfileUpdateRequest
+            {
+                FirstName = "Bob",
+                LastName = "Jones",
+                IsActive = requestedStatus
+            };
+
+            // Act
+            var result = await repository.UpdateAsync(1, 1, updateRequest);
+
+            // Assert
+            Assert.Equal(requestedStatus, result.IsActive);
+        }
+
+        // Verify the change was persisted to the database
+        using (var context = new ApplicationDbContext(options))
+        {
+            var user = await context.Users.FindAsync(1);
+            Assert.NotNull(user);
+            Assert.Equal(requestedStatus, user.ActiveStatus);
+        }
+    }
+}

--- a/tests/Infrastructure.Tests/PatientProfileRepositoryTests.cs
+++ b/tests/Infrastructure.Tests/PatientProfileRepositoryTests.cs
@@ -1,0 +1,72 @@
+using Xunit;
+using Microsoft.EntityFrameworkCore;
+using Neurocorp.Api.Core.BusinessObjects.Patients;
+using Neurocorp.Api.Core.Entities;
+using Neurocorp.Api.Infrastructure.Data;
+using Neurocorp.Api.Infrastructure.Repositories;
+
+namespace Infrastructure.Tests.Repositories;
+
+public class PatientProfileRepositoryTests
+{
+    private static DbContextOptions<ApplicationDbContext> CreateInMemoryOptions(string dbName)
+    {
+        return new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: dbName)
+            .Options;
+    }
+
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(true, true)]
+    [InlineData(false, false)]
+    public async Task UpdateAsync_ActiveStatus_IsAlwaysMappedCorrectly(bool initialStatus, bool requestedStatus)
+    {
+        // Arrange
+        var options = CreateInMemoryOptions($"PatientActiveStatus_{initialStatus}_{requestedStatus}");
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            context.Patients.Add(new Patient
+            {
+                Id = 1,
+                Gender = "M",
+                MedicalRecordNumber = "MRN-001",
+                User = new User
+                {
+                    Id = 1,
+                    FirstName = "John",
+                    LastName = "Doe",
+                    ActiveStatus = initialStatus
+                }
+            });
+            await context.SaveChangesAsync();
+        }
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            var repository = new PatientProfileRepository(context);
+            var updateRequest = new PatientProfileUpdateRequest
+            {
+                FirstName = "John",
+                LastName = "Doe",
+                ActiveStatus = requestedStatus
+            };
+
+            // Act
+            var result = await repository.UpdateAsync(1, 1, updateRequest);
+
+            // Assert
+            Assert.Equal(requestedStatus, result.IsActive);
+        }
+
+        // Verify the change was persisted to the database
+        using (var context = new ApplicationDbContext(options))
+        {
+            var user = await context.Users.FindAsync(1);
+            Assert.NotNull(user);
+            Assert.Equal(requestedStatus, user.ActiveStatus);
+        }
+    }
+}

--- a/tests/Infrastructure.Tests/TherapistProfileRepositoryTests.cs
+++ b/tests/Infrastructure.Tests/TherapistProfileRepositoryTests.cs
@@ -1,0 +1,74 @@
+using Xunit;
+using Microsoft.EntityFrameworkCore;
+using Neurocorp.Api.Core.BusinessObjects.Therapists;
+using Neurocorp.Api.Core.Entities;
+using Neurocorp.Api.Infrastructure.Data;
+using Neurocorp.Api.Infrastructure.Repositories;
+
+namespace Infrastructure.Tests.Repositories;
+
+public class TherapistProfileRepositoryTests
+{
+    private static DbContextOptions<ApplicationDbContext> CreateInMemoryOptions(string dbName)
+    {
+        return new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: dbName)
+            .Options;
+    }
+
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(true, true)]
+    [InlineData(false, false)]
+    public async Task UpdateAsync_ActiveStatus_IsAlwaysMappedCorrectly(bool initialStatus, bool requestedStatus)
+    {
+        // Arrange
+        var options = CreateInMemoryOptions($"TherapistActiveStatus_{initialStatus}_{requestedStatus}");
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            context.Therapists.Add(new Therapist
+            {
+                Id = 1,
+                TherapistId = 1,
+                UserId = 1,
+                FeePerSession = 100m,
+                FeePctPerSession = 0.5m,
+                User = new User
+                {
+                    Id = 1,
+                    FirstName = "Jane",
+                    LastName = "Smith",
+                    ActiveStatus = initialStatus
+                }
+            });
+            await context.SaveChangesAsync();
+        }
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            var repository = new TherapistProfileRepository(context);
+            var updateRequest = new TherapistProfileUpdateRequest
+            {
+                FirstName = "Jane",
+                LastName = "Smith",
+                ActiveStatus = requestedStatus
+            };
+
+            // Act
+            var result = await repository.UpdateAsync(1, 1, updateRequest);
+
+            // Assert
+            Assert.Equal(requestedStatus, result.IsActive);
+        }
+
+        // Verify the change was persisted to the database
+        using (var context = new ApplicationDbContext(options))
+        {
+            var user = await context.Users.FindAsync(1);
+            Assert.NotNull(user);
+            Assert.Equal(requestedStatus, user.ActiveStatus);
+        }
+    }
+}


### PR DESCRIPTION
The ActiveStatus conditional in MapToUpdatedUser had a logic error (!userOnFile.ActiveStatus && ...) that prevented updates when the current value was true. Simplified to a direct inequality check across all three profile repositories. Also fixed discarded AsNoTracking() call in EfRepository.GetAllAsync.