### PR TITLE
Auto-generate temporary MRN and enforce activation business rule

### DIFF
--- a/src/Core/BusinessObjects/Patients/PatientProfileUpdateRequest.cs
+++ b/src/Core/BusinessObjects/Patients/PatientProfileUpdateRequest.cs
@@ -24,6 +24,7 @@ public class PatientProfileUpdateRequest
     public string PhoneNumber { get; set; }
     public string Gender { get; set; }
     public bool ActiveStatus { get; set; }
+    public string? MedicalRecordNumber { get; set; }
 
     public override string ToString()
     {

--- a/src/Core/Entities/Patient.cs
+++ b/src/Core/Entities/Patient.cs
@@ -15,6 +15,12 @@ public class Patient : PersonBase
     public string MedicalRecordNumber { get; set; }
     public ICollection<PatientCaretaker>? Caretakers { get; set; }
 
+    public bool HasTemporaryMrn()
+    {
+        return string.IsNullOrEmpty(MedicalRecordNumber)
+            || MedicalRecordNumber.StartsWith("TEMP-", StringComparison.OrdinalIgnoreCase);
+    }
+
     public override string ToString()
     {
         var sb = new StringBuilder();

--- a/src/Core/Services/PatientProfileService.cs
+++ b/src/Core/Services/PatientProfileService.cs
@@ -58,8 +58,16 @@ public class PatientProfileService : IPatientProfileService
     public async Task<PatientProfile> CreateAsync(PatientProfileRequest patientRequest)
     {
         _logger.LogInformation("Creating new patient profile from request.");
-        var newUser = await _userRepo.AddAsync(MapToNewUser(patientRequest));
+        bool isMissingMrn = string.IsNullOrWhiteSpace(patientRequest.MedicalRecordNumber);
+        var newUser = await _userRepo.AddAsync(MapToNewUser(patientRequest, activeStatus: !isMissingMrn));
         var newPatient = await _patientRepo.AddAsync(MapToNewPatient(patientRequest, newUser));
+
+        if (isMissingMrn)
+        {
+            newPatient.MedicalRecordNumber = $"TEMP-{newPatient.Id}";
+            await _patientRepo.UpdateAsync(newPatient);
+        }
+
         var newRole = await _userRoleRepo.AddAsync(newPatient.MintNewRole());
         _logger.LogInformation($"New Patient Profile was created: Uid[{newUser.Id}], Pid[{newPatient.Id}], Role[{newRole.UserRoleId}]");
         return new PatientProfile
@@ -67,6 +75,7 @@ public class PatientProfileService : IPatientProfileService
             PatientId = newPatient.Id,
             UserId = newUser.Id,
             PatientName = $"{newUser.LastName}, {newUser.FirstName} {newUser.MiddleName}".Trim(),
+            MedicalRecordNumber = newPatient.MedicalRecordNumber,
             DateOfBirth = newPatient.DateOfBirth ?? DateTime.MinValue,
             Email = newUser.Email,
             PhoneNumber = newUser.PhoneNumber,
@@ -83,6 +92,13 @@ public class PatientProfileService : IPatientProfileService
         var profileOnFile = await this.GetByIdAsync(patientAggId);
         if (profileOnFile != null)
         {
+            if (updateRequest.ActiveStatus
+                && profileOnFile.MedicalRecordNumber.StartsWith("TEMP-", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException(
+                    "Cannot activate a patient with a temporary Medical Record Number. Assign a permanent MRN first.");
+            }
+
             await _repository.UpdateAsync(profileOnFile.PatientId, profileOnFile.UserId, updateRequest);
             return true;
         }
@@ -120,7 +136,7 @@ public class PatientProfileService : IPatientProfileService
         };
     }
 
-    private static User MapToNewUser(PatientProfileRequest patientRequest)
+    private static User MapToNewUser(PatientProfileRequest patientRequest, bool activeStatus = true)
     {
         return new User
         {
@@ -130,7 +146,7 @@ public class PatientProfileService : IPatientProfileService
             Email = patientRequest.Email,
             PhoneNumber = patientRequest.PhoneNumber,
             CreatedTimestamp = DateTime.UtcNow,
-            ActiveStatus = true
+            ActiveStatus = activeStatus
         };
     }
 }

--- a/src/Infrastructure/Repositories/PatientProfileRepository.cs
+++ b/src/Infrastructure/Repositories/PatientProfileRepository.cs
@@ -67,6 +67,8 @@ public class PatientProfileRepository(ApplicationDbContext dbContext) :
             && !patientRequest.DateOfBirth.Equals(DateTime.MinValue)
             && !patientOnFile.DateOfBirth.Value.Equals(patientRequest.DateOfBirth))
         { patientOnFile.DateOfBirth = patientRequest.DateOfBirth; }
+        if (!string.IsNullOrEmpty(patientRequest.MedicalRecordNumber))
+        { patientOnFile.MedicalRecordNumber = patientRequest.MedicalRecordNumber; }
 
         return patientOnFile;
     }

--- a/src/Web/Controllers/PatientsController.cs
+++ b/src/Web/Controllers/PatientsController.cs
@@ -68,14 +68,21 @@ public class PatientsController : ControllerBase
     {
         if (await _patientProfileService.VerifyRequestAsync(id))
         {
-            var updateResult = await _patientProfileService.UpdateAsync(id, patientRequest);
-            if (updateResult)
+            try
             {
-                return NoContent();
+                var updateResult = await _patientProfileService.UpdateAsync(id, patientRequest);
+                if (updateResult)
+                {
+                    return NoContent();
+                }
+                else
+                {
+                    return BadRequest("Bad input?");
+                }
             }
-            else
+            catch (InvalidOperationException ex)
             {
-                return BadRequest("Bad input?");
+                return BadRequest(ex.Message);
             }
         }
         return BadRequest();

--- a/tests/Core.Tests/Entity_Tests_Patient.cs
+++ b/tests/Core.Tests/Entity_Tests_Patient.cs
@@ -1,0 +1,34 @@
+using Neurocorp.Api.Core.Entities;
+
+namespace Core.Tests;
+
+public class EntityTestsPatient
+{
+    [Fact]
+    public void HasTemporaryMrn_EmptyString_ReturnsTrue()
+    {
+        var patient = new Patient { MedicalRecordNumber = "" };
+        Assert.True(patient.HasTemporaryMrn());
+    }
+
+    [Fact]
+    public void HasTemporaryMrn_Null_ReturnsTrue()
+    {
+        var patient = new Patient { MedicalRecordNumber = null! };
+        Assert.True(patient.HasTemporaryMrn());
+    }
+
+    [Fact]
+    public void HasTemporaryMrn_TempPrefix_ReturnsTrue()
+    {
+        var patient = new Patient { MedicalRecordNumber = "TEMP-42" };
+        Assert.True(patient.HasTemporaryMrn());
+    }
+
+    [Fact]
+    public void HasTemporaryMrn_RealMrn_ReturnsFalse()
+    {
+        var patient = new Patient { MedicalRecordNumber = "MRN-001" };
+        Assert.False(patient.HasTemporaryMrn());
+    }
+}

--- a/tests/Core.Tests/PatientProfileServiceTests.cs
+++ b/tests/Core.Tests/PatientProfileServiceTests.cs
@@ -2,6 +2,7 @@ using Neurocorp.Api.Core.Interfaces.Repositories;
 using Moq;
 using Neurocorp.Api.Core.Services;
 using Neurocorp.Api.Core.BusinessObjects.Patients;
+using Neurocorp.Api.Core.Entities;
 using Microsoft.Extensions.Logging;
 
 namespace Core.Tests;
@@ -106,5 +107,134 @@ public class PatientProfileServiceTests
         // Assert
         Assert.NotNull(result);
         Assert.IsAssignableFrom<IEnumerable<PatientProfile>>(result);
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithoutMrn_GeneratesTempMrn()
+    {
+        // Arrange
+        var fakeLogger = Mock.Of<ILogger<PatientProfileService>>();
+        var mockProfileRepo = Mock.Of<IPatientProfileRepository>();
+        var mockPatientRepo = new Mock<IPatientRepository>();
+        var mockUserRepo = new Mock<IUserRepository>();
+        var mockUserRoleRepo = new Mock<IUserRoleRepository>();
+
+        var savedUser = new User { Id = 10, FirstName = "Jane", LastName = "Doe", MiddleName = "", Email = "j@d.com", PhoneNumber = "555", ActiveStatus = false };
+        mockUserRepo.Setup(r => r.AddAsync(It.IsAny<User>())).ReturnsAsync(savedUser);
+
+        var savedPatient = new Patient { Id = 5, User = savedUser, MedicalRecordNumber = "", DateOfBirth = DateTime.Today, Gender = "F" };
+        mockPatientRepo.Setup(r => r.AddAsync(It.IsAny<Patient>())).ReturnsAsync(savedPatient);
+        mockPatientRepo.Setup(r => r.UpdateAsync(It.IsAny<Patient>())).Returns(Task.CompletedTask);
+
+        mockUserRoleRepo.Setup(r => r.AddAsync(It.IsAny<UserRole>())).ReturnsAsync(new UserRole { UserRoleId = 1 });
+
+        var svc = new PatientProfileService(fakeLogger, mockProfileRepo, mockPatientRepo.Object, mockUserRepo.Object, mockUserRoleRepo.Object);
+        var request = new PatientProfileRequest { FirstName = "Jane", LastName = "Doe", Email = "j@d.com", PhoneNumber = "555", Gender = "F", DateOfBirth = DateTime.Today, MedicalRecordNumber = "" };
+
+        // Act
+        var result = await svc.CreateAsync(request);
+
+        // Assert
+        Assert.Equal("TEMP-5", result.MedicalRecordNumber);
+        Assert.False(result.IsActive);
+        mockPatientRepo.Verify(r => r.UpdateAsync(It.IsAny<Patient>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithMrn_UsesProvidedMrn()
+    {
+        // Arrange
+        var fakeLogger = Mock.Of<ILogger<PatientProfileService>>();
+        var mockProfileRepo = Mock.Of<IPatientProfileRepository>();
+        var mockPatientRepo = new Mock<IPatientRepository>();
+        var mockUserRepo = new Mock<IUserRepository>();
+        var mockUserRoleRepo = new Mock<IUserRoleRepository>();
+
+        var savedUser = new User { Id = 10, FirstName = "Jane", LastName = "Doe", MiddleName = "", Email = "j@d.com", PhoneNumber = "555", ActiveStatus = true };
+        mockUserRepo.Setup(r => r.AddAsync(It.IsAny<User>())).ReturnsAsync(savedUser);
+
+        var savedPatient = new Patient { Id = 5, User = savedUser, MedicalRecordNumber = "MRN-001", DateOfBirth = DateTime.Today, Gender = "F" };
+        mockPatientRepo.Setup(r => r.AddAsync(It.IsAny<Patient>())).ReturnsAsync(savedPatient);
+
+        mockUserRoleRepo.Setup(r => r.AddAsync(It.IsAny<UserRole>())).ReturnsAsync(new UserRole { UserRoleId = 1 });
+
+        var svc = new PatientProfileService(fakeLogger, mockProfileRepo, mockPatientRepo.Object, mockUserRepo.Object, mockUserRoleRepo.Object);
+        var request = new PatientProfileRequest { FirstName = "Jane", LastName = "Doe", Email = "j@d.com", PhoneNumber = "555", Gender = "F", DateOfBirth = DateTime.Today, MedicalRecordNumber = "MRN-001" };
+
+        // Act
+        var result = await svc.CreateAsync(request);
+
+        // Assert
+        Assert.Equal("MRN-001", result.MedicalRecordNumber);
+        Assert.True(result.IsActive);
+        mockPatientRepo.Verify(r => r.UpdateAsync(It.IsAny<Patient>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ActivateWithTempMrn_ThrowsInvalidOperation()
+    {
+        // Arrange
+        var fakeLogger = Mock.Of<ILogger<PatientProfileService>>();
+        var mockProfileRepo = new Mock<IPatientProfileRepository>();
+        var fakePatientRepo = Mock.Of<IPatientRepository>();
+        var fakeUserRepo = Mock.Of<IUserRepository>();
+        var fakeUserRoleRepo = Mock.Of<IUserRoleRepository>();
+
+        var profileOnFile = new PatientProfile { PatientId = 1, UserId = 10, MedicalRecordNumber = "TEMP-1", PatientName = "Test" };
+        mockProfileRepo.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(profileOnFile);
+
+        var svc = new PatientProfileService(fakeLogger, mockProfileRepo.Object, fakePatientRepo, fakeUserRepo, fakeUserRoleRepo);
+        var updateRequest = new PatientProfileUpdateRequest { ActiveStatus = true };
+
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(() => svc.UpdateAsync(1, updateRequest));
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ActivateWithRealMrn_Succeeds()
+    {
+        // Arrange
+        var fakeLogger = Mock.Of<ILogger<PatientProfileService>>();
+        var mockProfileRepo = new Mock<IPatientProfileRepository>();
+        var fakePatientRepo = Mock.Of<IPatientRepository>();
+        var fakeUserRepo = Mock.Of<IUserRepository>();
+        var fakeUserRoleRepo = Mock.Of<IUserRoleRepository>();
+
+        var profileOnFile = new PatientProfile { PatientId = 1, UserId = 10, MedicalRecordNumber = "MRN-001", PatientName = "Test" };
+        mockProfileRepo.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(profileOnFile);
+        mockProfileRepo.Setup(r => r.UpdateAsync(1, 10, It.IsAny<PatientProfileUpdateRequest>())).ReturnsAsync(profileOnFile);
+
+        var svc = new PatientProfileService(fakeLogger, mockProfileRepo.Object, fakePatientRepo, fakeUserRepo, fakeUserRoleRepo);
+        var updateRequest = new PatientProfileUpdateRequest { ActiveStatus = true };
+
+        // Act
+        var result = await svc.UpdateAsync(1, updateRequest);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_DeactivateWithTempMrn_Succeeds()
+    {
+        // Arrange
+        var fakeLogger = Mock.Of<ILogger<PatientProfileService>>();
+        var mockProfileRepo = new Mock<IPatientProfileRepository>();
+        var fakePatientRepo = Mock.Of<IPatientRepository>();
+        var fakeUserRepo = Mock.Of<IUserRepository>();
+        var fakeUserRoleRepo = Mock.Of<IUserRoleRepository>();
+
+        var profileOnFile = new PatientProfile { PatientId = 1, UserId = 10, MedicalRecordNumber = "TEMP-1", PatientName = "Test" };
+        mockProfileRepo.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(profileOnFile);
+        mockProfileRepo.Setup(r => r.UpdateAsync(1, 10, It.IsAny<PatientProfileUpdateRequest>())).ReturnsAsync(profileOnFile);
+
+        var svc = new PatientProfileService(fakeLogger, mockProfileRepo.Object, fakePatientRepo, fakeUserRepo, fakeUserRoleRepo);
+        var updateRequest = new PatientProfileUpdateRequest { ActiveStatus = false };
+
+        // Act
+        var result = await svc.UpdateAsync(1, updateRequest);
+
+        // Assert
+        Assert.True(result);
     }
 }


### PR DESCRIPTION
Patients created without a Medical Record Number now receive a TEMP-{id} MRN and are set inactive. Activating a patient with a temporary MRN is blocked (400 Bad Request) until a permanent MRN is assigned. Adds MRN field to the update DTO so callers can replace a temp MRN.