### PR TITLE
Add GET /api/patients/pastdue endpoint to retrieve all past-due patients

### DIFF
--- a/src/Core/Interfaces/Services/IHandleSessionEvent.cs
+++ b/src/Core/Interfaces/Services/IHandleSessionEvent.cs
@@ -1,3 +1,4 @@
+using Neurocorp.Api.Core.BusinessObjects.Patients;
 using Neurocorp.Api.Core.BusinessObjects.Sessions;
 
 namespace Neurocorp.Api.Core.Interfaces.Services;
@@ -6,6 +7,7 @@ public interface IHandleSessionEvent : IService<SessionEvent>
 {
     public Task<IEnumerable<SessionEvent>> GetAllByTargetDateAsync(DateOnly targetDate);
     public Task<IEnumerable<SessionEvent>> GetAllPastDueAsync();
+    public Task<IEnumerable<PatientPastDueInfo>> GetAllPatientsPastDueAsync();
     public Task<SessionEvent> CreateAsync(SessionEventRequest request);
     public Task<bool> UpdateAsync(int SessionEventId, SessionEventUpdateRequest request);
     public Task<bool> VerifyRequestAsync(int sessionAggId, SessionEventUpdateRequest request);

--- a/src/Core/Services/SessionEventHandler.cs
+++ b/src/Core/Services/SessionEventHandler.cs
@@ -78,6 +78,36 @@ public class SessionEventHandler : IHandleSessionEvent
         return sortedPastDueEvents;
     }
 
+    public async Task<IEnumerable<PatientPastDueInfo>> GetAllPatientsPastDueAsync()
+    {
+        _logger.LogInformation("Started to fetch all patients with past-due sessions");
+        var stopwatch = Stopwatch.StartNew();
+
+        var pastDueSessions = await GetAllPastDueAsync();
+        var groupedByPatient = pastDueSessions.GroupBy(s => s.PatientId);
+
+        var results = new List<PatientPastDueInfo>();
+        foreach (var group in groupedByPatient)
+        {
+            var patient = await _patientService.GetByIdAsync(group.Key);
+            if (patient is null) continue;
+
+            var sessions = group.ToList();
+            results.Add(new PatientPastDueInfo
+            {
+                Party = patient,
+                PastDueSessions = sessions.Count,
+                PastDueTotalAmount = sessions.Sum(s => s.AmountDue),
+                AmountPaidSoFar = sessions.Sum(s => s.AmountPaid),
+                Delinquency = sessions,
+            });
+        }
+
+        _logger.LogInformation("Found {Count} patients with past-due sessions in {ElapsedMilliseconds} ms",
+            results.Count, stopwatch.ElapsedMilliseconds);
+        return results;
+    }
+
     public async Task<SessionEvent?> GetByIdAsync(int id)
     {
         return await _repository.GetByIdAsync(id);

--- a/src/Web/Controllers/PatientsController.cs
+++ b/src/Web/Controllers/PatientsController.cs
@@ -31,7 +31,7 @@ public class PatientsController : ControllerBase
         return Ok(patients);
     }
 
-    [HttpGet("{id}")]
+    [HttpGet("{id:int}")]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(PatientProfile))]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
@@ -42,7 +42,7 @@ public class PatientsController : ControllerBase
         return Ok(patient);
     }
 
-    [HttpGet("{id}/pastdue")]
+    [HttpGet("{id:int}/pastdue")]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(PatientPastDueInfo))]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
@@ -56,6 +56,15 @@ public class PatientsController : ControllerBase
         return NotFound();
     }    
 
+    [HttpGet("pastdue")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<PatientPastDueInfo>))]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<IActionResult> GetAllPastDuePatients()
+    {
+        var pastDuePatients = await _sessionEventHandler.GetAllPatientsPastDueAsync();
+        return Ok(pastDuePatients);
+    }
+
     [HttpPost]
     public async Task<IActionResult> CreatePatient([FromBody] PatientProfileRequest patientRequest)
     {
@@ -63,7 +72,7 @@ public class PatientsController : ControllerBase
         return CreatedAtAction(nameof(CreatePatient), new { id = createdPatient.PatientId }, createdPatient);
     }
 
-    [HttpPut("{id}")]
+    [HttpPut("{id:int}")]
     public async Task<IActionResult> UpdatePatient(int id, [FromBody] PatientProfileUpdateRequest patientRequest)
     {
         if (await _patientProfileService.VerifyRequestAsync(id))

--- a/tests/Core.Tests/SessionEventHandlerTests.cs
+++ b/tests/Core.Tests/SessionEventHandlerTests.cs
@@ -1,0 +1,108 @@
+using Moq;
+using Microsoft.Extensions.Logging;
+using Neurocorp.Api.Core.Services;
+using Neurocorp.Api.Core.BusinessObjects.Sessions;
+using Neurocorp.Api.Core.BusinessObjects.Patients;
+using Neurocorp.Api.Core.Interfaces.Repositories;
+using Neurocorp.Api.Core.Interfaces.Services;
+
+namespace Core.Tests;
+
+public class SessionEventHandlerTests
+{
+    private readonly Mock<ISessionEventRepository> _mockRepository;
+    private readonly Mock<ITherapySessionRepository> _mockTherapySessionRepository;
+    private readonly Mock<IPatientProfileService> _mockPatientService;
+    private readonly Mock<ITherapistProfileService> _mockTherapistService;
+    private readonly SessionEventHandler _sut;
+
+    public SessionEventHandlerTests()
+    {
+        var fakeLogger = Mock.Of<ILogger<SessionEventHandler>>();
+        _mockRepository = new Mock<ISessionEventRepository>();
+        _mockTherapySessionRepository = new Mock<ITherapySessionRepository>();
+        _mockPatientService = new Mock<IPatientProfileService>();
+        _mockTherapistService = new Mock<ITherapistProfileService>();
+        _sut = new SessionEventHandler(
+            fakeLogger,
+            _mockRepository.Object,
+            _mockTherapySessionRepository.Object,
+            _mockTherapistService.Object,
+            _mockPatientService.Object);
+    }
+
+    [Fact]
+    public async Task GetAllPatientsPastDueAsync_GroupsByPatient_AndAggregatesCorrectly()
+    {
+        // Arrange
+        var pastDueSessions = new List<SessionEvent>
+        {
+            new() { SessionId = 1, PatientId = 1, AmountDue = 50m, AmountPaid = 10m, IsPastDue = true },
+            new() { SessionId = 2, PatientId = 1, AmountDue = 30m, AmountPaid = 5m, IsPastDue = true },
+            new() { SessionId = 3, PatientId = 2, AmountDue = 100m, AmountPaid = 0m, IsPastDue = true }
+        };
+        _mockRepository
+            .Setup(r => r.GetAllPastDueAsync())
+            .ReturnsAsync(pastDueSessions);
+        _mockPatientService
+            .Setup(s => s.GetByIdAsync(1))
+            .ReturnsAsync(new PatientProfile { PatientId = 1, PatientName = "Patient One" });
+        _mockPatientService
+            .Setup(s => s.GetByIdAsync(2))
+            .ReturnsAsync(new PatientProfile { PatientId = 2, PatientName = "Patient Two" });
+
+        // Act
+        var result = (await _sut.GetAllPatientsPastDueAsync()).ToList();
+
+        // Assert
+        Assert.Equal(2, result.Count);
+
+        var patient1 = result.First(r => r.Party is PatientProfile p && p.PatientId == 1);
+        Assert.Equal(2, patient1.PastDueSessions);
+        Assert.Equal(80m, patient1.PastDueTotalAmount);
+        Assert.Equal(15m, patient1.AmountPaidSoFar);
+        Assert.Equal(2, patient1.Delinquency!.Count());
+
+        var patient2 = result.First(r => r.Party is PatientProfile p && p.PatientId == 2);
+        Assert.Equal(1, patient2.PastDueSessions);
+        Assert.Equal(100m, patient2.PastDueTotalAmount);
+        Assert.Equal(0m, patient2.AmountPaidSoFar);
+    }
+
+    [Fact]
+    public async Task GetAllPatientsPastDueAsync_SkipsPatient_WhenProfileNotFound()
+    {
+        // Arrange
+        var pastDueSessions = new List<SessionEvent>
+        {
+            new() { SessionId = 1, PatientId = 99, AmountDue = 50m, IsPastDue = true }
+        };
+        _mockRepository
+            .Setup(r => r.GetAllPastDueAsync())
+            .ReturnsAsync(pastDueSessions);
+        _mockPatientService
+            .Setup(s => s.GetByIdAsync(99))
+            .ReturnsAsync((PatientProfile?)null);
+
+        // Act
+        var result = (await _sut.GetAllPatientsPastDueAsync()).ToList();
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetAllPatientsPastDueAsync_ReturnsEmpty_WhenNoPastDueSessions()
+    {
+        // Arrange
+        _mockRepository
+            .Setup(r => r.GetAllPastDueAsync())
+            .ReturnsAsync(new List<SessionEvent>());
+
+        // Act
+        var result = (await _sut.GetAllPatientsPastDueAsync()).ToList();
+
+        // Assert
+        Assert.Empty(result);
+    }
+}

--- a/tests/Web.Tests/PatientsControllerTests.cs
+++ b/tests/Web.Tests/PatientsControllerTests.cs
@@ -116,6 +116,45 @@ public class PatientsControllerTests
     }    
 
     [Fact]
+    public async Task GetAllPastDuePatients_ReturnsOk_WithPastDuePatients()
+    {
+        // Arrange
+        var pastDuePatients = new List<PatientPastDueInfo>
+        {
+            new() { Party = Mock.Of<PatientProfile>(p => p.PatientId == 1), PastDueSessions = 2, PastDueTotalAmount = 100m, AmountPaidSoFar = 20m },
+            new() { Party = Mock.Of<PatientProfile>(p => p.PatientId == 2), PastDueSessions = 1, PastDueTotalAmount = 50m, AmountPaidSoFar = 0m }
+        };
+        _mockSessionEventHandler
+            .Setup(x => x.GetAllPatientsPastDueAsync())
+            .ReturnsAsync(pastDuePatients);
+
+        // Act
+        var result = await _controller.GetAllPastDuePatients();
+
+        // Assert
+        result.Should().BeOfType<OkObjectResult>()
+            .Which.Value.Should().BeAssignableTo<IEnumerable<PatientPastDueInfo>>()
+            .Which.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task GetAllPastDuePatients_ReturnsOk_WithEmptyList()
+    {
+        // Arrange
+        _mockSessionEventHandler
+            .Setup(x => x.GetAllPatientsPastDueAsync())
+            .ReturnsAsync(new List<PatientPastDueInfo>());
+
+        // Act
+        var result = await _controller.GetAllPastDuePatients();
+
+        // Assert
+        result.Should().BeOfType<OkObjectResult>()
+            .Which.Value.Should().BeAssignableTo<IEnumerable<PatientPastDueInfo>>()
+            .Which.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task GetPatient_PastDueEvents_Returns_NO_Result_WithSessionEvents()
     {
         // Arrange


### PR DESCRIPTION
Adds a collection-level endpoint that aggregates past-due session data grouped by patient, returning financial summaries and delinquent sessions. Also adds {id:int} route constraints for routing clarity.