### PR TITLE
Add coordinator context and pickup-task prompt

### DIFF
--- a/.claude/prompts/pickup-task.md
+++ b/.claude/prompts/pickup-task.md
@@ -1,0 +1,31 @@
+# Pick Up Task from Coordinator
+
+Read the active plan files from the coordinator to pick up your portion of a cross-cutting task.
+
+## Steps
+
+1. List available plans:
+   ```
+   ls ../patient-care-super/planning/active/
+   ```
+
+2. Read the plan file(s) to understand:
+   - What is the overall goal?
+   - What is the **API layer's** responsibility in this plan?
+   - What has already been completed in other layers (especially DB)?
+
+3. Read the coordinator's CLAUDE.md if you need broader context:
+   ```
+   ../patient-care-super/CLAUDE.md
+   ```
+
+4. Check relevant API contracts for the expected endpoint shapes:
+   ```
+   ../patient-care-super/_contracts/
+   ```
+
+5. Summarize what you need to do and confirm with the user before implementing.
+
+## Reminder
+
+DB schema changes must land before yours. After implementing, run `dotnet build && dotnet test` to verify. The UI layer depends on your output — update `../patient-care-super/_contracts/` if you change endpoint shapes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,3 +69,18 @@ dotnet run --project src/Web/Web.csproj   # starts on http://localhost:5245
 - **Naming**: PascalCase for C# types/members; controllers named `{Resource}Controller`
 - **Database**: MySQL via Pomelo EF Core provider; connection built from env vars (`DATABASE_HOST`, `DATABASE_PORT`, `DATABASE_NAME`, `DATABASE_USER`, `DATABASE_PASSWORD`)
 - **Testing**: xUnit + Moq + FluentAssertions; test projects mirror `src/` structure
+
+## Coordinator Context
+
+This project is part of a multi-repo system managed by a coordinator instance at `../patient-care-super/`.
+
+- **Coordinator guide**: `../patient-care-super/CLAUDE.md`
+- **API contracts**: `../patient-care-super/_contracts/`
+- **Active plans**: `../patient-care-super/planning/active/`
+
+### Dependency Position
+
+DB schema changes must land before yours. UI consumes your output. When making changes:
+1. DB layer (`../patient-care-db/`) applies schema changes first
+2. You update entities, repositories, services, and controllers
+3. UI layer (`../patient-care-ui-vue/`) updates last to consume your endpoints


### PR DESCRIPTION
Adds coordinator awareness section to CLAUDE.md (dependency position: between DB and UI) and pickup-task prompt for receiving handoffs from the patient-care-super coordinator instance.