### PR TITLE
Add /pickup-task prompt for coordinator handoff workflow

### DIFF
--- a/.claude/prompts/pickup-task.md
+++ b/.claude/prompts/pickup-task.md
@@ -1,31 +1,24 @@
-# Pick Up Task from Coordinator
+# Pickup Task from Coordinator
 
-Read the active plan files from the coordinator to pick up your portion of a cross-cutting task.
+You are receiving an implementation plan from the **coordinator instance** (`patient-care-super`). This plan was created after cross-project analysis and describes work scoped to the **API layer**.
 
-## Steps
+## Instructions
 
-1. List available plans:
+1. **Read the plan.** The user will provide it — either pasted inline or as a file path. Read the full plan carefully.
+2. **Review your conventions.** Re-read `CLAUDE.md` in this repo to ensure you follow API project conventions (Clean Architecture layers, namespace conventions, DTO patterns).
+3. **Check contracts.** If the plan references `_contracts/` files in the coordinator repo, read them to understand the expected request/response shapes.
+4. **Create a feature branch.** Use the branch name specified in the plan, or derive one from the task (e.g., `feature/<short-description>`). Never commit directly to main.
+5. **Implement.** Execute only the API-layer steps from the plan. Do not attempt work designated for DB or UI layers.
+6. **Verify.** Run the verification steps specified in the plan. At minimum:
+   ```bash
+   dotnet build patient-care-api.sln
+   dotnet test patient-care-api.sln
    ```
-   ls ../patient-care-super/planning/active/
-   ```
+7. **Commit.** Stage and commit your changes with a clear message describing what was done.
+8. **Report back.** Summarize what you implemented, what you verified, and any issues or open questions for the coordinator.
 
-2. Read the plan file(s) to understand:
-   - What is the overall goal?
-   - What is the **API layer's** responsibility in this plan?
-   - What has already been completed in other layers (especially DB)?
+## Important
 
-3. Read the coordinator's CLAUDE.md if you need broader context:
-   ```
-   ../patient-care-super/CLAUDE.md
-   ```
-
-4. Check relevant API contracts for the expected endpoint shapes:
-   ```
-   ../patient-care-super/_contracts/
-   ```
-
-5. Summarize what you need to do and confirm with the user before implementing.
-
-## Reminder
-
-DB schema changes must land before yours. After implementing, run `dotnet build && dotnet test` to verify. The UI layer depends on your output — update `../patient-care-super/_contracts/` if you change endpoint shapes.
+- Only implement work scoped to this layer (API endpoints, services, repositories, DTOs).
+- If the plan references DB or UI work, ignore those sections — other specialist instances handle them.
+- If something in the plan is unclear or seems wrong, ask the user before proceeding.


### PR DESCRIPTION
Enables this API specialist instance to receive implementation plans from the coordinator (patient-care-super) and execute only the API-layer steps.