### PR TITLE
Fix 6 entity and DbContext bugs to align with MySQL schema

### DIFF
--- a/src/Core/Entities/Caretaker.cs
+++ b/src/Core/Entities/Caretaker.cs
@@ -23,7 +23,7 @@ public class UndefinedCaretaker : Caretaker
 {
     public UndefinedCaretaker()
     {
-        this.User!.Id = int.MinValue;
+        this.User = new User { Id = int.MinValue, FirstName = string.Empty, LastName = string.Empty };
         this.Id = int.MinValue;
         this.Notes = "Undefined";
     }

--- a/src/Core/Entities/Caretaker.cs
+++ b/src/Core/Entities/Caretaker.cs
@@ -16,5 +16,15 @@ public class Caretaker : PersonBase
             UserId = this.User!.Id,
             RoleId = 4 // as defined in table UserRole for Caretakers
         };
-    }    
+    }
+}
+
+public class UndefinedCaretaker : Caretaker
+{
+    public UndefinedCaretaker()
+    {
+        this.User!.Id = int.MinValue;
+        this.Id = int.MinValue;
+        this.Notes = "Undefined";
+    }
 }

--- a/src/Core/Entities/Payment.cs
+++ b/src/Core/Entities/Payment.cs
@@ -6,12 +6,14 @@ public class Payment
 {
     public Payment()
     {
-        this.Patient = new UndefinedPatient();
+        this.Caretaker = new UndefinedCaretaker();
         this.SessionPayments = [];
     }
     public int Id { get; set; }
-    public int PatientId { get; set; }
-    public Patient Patient { get; set; }
+    public int CaretakerId { get; set; }
+    public Caretaker Caretaker { get; set; }
+    public int PaymentTypeId { get; set; }
+    public string? CheckNumber { get; set; }
     public decimal Amount { get; set; }
     public DateTime PaymentDate { get; set; }
     public ICollection<SessionPayment> SessionPayments { get; set; }

--- a/src/Core/Entities/Payment.cs
+++ b/src/Core/Entities/Payment.cs
@@ -6,7 +6,7 @@ public class Payment
 {
     public Payment()
     {
-        this.Caretaker = new UndefinedCaretaker();
+        this.Caretaker = null!;
         this.SessionPayments = [];
     }
     public int Id { get; set; }

--- a/src/Core/Entities/PaymentType.cs
+++ b/src/Core/Entities/PaymentType.cs
@@ -1,0 +1,8 @@
+namespace Neurocorp.Api.Core.Entities;
+
+public class PaymentType
+{
+    public int Id { get; set; }
+    public string PmtTypeAbbreviation { get; set; } = string.Empty;
+    public string PmtTypeName { get; set; } = string.Empty;
+}

--- a/src/Core/Entities/SessionPayment.cs
+++ b/src/Core/Entities/SessionPayment.cs
@@ -15,4 +15,5 @@ public class SessionPayment
     public Payment Payment { get; set; }
     public int TherapySessionId { get; set; }
     public TherapySession TherapySession { get; set; }
+    public decimal AmountAllocated { get; set; }
 }

--- a/src/Core/Entities/SessionPayment.cs
+++ b/src/Core/Entities/SessionPayment.cs
@@ -6,8 +6,8 @@ public class SessionPayment
 {
     public SessionPayment()
     {
-        this.Payment = new UndefinedPayment();
-        this.TherapySession = new UndefinedSession();
+        this.Payment = null!;
+        this.TherapySession = null!;
     }
 
     public int Id { get; set; }

--- a/src/Infrastructure/Data/ApplicationDbContext.cs
+++ b/src/Infrastructure/Data/ApplicationDbContext.cs
@@ -14,6 +14,9 @@ public class ApplicationDbContext : DbContext
     public DbSet<Caretaker> Caretakers { get; set; }
     public DbSet<Therapist> Therapists { get; set; }
     public DbSet<TherapySession> TherapySessions { get; set; }
+    public DbSet<Payment> Payments { get; set; }
+    public DbSet<SessionPayment> SessionPayments { get; set; }
+    public DbSet<PaymentType> PaymentTypes { get; set; }
 
     public override int SaveChanges()
     {
@@ -78,7 +81,7 @@ public class ApplicationDbContext : DbContext
         modelBuilder.Entity<Caretaker>(ct => {
             ct.ToTable("Caretaker");
             ct.HasKey(e => e.Id);
-            ct.Property(e => e.Id).HasColumnName("CareTakerID");
+            ct.Property(e => e.Id).HasColumnName("CaretakerID");
             ct.Property(e => e.Notes).IsRequired(false);
         });
         modelBuilder.Entity<Therapist>(t => {
@@ -98,9 +101,25 @@ public class ApplicationDbContext : DbContext
             ur.Property(e => e.Id).HasColumnName("UserRoleID");
             ur.Ignore(e => e.RoleCreatedOn);
         });
+        modelBuilder.Entity<Payment>(p => {
+            p.ToTable("Payment");
+            p.HasKey(e => e.Id);
+            p.Property(e => e.Id).HasColumnName("PaymentID");
+            p.Property(e => e.CaretakerId).HasColumnName("PaidBy");
+        });
+        modelBuilder.Entity<SessionPayment>(sp => {
+            sp.ToTable("SessionPayment");
+            sp.HasKey(e => e.Id);
+            sp.Property(e => e.Id).HasColumnName("SessionPaymentID");
+        });
+        modelBuilder.Entity<PaymentType>(pt => {
+            pt.ToTable("PaymentType");
+            pt.HasKey(e => e.Id);
+            pt.Property(e => e.Id).HasColumnName("PaymentTypeID");
+        });
         modelBuilder.Entity<PatientCaretaker>(entity =>
         {
-            entity.ToTable("PatientCareTakers");
+            entity.ToTable("PatientCaretaker");
             entity.HasKey(pc => new { pc.PatientId, pc.CaretakerId });
 
             entity.HasOne(pc => pc.Patient)
@@ -114,10 +133,7 @@ public class ApplicationDbContext : DbContext
             entity.Property(pc => pc.PrimaryCaretaker)
                 .IsRequired();
 
-            // Unique constraint to ensure only one primary care-taker per patient
-            entity.HasIndex(pc => new { pc.PatientId, pc.PrimaryCaretaker })
-                .IsUnique()
-                .HasFilter("[PrimaryCareTaker] = 1");
+            entity.HasIndex(pc => new { pc.PatientId, pc.PrimaryCaretaker });
         });
     }
 

--- a/tests/Infrastructure.Tests/DbContextMappingTests.cs
+++ b/tests/Infrastructure.Tests/DbContextMappingTests.cs
@@ -1,0 +1,208 @@
+using Xunit;
+using Microsoft.EntityFrameworkCore;
+using Neurocorp.Api.Core.Entities;
+using Neurocorp.Api.Infrastructure.Data;
+
+namespace Infrastructure.Tests.Repositories;
+
+public class DbContextMappingTests
+{
+    private static DbContextOptions<ApplicationDbContext> CreateInMemoryOptions(string dbName)
+    {
+        return new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: dbName)
+            .Options;
+    }
+
+    [Fact]
+    public void DbContext_HasPaymentsDbSet()
+    {
+        // Arrange & Act
+        var options = CreateInMemoryOptions("DbContext_HasPaymentsDbSet");
+        using var context = new ApplicationDbContext(options);
+
+        // Assert
+        Assert.NotNull(context.Payments);
+    }
+
+    [Fact]
+    public void DbContext_HasSessionPaymentsDbSet()
+    {
+        // Arrange & Act
+        var options = CreateInMemoryOptions("DbContext_HasSessionPaymentsDbSet");
+        using var context = new ApplicationDbContext(options);
+
+        // Assert
+        Assert.NotNull(context.SessionPayments);
+    }
+
+    [Fact]
+    public void DbContext_HasPaymentTypesDbSet()
+    {
+        // Arrange & Act
+        var options = CreateInMemoryOptions("DbContext_HasPaymentTypesDbSet");
+        using var context = new ApplicationDbContext(options);
+
+        // Assert
+        Assert.NotNull(context.PaymentTypes);
+    }
+
+    [Fact]
+    public async Task PaymentType_CanBePersisted_AndQueried()
+    {
+        // Arrange
+        var options = CreateInMemoryOptions("PaymentType_CanBePersisted_AndQueried");
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            context.PaymentTypes.Add(new PaymentType
+            {
+                Id = 1,
+                PmtTypeAbbreviation = "CSH",
+                PmtTypeName = "Cash"
+            });
+            context.PaymentTypes.Add(new PaymentType
+            {
+                Id = 2,
+                PmtTypeAbbreviation = "CHK",
+                PmtTypeName = "Check"
+            });
+            context.PaymentTypes.Add(new PaymentType
+            {
+                Id = 3,
+                PmtTypeAbbreviation = "CC",
+                PmtTypeName = "Credit Card"
+            });
+            await context.SaveChangesAsync();
+        }
+
+        // Act & Assert
+        using (var context = new ApplicationDbContext(options))
+        {
+            var paymentTypes = await context.PaymentTypes.ToListAsync();
+            Assert.Equal(3, paymentTypes.Count);
+            Assert.Contains(paymentTypes, pt => pt.PmtTypeAbbreviation == "CSH" && pt.PmtTypeName == "Cash");
+            Assert.Contains(paymentTypes, pt => pt.PmtTypeAbbreviation == "CHK" && pt.PmtTypeName == "Check");
+            Assert.Contains(paymentTypes, pt => pt.PmtTypeAbbreviation == "CC" && pt.PmtTypeName == "Credit Card");
+        }
+    }
+
+    [Fact]
+    public async Task PatientCaretaker_CanBeAdded_VerifiesTableNameFix()
+    {
+        // Arrange
+        var options = CreateInMemoryOptions("PatientCaretaker_CanBeAdded_VerifiesTableNameFix");
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            context.Patients.Add(new Patient
+            {
+                Id = 1,
+                User = new User { Id = 1, FirstName = "John", LastName = "Doe" }
+            });
+            context.Caretakers.Add(new Caretaker
+            {
+                Id = 1,
+                Notes = "Primary caretaker",
+                User = new User { Id = 2, FirstName = "Jane", LastName = "Doe" }
+            });
+            await context.SaveChangesAsync();
+        }
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            context.Set<PatientCaretaker>().Add(new PatientCaretaker
+            {
+                PatientId = 1,
+                CaretakerId = 1,
+                PrimaryCaretaker = true
+            });
+            await context.SaveChangesAsync();
+        }
+
+        // Act & Assert
+        using (var context = new ApplicationDbContext(options))
+        {
+            var patientCaretaker = await context.Set<PatientCaretaker>()
+                .FirstOrDefaultAsync(pc => pc.PatientId == 1 && pc.CaretakerId == 1);
+            Assert.NotNull(patientCaretaker);
+            Assert.True(patientCaretaker.PrimaryCaretaker);
+        }
+    }
+
+    [Fact]
+    public async Task Caretaker_MapsWithCorrectPrimaryKey()
+    {
+        // Arrange
+        var options = CreateInMemoryOptions("Caretaker_MapsWithCorrectPrimaryKey");
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            context.Caretakers.Add(new Caretaker
+            {
+                Id = 42,
+                Notes = "Test caretaker with specific ID",
+                User = new User { Id = 1, FirstName = "Test", LastName = "User" }
+            });
+            await context.SaveChangesAsync();
+        }
+
+        // Act & Assert
+        using (var context = new ApplicationDbContext(options))
+        {
+            var caretaker = await context.Caretakers.FindAsync(42);
+            Assert.NotNull(caretaker);
+            Assert.Equal(42, caretaker.Id);
+            Assert.Equal("Test caretaker with specific ID", caretaker.Notes);
+        }
+    }
+
+    [Fact]
+    public async Task Payment_CaretakerId_MappedToPaidByColumn_RoundTrips()
+    {
+        // Arrange — verifies the CaretakerId -> PaidBy column mapping works
+        var options = CreateInMemoryOptions("Payment_CaretakerId_MappedToPaidByColumn");
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            context.Caretakers.Add(new Caretaker
+            {
+                Id = 5,
+                Notes = "Payer",
+                User = new User { Id = 1, FirstName = "Payer", LastName = "Person" }
+            });
+            context.PaymentTypes.Add(new PaymentType
+            {
+                Id = 1,
+                PmtTypeAbbreviation = "CSH",
+                PmtTypeName = "Cash"
+            });
+            await context.SaveChangesAsync();
+        }
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            context.Payments.Add(new Payment
+            {
+                Id = 1,
+                CaretakerId = 5,
+                PaymentTypeId = 1,
+                Amount = 300m,
+                PaymentDate = DateTime.UtcNow
+            });
+            await context.SaveChangesAsync();
+        }
+
+        // Act & Assert
+        using (var context = new ApplicationDbContext(options))
+        {
+            var payment = await context.Payments
+                .Include(p => p.Caretaker)
+                .FirstAsync(p => p.Id == 1);
+
+            Assert.Equal(5, payment.CaretakerId);
+            Assert.NotNull(payment.Caretaker);
+            Assert.Equal(5, payment.Caretaker.Id);
+        }
+    }
+}

--- a/tests/Infrastructure.Tests/PaymentEntityMappingTests.cs
+++ b/tests/Infrastructure.Tests/PaymentEntityMappingTests.cs
@@ -1,0 +1,260 @@
+using Xunit;
+using Microsoft.EntityFrameworkCore;
+using Neurocorp.Api.Core.Entities;
+using Neurocorp.Api.Infrastructure.Data;
+
+namespace Infrastructure.Tests.Repositories;
+
+public class PaymentEntityMappingTests
+{
+    private static DbContextOptions<ApplicationDbContext> CreateInMemoryOptions(string dbName)
+    {
+        return new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: dbName)
+            .Options;
+    }
+
+    [Fact]
+    public async Task Payment_CanBePersisted_WithAllProperties()
+    {
+        // Arrange
+        var options = CreateInMemoryOptions("Payment_CanBePersisted_WithAllProperties");
+        var paymentDate = DateTime.UtcNow;
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            context.PaymentTypes.Add(new PaymentType
+            {
+                Id = 1,
+                PmtTypeAbbreviation = "CHK",
+                PmtTypeName = "Check"
+            });
+            context.Caretakers.Add(new Caretaker
+            {
+                Id = 1,
+                Notes = "Test caretaker",
+                User = new User { Id = 1, FirstName = "Alice", LastName = "Smith" }
+            });
+            await context.SaveChangesAsync();
+        }
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            context.Payments.Add(new Payment
+            {
+                Id = 1,
+                CaretakerId = 1,
+                PaymentTypeId = 1,
+                CheckNumber = "1234",
+                Amount = 150.00m,
+                PaymentDate = paymentDate
+            });
+            await context.SaveChangesAsync();
+        }
+
+        // Act & Assert
+        using (var context = new ApplicationDbContext(options))
+        {
+            var payment = await context.Payments.FindAsync(1);
+            Assert.NotNull(payment);
+            Assert.Equal(1, payment.CaretakerId);
+            Assert.Equal(1, payment.PaymentTypeId);
+            Assert.Equal("1234", payment.CheckNumber);
+            Assert.Equal(150.00m, payment.Amount);
+            Assert.Equal(paymentDate, payment.PaymentDate);
+        }
+    }
+
+    [Fact]
+    public async Task Payment_CaretakerNavigation_LoadsCorrectly()
+    {
+        // Arrange
+        var options = CreateInMemoryOptions("Payment_CaretakerNavigation_LoadsCorrectly");
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            context.Caretakers.Add(new Caretaker
+            {
+                Id = 1,
+                Notes = "Primary caretaker",
+                User = new User { Id = 1, FirstName = "Bob", LastName = "Jones" }
+            });
+            context.PaymentTypes.Add(new PaymentType
+            {
+                Id = 1,
+                PmtTypeAbbreviation = "CSH",
+                PmtTypeName = "Cash"
+            });
+            await context.SaveChangesAsync();
+        }
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            context.Payments.Add(new Payment
+            {
+                Id = 1,
+                CaretakerId = 1,
+                PaymentTypeId = 1,
+                Amount = 200.00m,
+                PaymentDate = DateTime.UtcNow
+            });
+            await context.SaveChangesAsync();
+        }
+
+        // Act & Assert
+        using (var context = new ApplicationDbContext(options))
+        {
+            var payment = await context.Payments
+                .Include(p => p.Caretaker)
+                .FirstAsync(p => p.Id == 1);
+
+            Assert.NotNull(payment.Caretaker);
+            Assert.Equal(1, payment.Caretaker.Id);
+        }
+    }
+
+    [Fact]
+    public async Task Payment_SessionPaymentsCollection_LoadsCorrectly()
+    {
+        // Arrange
+        var options = CreateInMemoryOptions("Payment_SessionPaymentsCollection_LoadsCorrectly");
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            context.Caretakers.Add(new Caretaker
+            {
+                Id = 1,
+                Notes = "Test caretaker",
+                User = new User { Id = 1, FirstName = "Carol", LastName = "White" }
+            });
+            context.PaymentTypes.Add(new PaymentType
+            {
+                Id = 1,
+                PmtTypeAbbreviation = "CC",
+                PmtTypeName = "Credit Card"
+            });
+            context.Patients.Add(new Patient
+            {
+                Id = 1,
+                User = new User { Id = 2, FirstName = "Dan", LastName = "Green" }
+            });
+            context.Therapists.Add(new Therapist
+            {
+                Id = 1,
+                User = new User { Id = 3, FirstName = "Eve", LastName = "Brown" }
+            });
+            context.TherapySessions.Add(new TherapySession
+            {
+                Id = 1,
+                PatientId = 1,
+                TherapistId = 1,
+                SessionDate = DateOnly.FromDateTime(DateTime.UtcNow),
+                SessionTime = TimeOnly.FromDateTime(DateTime.UtcNow),
+                Amount = 100m,
+                Notes = "Session 1"
+            });
+            context.TherapySessions.Add(new TherapySession
+            {
+                Id = 2,
+                PatientId = 1,
+                TherapistId = 1,
+                SessionDate = DateOnly.FromDateTime(DateTime.UtcNow),
+                SessionTime = TimeOnly.FromDateTime(DateTime.UtcNow),
+                Amount = 100m,
+                Notes = "Session 2"
+            });
+            await context.SaveChangesAsync();
+        }
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            context.Payments.Add(new Payment
+            {
+                Id = 1,
+                CaretakerId = 1,
+                PaymentTypeId = 1,
+                Amount = 150.00m,
+                PaymentDate = DateTime.UtcNow
+            });
+            await context.SaveChangesAsync();
+        }
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            context.SessionPayments.Add(new SessionPayment
+            {
+                Id = 1,
+                PaymentId = 1,
+                TherapySessionId = 1,
+                AmountAllocated = 100.00m
+            });
+            context.SessionPayments.Add(new SessionPayment
+            {
+                Id = 2,
+                PaymentId = 1,
+                TherapySessionId = 2,
+                AmountAllocated = 50.00m
+            });
+            await context.SaveChangesAsync();
+        }
+
+        // Act & Assert
+        using (var context = new ApplicationDbContext(options))
+        {
+            var payment = await context.Payments
+                .Include(p => p.SessionPayments)
+                .FirstAsync(p => p.Id == 1);
+
+            Assert.NotNull(payment.SessionPayments);
+            Assert.Equal(2, payment.SessionPayments.Count);
+            Assert.Contains(payment.SessionPayments, sp => sp.AmountAllocated == 100.00m);
+            Assert.Contains(payment.SessionPayments, sp => sp.AmountAllocated == 50.00m);
+        }
+    }
+
+    [Fact]
+    public async Task Payment_CheckNumber_CanBeNull()
+    {
+        // Arrange
+        var options = CreateInMemoryOptions("Payment_CheckNumber_CanBeNull");
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            context.Caretakers.Add(new Caretaker
+            {
+                Id = 1,
+                Notes = "Test caretaker",
+                User = new User { Id = 1, FirstName = "Frank", LastName = "Miller" }
+            });
+            context.PaymentTypes.Add(new PaymentType
+            {
+                Id = 1,
+                PmtTypeAbbreviation = "CSH",
+                PmtTypeName = "Cash"
+            });
+            await context.SaveChangesAsync();
+        }
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            context.Payments.Add(new Payment
+            {
+                Id = 1,
+                CaretakerId = 1,
+                PaymentTypeId = 1,
+                CheckNumber = null,
+                Amount = 75.00m,
+                PaymentDate = DateTime.UtcNow
+            });
+            await context.SaveChangesAsync();
+        }
+
+        // Act & Assert
+        using (var context = new ApplicationDbContext(options))
+        {
+            var payment = await context.Payments.FindAsync(1);
+            Assert.NotNull(payment);
+            Assert.Null(payment.CheckNumber);
+        }
+    }
+}

--- a/tests/Infrastructure.Tests/SessionPaymentEntityMappingTests.cs
+++ b/tests/Infrastructure.Tests/SessionPaymentEntityMappingTests.cs
@@ -1,0 +1,249 @@
+using Xunit;
+using Microsoft.EntityFrameworkCore;
+using Neurocorp.Api.Core.Entities;
+using Neurocorp.Api.Infrastructure.Data;
+
+namespace Infrastructure.Tests.Repositories;
+
+public class SessionPaymentEntityMappingTests
+{
+    private static DbContextOptions<ApplicationDbContext> CreateInMemoryOptions(string dbName)
+    {
+        return new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: dbName)
+            .Options;
+    }
+
+    [Fact]
+    public async Task SessionPayment_CanBePersisted_WithAmountAllocated()
+    {
+        // Arrange
+        var options = CreateInMemoryOptions("SessionPayment_CanBePersisted_WithAmountAllocated");
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            context.Caretakers.Add(new Caretaker
+            {
+                Id = 1,
+                Notes = "Test caretaker",
+                User = new User { Id = 1, FirstName = "Alice", LastName = "Smith" }
+            });
+            context.PaymentTypes.Add(new PaymentType
+            {
+                Id = 1,
+                PmtTypeAbbreviation = "CSH",
+                PmtTypeName = "Cash"
+            });
+            context.Patients.Add(new Patient
+            {
+                Id = 1,
+                User = new User { Id = 2, FirstName = "Bob", LastName = "Jones" }
+            });
+            context.Therapists.Add(new Therapist
+            {
+                Id = 1,
+                User = new User { Id = 3, FirstName = "Carol", LastName = "White" }
+            });
+            context.TherapySessions.Add(new TherapySession
+            {
+                Id = 1,
+                PatientId = 1,
+                TherapistId = 1,
+                SessionDate = DateOnly.FromDateTime(DateTime.UtcNow),
+                SessionTime = TimeOnly.FromDateTime(DateTime.UtcNow),
+                Amount = 200m,
+                Notes = "Test session"
+            });
+            context.Payments.Add(new Payment
+            {
+                Id = 1,
+                CaretakerId = 1,
+                PaymentTypeId = 1,
+                Amount = 200m,
+                PaymentDate = DateTime.UtcNow
+            });
+            await context.SaveChangesAsync();
+        }
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            context.SessionPayments.Add(new SessionPayment
+            {
+                Id = 1,
+                PaymentId = 1,
+                TherapySessionId = 1,
+                AmountAllocated = 175.50m
+            });
+            await context.SaveChangesAsync();
+        }
+
+        // Act & Assert
+        using (var context = new ApplicationDbContext(options))
+        {
+            var sessionPayment = await context.SessionPayments.FindAsync(1);
+            Assert.NotNull(sessionPayment);
+            Assert.Equal(175.50m, sessionPayment.AmountAllocated);
+            Assert.Equal(1, sessionPayment.PaymentId);
+            Assert.Equal(1, sessionPayment.TherapySessionId);
+        }
+    }
+
+    [Theory]
+    [InlineData(0.01)]
+    [InlineData(99.99)]
+    [InlineData(1000.00)]
+    public async Task SessionPayment_AmountAllocated_RoundTripsCorrectly(double amount)
+    {
+        // Arrange
+        var decimalAmount = (decimal)amount;
+        var dbName = $"SessionPayment_AmountAllocated_RoundTrip_{amount}";
+        var options = CreateInMemoryOptions(dbName);
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            context.Caretakers.Add(new Caretaker
+            {
+                Id = 1,
+                Notes = "Test",
+                User = new User { Id = 1, FirstName = "A", LastName = "B" }
+            });
+            context.PaymentTypes.Add(new PaymentType
+            {
+                Id = 1,
+                PmtTypeAbbreviation = "CSH",
+                PmtTypeName = "Cash"
+            });
+            context.Patients.Add(new Patient
+            {
+                Id = 1,
+                User = new User { Id = 2, FirstName = "C", LastName = "D" }
+            });
+            context.Therapists.Add(new Therapist
+            {
+                Id = 1,
+                User = new User { Id = 3, FirstName = "E", LastName = "F" }
+            });
+            context.TherapySessions.Add(new TherapySession
+            {
+                Id = 1,
+                PatientId = 1,
+                TherapistId = 1,
+                SessionDate = DateOnly.FromDateTime(DateTime.UtcNow),
+                SessionTime = TimeOnly.FromDateTime(DateTime.UtcNow),
+                Amount = 1000m,
+                Notes = "Test"
+            });
+            context.Payments.Add(new Payment
+            {
+                Id = 1,
+                CaretakerId = 1,
+                PaymentTypeId = 1,
+                Amount = 1000m,
+                PaymentDate = DateTime.UtcNow
+            });
+            await context.SaveChangesAsync();
+        }
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            context.SessionPayments.Add(new SessionPayment
+            {
+                Id = 1,
+                PaymentId = 1,
+                TherapySessionId = 1,
+                AmountAllocated = decimalAmount
+            });
+            await context.SaveChangesAsync();
+        }
+
+        // Act & Assert
+        using (var context = new ApplicationDbContext(options))
+        {
+            var sessionPayment = await context.SessionPayments.FindAsync(1);
+            Assert.NotNull(sessionPayment);
+            Assert.Equal(decimalAmount, sessionPayment.AmountAllocated);
+        }
+    }
+
+    [Fact]
+    public async Task SessionPayment_NavigationProperties_LoadCorrectly()
+    {
+        // Arrange
+        var options = CreateInMemoryOptions("SessionPayment_NavigationProperties_LoadCorrectly");
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            context.Caretakers.Add(new Caretaker
+            {
+                Id = 1,
+                Notes = "Test caretaker",
+                User = new User { Id = 1, FirstName = "Alice", LastName = "Smith" }
+            });
+            context.PaymentTypes.Add(new PaymentType
+            {
+                Id = 1,
+                PmtTypeAbbreviation = "CHK",
+                PmtTypeName = "Check"
+            });
+            context.Patients.Add(new Patient
+            {
+                Id = 1,
+                User = new User { Id = 2, FirstName = "Bob", LastName = "Jones" }
+            });
+            context.Therapists.Add(new Therapist
+            {
+                Id = 1,
+                User = new User { Id = 3, FirstName = "Carol", LastName = "White" }
+            });
+            context.TherapySessions.Add(new TherapySession
+            {
+                Id = 1,
+                PatientId = 1,
+                TherapistId = 1,
+                SessionDate = DateOnly.FromDateTime(DateTime.UtcNow),
+                SessionTime = TimeOnly.FromDateTime(DateTime.UtcNow),
+                Amount = 100m,
+                Notes = "Therapy session"
+            });
+            context.Payments.Add(new Payment
+            {
+                Id = 1,
+                CaretakerId = 1,
+                PaymentTypeId = 1,
+                Amount = 100m,
+                CheckNumber = "5678",
+                PaymentDate = DateTime.UtcNow
+            });
+            await context.SaveChangesAsync();
+        }
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            context.SessionPayments.Add(new SessionPayment
+            {
+                Id = 1,
+                PaymentId = 1,
+                TherapySessionId = 1,
+                AmountAllocated = 100m
+            });
+            await context.SaveChangesAsync();
+        }
+
+        // Act & Assert
+        using (var context = new ApplicationDbContext(options))
+        {
+            var sessionPayment = await context.SessionPayments
+                .Include(sp => sp.Payment)
+                .Include(sp => sp.TherapySession)
+                .FirstAsync(sp => sp.Id == 1);
+
+            Assert.NotNull(sessionPayment.Payment);
+            Assert.Equal(1, sessionPayment.Payment.Id);
+            Assert.Equal(100m, sessionPayment.Payment.Amount);
+
+            Assert.NotNull(sessionPayment.TherapySession);
+            Assert.Equal(1, sessionPayment.TherapySession.Id);
+            Assert.Equal("Therapy session", sessionPayment.TherapySession.Notes);
+        }
+    }
+}


### PR DESCRIPTION
- B1: Payment entity FK corrected from PatientId to CaretakerId (maps to PaidBy column), added PaymentTypeId and CheckNumber properties
- B2: Added AmountAllocated property to SessionPayment entity
- B3: Fixed PatientCaretaker table name from "PatientCareTakers" to "PatientCaretaker"
- B4: Removed SQL Server bracket syntax .HasFilter() and .IsUnique() on PatientCaretaker index for MySQL compatibility
- B5: Fixed Caretaker PK column name from "CareTakerID" to "CaretakerID"
- B6: Added DbSet entries and OnModelCreating mappings for Payment, SessionPayment, and PaymentType entities