### PR TITLE
Admin lookup table CRUD: API endpoints for AppointmentStatus, Payment…

### DIFF
--- a/src/Core/BusinessObjects/Lookups/AppointmentStatusCreateRequest.cs
+++ b/src/Core/BusinessObjects/Lookups/AppointmentStatusCreateRequest.cs
@@ -1,0 +1,10 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Neurocorp.Api.Core.BusinessObjects.Lookups;
+
+public class AppointmentStatusCreateRequest
+{
+    [Required]
+    public string StatusName { get; set; } = string.Empty;
+    public string? StatusDescription { get; set; }
+}

--- a/src/Core/BusinessObjects/Lookups/AppointmentStatusUpdateRequest.cs
+++ b/src/Core/BusinessObjects/Lookups/AppointmentStatusUpdateRequest.cs
@@ -1,0 +1,7 @@
+namespace Neurocorp.Api.Core.BusinessObjects.Lookups;
+
+public class AppointmentStatusUpdateRequest
+{
+    public string? StatusName { get; set; }
+    public string? StatusDescription { get; set; }
+}

--- a/src/Core/BusinessObjects/Lookups/PaymentTypeCreateRequest.cs
+++ b/src/Core/BusinessObjects/Lookups/PaymentTypeCreateRequest.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Neurocorp.Api.Core.BusinessObjects.Lookups;
+
+public class PaymentTypeCreateRequest
+{
+    [Required]
+    public string Abbreviation { get; set; } = string.Empty;
+    [Required]
+    public string Name { get; set; } = string.Empty;
+}

--- a/src/Core/BusinessObjects/Lookups/PaymentTypeUpdateRequest.cs
+++ b/src/Core/BusinessObjects/Lookups/PaymentTypeUpdateRequest.cs
@@ -1,0 +1,7 @@
+namespace Neurocorp.Api.Core.BusinessObjects.Lookups;
+
+public class PaymentTypeUpdateRequest
+{
+    public string? Abbreviation { get; set; }
+    public string? Name { get; set; }
+}

--- a/src/Core/BusinessObjects/Lookups/RoleTypeCreateRequest.cs
+++ b/src/Core/BusinessObjects/Lookups/RoleTypeCreateRequest.cs
@@ -1,0 +1,9 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Neurocorp.Api.Core.BusinessObjects.Lookups;
+
+public class RoleTypeCreateRequest
+{
+    [Required]
+    public string RoleName { get; set; } = string.Empty;
+}

--- a/src/Core/BusinessObjects/Lookups/RoleTypeInfo.cs
+++ b/src/Core/BusinessObjects/Lookups/RoleTypeInfo.cs
@@ -1,0 +1,7 @@
+namespace Neurocorp.Api.Core.BusinessObjects.Lookups;
+
+public class RoleTypeInfo
+{
+    public int RoleId { get; set; }
+    public string RoleName { get; set; } = string.Empty;
+}

--- a/src/Core/BusinessObjects/Lookups/RoleTypeUpdateRequest.cs
+++ b/src/Core/BusinessObjects/Lookups/RoleTypeUpdateRequest.cs
@@ -1,0 +1,6 @@
+namespace Neurocorp.Api.Core.BusinessObjects.Lookups;
+
+public class RoleTypeUpdateRequest
+{
+    public string? RoleName { get; set; }
+}

--- a/src/Core/BusinessObjects/Lookups/SpecialtyTypeCreateRequest.cs
+++ b/src/Core/BusinessObjects/Lookups/SpecialtyTypeCreateRequest.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Neurocorp.Api.Core.BusinessObjects.Lookups;
+
+public class SpecialtyTypeCreateRequest
+{
+    [Required]
+    public string Abbreviation { get; set; } = string.Empty;
+    [Required]
+    public string Name { get; set; } = string.Empty;
+}

--- a/src/Core/BusinessObjects/Lookups/SpecialtyTypeInfo.cs
+++ b/src/Core/BusinessObjects/Lookups/SpecialtyTypeInfo.cs
@@ -1,0 +1,8 @@
+namespace Neurocorp.Api.Core.BusinessObjects.Lookups;
+
+public class SpecialtyTypeInfo
+{
+    public int SpecialtyId { get; set; }
+    public string Abbreviation { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+}

--- a/src/Core/BusinessObjects/Lookups/SpecialtyTypeUpdateRequest.cs
+++ b/src/Core/BusinessObjects/Lookups/SpecialtyTypeUpdateRequest.cs
@@ -1,0 +1,7 @@
+namespace Neurocorp.Api.Core.BusinessObjects.Lookups;
+
+public class SpecialtyTypeUpdateRequest
+{
+    public string? Abbreviation { get; set; }
+    public string? Name { get; set; }
+}

--- a/src/Core/Configurations/Dependencies.cs
+++ b/src/Core/Configurations/Dependencies.cs
@@ -22,6 +22,10 @@ public static class NeurocorpConfigurationExtensions
         services.AddScoped<IAccountStatementService, AccountStatementService>();
         services.AddScoped<IBookingService, BookingService>();
         services.AddScoped<ISiteProfileService, SiteProfileService>();
+        services.AddScoped<IAppointmentStatusService, AppointmentStatusService>();
+        services.AddScoped<IPaymentTypeService, PaymentTypeService>();
+        services.AddScoped<IRoleTypeService, RoleTypeService>();
+        services.AddScoped<ISpecialtyTypeService, SpecialtyTypeService>();
         return services;
     }
 }

--- a/src/Core/Entities/RoleType.cs
+++ b/src/Core/Entities/RoleType.cs
@@ -1,0 +1,7 @@
+namespace Neurocorp.Api.Core.Entities;
+
+public class RoleType
+{
+    public int Id { get; set; }
+    public string RoleName { get; set; } = string.Empty;
+}

--- a/src/Core/Entities/SpecialtyType.cs
+++ b/src/Core/Entities/SpecialtyType.cs
@@ -1,0 +1,8 @@
+namespace Neurocorp.Api.Core.Entities;
+
+public class SpecialtyType
+{
+    public int Id { get; set; }
+    public string SpecialtyAbbreviation { get; set; } = string.Empty;
+    public string SpecialtyName { get; set; } = string.Empty;
+}

--- a/src/Core/Interfaces/Services/IAppointmentStatusService.cs
+++ b/src/Core/Interfaces/Services/IAppointmentStatusService.cs
@@ -1,0 +1,12 @@
+using Neurocorp.Api.Core.BusinessObjects.Lookups;
+using Neurocorp.Api.Core.BusinessObjects.Sessions;
+
+namespace Neurocorp.Api.Core.Interfaces.Services;
+
+public interface IAppointmentStatusService
+{
+    Task<IEnumerable<AppointmentStatusInfo>> GetAllAsync();
+    Task<AppointmentStatusInfo?> GetByIdAsync(int id);
+    Task<AppointmentStatusInfo> CreateAsync(AppointmentStatusCreateRequest request);
+    Task<bool> UpdateAsync(int id, AppointmentStatusUpdateRequest request);
+}

--- a/src/Core/Interfaces/Services/IPaymentTypeService.cs
+++ b/src/Core/Interfaces/Services/IPaymentTypeService.cs
@@ -1,0 +1,12 @@
+using Neurocorp.Api.Core.BusinessObjects.Lookups;
+using Neurocorp.Api.Core.BusinessObjects.Payments;
+
+namespace Neurocorp.Api.Core.Interfaces.Services;
+
+public interface IPaymentTypeService
+{
+    Task<IEnumerable<PaymentTypeInfo>> GetAllAsync();
+    Task<PaymentTypeInfo?> GetByIdAsync(int id);
+    Task<PaymentTypeInfo> CreateAsync(PaymentTypeCreateRequest request);
+    Task<bool> UpdateAsync(int id, PaymentTypeUpdateRequest request);
+}

--- a/src/Core/Interfaces/Services/IRoleTypeService.cs
+++ b/src/Core/Interfaces/Services/IRoleTypeService.cs
@@ -1,0 +1,11 @@
+using Neurocorp.Api.Core.BusinessObjects.Lookups;
+
+namespace Neurocorp.Api.Core.Interfaces.Services;
+
+public interface IRoleTypeService
+{
+    Task<IEnumerable<RoleTypeInfo>> GetAllAsync();
+    Task<RoleTypeInfo?> GetByIdAsync(int id);
+    Task<RoleTypeInfo> CreateAsync(RoleTypeCreateRequest request);
+    Task<bool> UpdateAsync(int id, RoleTypeUpdateRequest request);
+}

--- a/src/Core/Interfaces/Services/ISpecialtyTypeService.cs
+++ b/src/Core/Interfaces/Services/ISpecialtyTypeService.cs
@@ -1,0 +1,11 @@
+using Neurocorp.Api.Core.BusinessObjects.Lookups;
+
+namespace Neurocorp.Api.Core.Interfaces.Services;
+
+public interface ISpecialtyTypeService
+{
+    Task<IEnumerable<SpecialtyTypeInfo>> GetAllAsync();
+    Task<SpecialtyTypeInfo?> GetByIdAsync(int id);
+    Task<SpecialtyTypeInfo> CreateAsync(SpecialtyTypeCreateRequest request);
+    Task<bool> UpdateAsync(int id, SpecialtyTypeUpdateRequest request);
+}

--- a/src/Core/Services/AppointmentStatusService.cs
+++ b/src/Core/Services/AppointmentStatusService.cs
@@ -1,0 +1,74 @@
+using Microsoft.Extensions.Logging;
+using Neurocorp.Api.Core.BusinessObjects.Lookups;
+using Neurocorp.Api.Core.BusinessObjects.Sessions;
+using Neurocorp.Api.Core.Entities;
+using Neurocorp.Api.Core.Interfaces.Repositories;
+using Neurocorp.Api.Core.Interfaces.Services;
+
+namespace Neurocorp.Api.Core.Services;
+
+public class AppointmentStatusService : IAppointmentStatusService
+{
+    private readonly IRepository<AppointmentStatus> _repository;
+    private readonly ILogger<AppointmentStatusService> _logger;
+
+    public AppointmentStatusService(
+        ILogger<AppointmentStatusService> logger,
+        IRepository<AppointmentStatus> repository)
+    {
+        _logger = logger;
+        _repository = repository;
+    }
+
+    public async Task<IEnumerable<AppointmentStatusInfo>> GetAllAsync()
+    {
+        _logger.LogInformation("Getting all appointment statuses");
+        var statuses = await _repository.GetAllAsync();
+        return statuses.Select(MapToInfo);
+    }
+
+    public async Task<AppointmentStatusInfo?> GetByIdAsync(int id)
+    {
+        _logger.LogInformation("Getting appointment status by ID: {Id}", id);
+        var status = await _repository.GetByIdAsync(id);
+        return status != null ? MapToInfo(status) : null;
+    }
+
+    public async Task<AppointmentStatusInfo> CreateAsync(AppointmentStatusCreateRequest request)
+    {
+        _logger.LogInformation("Creating new appointment status");
+        var entity = new AppointmentStatus
+        {
+            StatusName = request.StatusName,
+            StatusDescription = request.StatusDescription,
+        };
+        var created = await _repository.AddAsync(entity);
+        _logger.LogInformation("Created appointment status: {Id}", created.Id);
+        return MapToInfo(created);
+    }
+
+    public async Task<bool> UpdateAsync(int id, AppointmentStatusUpdateRequest request)
+    {
+        _logger.LogInformation("Updating appointment status with ID: {Id}", id);
+        ArgumentNullException.ThrowIfNull(request);
+
+        var entity = await _repository.GetByIdAsync(id);
+        if (entity == null) return false;
+
+        if (request.StatusName != null) entity.StatusName = request.StatusName;
+        if (request.StatusDescription != null) entity.StatusDescription = request.StatusDescription;
+
+        await _repository.UpdateAsync(entity);
+        return true;
+    }
+
+    private static AppointmentStatusInfo MapToInfo(AppointmentStatus entity)
+    {
+        return new AppointmentStatusInfo
+        {
+            AppointmentStatusId = entity.Id,
+            StatusName = entity.StatusName,
+            StatusDescription = entity.StatusDescription,
+        };
+    }
+}

--- a/src/Core/Services/PaymentTypeService.cs
+++ b/src/Core/Services/PaymentTypeService.cs
@@ -1,0 +1,74 @@
+using Microsoft.Extensions.Logging;
+using Neurocorp.Api.Core.BusinessObjects.Lookups;
+using Neurocorp.Api.Core.BusinessObjects.Payments;
+using Neurocorp.Api.Core.Entities;
+using Neurocorp.Api.Core.Interfaces.Repositories;
+using Neurocorp.Api.Core.Interfaces.Services;
+
+namespace Neurocorp.Api.Core.Services;
+
+public class PaymentTypeService : IPaymentTypeService
+{
+    private readonly IRepository<PaymentType> _repository;
+    private readonly ILogger<PaymentTypeService> _logger;
+
+    public PaymentTypeService(
+        ILogger<PaymentTypeService> logger,
+        IRepository<PaymentType> repository)
+    {
+        _logger = logger;
+        _repository = repository;
+    }
+
+    public async Task<IEnumerable<PaymentTypeInfo>> GetAllAsync()
+    {
+        _logger.LogInformation("Getting all payment types");
+        var types = await _repository.GetAllAsync();
+        return types.Select(MapToInfo);
+    }
+
+    public async Task<PaymentTypeInfo?> GetByIdAsync(int id)
+    {
+        _logger.LogInformation("Getting payment type by ID: {Id}", id);
+        var type = await _repository.GetByIdAsync(id);
+        return type != null ? MapToInfo(type) : null;
+    }
+
+    public async Task<PaymentTypeInfo> CreateAsync(PaymentTypeCreateRequest request)
+    {
+        _logger.LogInformation("Creating new payment type");
+        var entity = new PaymentType
+        {
+            PmtTypeAbbreviation = request.Abbreviation,
+            PmtTypeName = request.Name,
+        };
+        var created = await _repository.AddAsync(entity);
+        _logger.LogInformation("Created payment type: {Id}", created.Id);
+        return MapToInfo(created);
+    }
+
+    public async Task<bool> UpdateAsync(int id, PaymentTypeUpdateRequest request)
+    {
+        _logger.LogInformation("Updating payment type with ID: {Id}", id);
+        ArgumentNullException.ThrowIfNull(request);
+
+        var entity = await _repository.GetByIdAsync(id);
+        if (entity == null) return false;
+
+        if (request.Abbreviation != null) entity.PmtTypeAbbreviation = request.Abbreviation;
+        if (request.Name != null) entity.PmtTypeName = request.Name;
+
+        await _repository.UpdateAsync(entity);
+        return true;
+    }
+
+    private static PaymentTypeInfo MapToInfo(PaymentType entity)
+    {
+        return new PaymentTypeInfo
+        {
+            PaymentTypeId = entity.Id,
+            Abbreviation = entity.PmtTypeAbbreviation,
+            Name = entity.PmtTypeName,
+        };
+    }
+}

--- a/src/Core/Services/RoleTypeService.cs
+++ b/src/Core/Services/RoleTypeService.cs
@@ -1,0 +1,70 @@
+using Microsoft.Extensions.Logging;
+using Neurocorp.Api.Core.BusinessObjects.Lookups;
+using Neurocorp.Api.Core.Entities;
+using Neurocorp.Api.Core.Interfaces.Repositories;
+using Neurocorp.Api.Core.Interfaces.Services;
+
+namespace Neurocorp.Api.Core.Services;
+
+public class RoleTypeService : IRoleTypeService
+{
+    private readonly IRepository<RoleType> _repository;
+    private readonly ILogger<RoleTypeService> _logger;
+
+    public RoleTypeService(
+        ILogger<RoleTypeService> logger,
+        IRepository<RoleType> repository)
+    {
+        _logger = logger;
+        _repository = repository;
+    }
+
+    public async Task<IEnumerable<RoleTypeInfo>> GetAllAsync()
+    {
+        _logger.LogInformation("Getting all role types");
+        var roles = await _repository.GetAllAsync();
+        return roles.Select(MapToInfo);
+    }
+
+    public async Task<RoleTypeInfo?> GetByIdAsync(int id)
+    {
+        _logger.LogInformation("Getting role type by ID: {Id}", id);
+        var role = await _repository.GetByIdAsync(id);
+        return role != null ? MapToInfo(role) : null;
+    }
+
+    public async Task<RoleTypeInfo> CreateAsync(RoleTypeCreateRequest request)
+    {
+        _logger.LogInformation("Creating new role type");
+        var entity = new RoleType
+        {
+            RoleName = request.RoleName,
+        };
+        var created = await _repository.AddAsync(entity);
+        _logger.LogInformation("Created role type: {Id}", created.Id);
+        return MapToInfo(created);
+    }
+
+    public async Task<bool> UpdateAsync(int id, RoleTypeUpdateRequest request)
+    {
+        _logger.LogInformation("Updating role type with ID: {Id}", id);
+        ArgumentNullException.ThrowIfNull(request);
+
+        var entity = await _repository.GetByIdAsync(id);
+        if (entity == null) return false;
+
+        if (request.RoleName != null) entity.RoleName = request.RoleName;
+
+        await _repository.UpdateAsync(entity);
+        return true;
+    }
+
+    private static RoleTypeInfo MapToInfo(RoleType entity)
+    {
+        return new RoleTypeInfo
+        {
+            RoleId = entity.Id,
+            RoleName = entity.RoleName,
+        };
+    }
+}

--- a/src/Core/Services/SpecialtyTypeService.cs
+++ b/src/Core/Services/SpecialtyTypeService.cs
@@ -1,0 +1,73 @@
+using Microsoft.Extensions.Logging;
+using Neurocorp.Api.Core.BusinessObjects.Lookups;
+using Neurocorp.Api.Core.Entities;
+using Neurocorp.Api.Core.Interfaces.Repositories;
+using Neurocorp.Api.Core.Interfaces.Services;
+
+namespace Neurocorp.Api.Core.Services;
+
+public class SpecialtyTypeService : ISpecialtyTypeService
+{
+    private readonly IRepository<SpecialtyType> _repository;
+    private readonly ILogger<SpecialtyTypeService> _logger;
+
+    public SpecialtyTypeService(
+        ILogger<SpecialtyTypeService> logger,
+        IRepository<SpecialtyType> repository)
+    {
+        _logger = logger;
+        _repository = repository;
+    }
+
+    public async Task<IEnumerable<SpecialtyTypeInfo>> GetAllAsync()
+    {
+        _logger.LogInformation("Getting all specialty types");
+        var specialties = await _repository.GetAllAsync();
+        return specialties.Select(MapToInfo);
+    }
+
+    public async Task<SpecialtyTypeInfo?> GetByIdAsync(int id)
+    {
+        _logger.LogInformation("Getting specialty type by ID: {Id}", id);
+        var specialty = await _repository.GetByIdAsync(id);
+        return specialty != null ? MapToInfo(specialty) : null;
+    }
+
+    public async Task<SpecialtyTypeInfo> CreateAsync(SpecialtyTypeCreateRequest request)
+    {
+        _logger.LogInformation("Creating new specialty type");
+        var entity = new SpecialtyType
+        {
+            SpecialtyAbbreviation = request.Abbreviation,
+            SpecialtyName = request.Name,
+        };
+        var created = await _repository.AddAsync(entity);
+        _logger.LogInformation("Created specialty type: {Id}", created.Id);
+        return MapToInfo(created);
+    }
+
+    public async Task<bool> UpdateAsync(int id, SpecialtyTypeUpdateRequest request)
+    {
+        _logger.LogInformation("Updating specialty type with ID: {Id}", id);
+        ArgumentNullException.ThrowIfNull(request);
+
+        var entity = await _repository.GetByIdAsync(id);
+        if (entity == null) return false;
+
+        if (request.Abbreviation != null) entity.SpecialtyAbbreviation = request.Abbreviation;
+        if (request.Name != null) entity.SpecialtyName = request.Name;
+
+        await _repository.UpdateAsync(entity);
+        return true;
+    }
+
+    private static SpecialtyTypeInfo MapToInfo(SpecialtyType entity)
+    {
+        return new SpecialtyTypeInfo
+        {
+            SpecialtyId = entity.Id,
+            Abbreviation = entity.SpecialtyAbbreviation,
+            Name = entity.SpecialtyName,
+        };
+    }
+}

--- a/src/Infrastructure/Data/ApplicationDbContext.cs
+++ b/src/Infrastructure/Data/ApplicationDbContext.cs
@@ -20,6 +20,8 @@ public class ApplicationDbContext : DbContext
     public DbSet<AppointmentStatus> AppointmentStatuses { get; set; }
     public DbSet<AppointmentConfirmation> AppointmentConfirmations { get; set; }
     public DbSet<Site> Sites { get; set; }
+    public DbSet<RoleType> RoleTypes { get; set; }
+    public DbSet<SpecialtyType> SpecialtyTypes { get; set; }
 
     public override int SaveChanges()
     {
@@ -151,6 +153,16 @@ public class ApplicationDbContext : DbContext
             ac.HasKey(e => e.Id);
             ac.Property(e => e.Id).HasColumnName("ConfirmationID");
             ac.Property(e => e.SessionId).HasColumnName("SessionID");
+        });
+        modelBuilder.Entity<RoleType>(rt => {
+            rt.ToTable("RoleType");
+            rt.HasKey(e => e.Id);
+            rt.Property(e => e.Id).HasColumnName("RoleID");
+        });
+        modelBuilder.Entity<SpecialtyType>(st => {
+            st.ToTable("SpecialtyType");
+            st.HasKey(e => e.Id);
+            st.Property(e => e.Id).HasColumnName("SpecialtyID");
         });
         modelBuilder.Entity<PatientCaretaker>(entity =>
         {

--- a/src/Web/Controllers/AppointmentStatusesController.cs
+++ b/src/Web/Controllers/AppointmentStatusesController.cs
@@ -1,0 +1,62 @@
+using Microsoft.AspNetCore.Mvc;
+using Neurocorp.Api.Core.BusinessObjects.Lookups;
+using Neurocorp.Api.Core.BusinessObjects.Sessions;
+using Neurocorp.Api.Core.Interfaces.Services;
+
+namespace Neurocorp.Api.Web.Controllers;
+
+[ApiController]
+[Route("api/appointment-statuses")]
+public class AppointmentStatusesController : ControllerBase
+{
+    private readonly IAppointmentStatusService _service;
+    private readonly ILogger<AppointmentStatusesController> _logger;
+
+    public AppointmentStatusesController(
+        ILogger<AppointmentStatusesController> logger,
+        IAppointmentStatusService service)
+    {
+        _logger = logger;
+        _service = service;
+    }
+
+    [HttpGet]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<AppointmentStatusInfo>))]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<IActionResult> GetAll()
+    {
+        var items = await _service.GetAllAsync();
+        return Ok(items);
+    }
+
+    [HttpGet("{id}")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(AppointmentStatusInfo))]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<IActionResult> GetById(int id)
+    {
+        var item = await _service.GetByIdAsync(id);
+        if (item == null) return NotFound();
+        return Ok(item);
+    }
+
+    [HttpPost]
+    [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(AppointmentStatusInfo))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<IActionResult> Create([FromBody] AppointmentStatusCreateRequest request)
+    {
+        var created = await _service.CreateAsync(request);
+        return CreatedAtAction(nameof(GetById), new { id = created.AppointmentStatusId }, created);
+    }
+
+    [HttpPut("{id}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<IActionResult> Update(int id, [FromBody] AppointmentStatusUpdateRequest request)
+    {
+        var result = await _service.UpdateAsync(id, request);
+        return result ? NoContent() : NotFound();
+    }
+}

--- a/src/Web/Controllers/PaymentTypesController.cs
+++ b/src/Web/Controllers/PaymentTypesController.cs
@@ -1,0 +1,62 @@
+using Microsoft.AspNetCore.Mvc;
+using Neurocorp.Api.Core.BusinessObjects.Lookups;
+using Neurocorp.Api.Core.BusinessObjects.Payments;
+using Neurocorp.Api.Core.Interfaces.Services;
+
+namespace Neurocorp.Api.Web.Controllers;
+
+[ApiController]
+[Route("api/payment-types")]
+public class PaymentTypesController : ControllerBase
+{
+    private readonly IPaymentTypeService _service;
+    private readonly ILogger<PaymentTypesController> _logger;
+
+    public PaymentTypesController(
+        ILogger<PaymentTypesController> logger,
+        IPaymentTypeService service)
+    {
+        _logger = logger;
+        _service = service;
+    }
+
+    [HttpGet]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<PaymentTypeInfo>))]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<IActionResult> GetAll()
+    {
+        var items = await _service.GetAllAsync();
+        return Ok(items);
+    }
+
+    [HttpGet("{id}")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(PaymentTypeInfo))]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<IActionResult> GetById(int id)
+    {
+        var item = await _service.GetByIdAsync(id);
+        if (item == null) return NotFound();
+        return Ok(item);
+    }
+
+    [HttpPost]
+    [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(PaymentTypeInfo))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<IActionResult> Create([FromBody] PaymentTypeCreateRequest request)
+    {
+        var created = await _service.CreateAsync(request);
+        return CreatedAtAction(nameof(GetById), new { id = created.PaymentTypeId }, created);
+    }
+
+    [HttpPut("{id}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<IActionResult> Update(int id, [FromBody] PaymentTypeUpdateRequest request)
+    {
+        var result = await _service.UpdateAsync(id, request);
+        return result ? NoContent() : NotFound();
+    }
+}

--- a/src/Web/Controllers/RoleTypesController.cs
+++ b/src/Web/Controllers/RoleTypesController.cs
@@ -1,0 +1,61 @@
+using Microsoft.AspNetCore.Mvc;
+using Neurocorp.Api.Core.BusinessObjects.Lookups;
+using Neurocorp.Api.Core.Interfaces.Services;
+
+namespace Neurocorp.Api.Web.Controllers;
+
+[ApiController]
+[Route("api/role-types")]
+public class RoleTypesController : ControllerBase
+{
+    private readonly IRoleTypeService _service;
+    private readonly ILogger<RoleTypesController> _logger;
+
+    public RoleTypesController(
+        ILogger<RoleTypesController> logger,
+        IRoleTypeService service)
+    {
+        _logger = logger;
+        _service = service;
+    }
+
+    [HttpGet]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<RoleTypeInfo>))]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<IActionResult> GetAll()
+    {
+        var items = await _service.GetAllAsync();
+        return Ok(items);
+    }
+
+    [HttpGet("{id}")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(RoleTypeInfo))]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<IActionResult> GetById(int id)
+    {
+        var item = await _service.GetByIdAsync(id);
+        if (item == null) return NotFound();
+        return Ok(item);
+    }
+
+    [HttpPost]
+    [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(RoleTypeInfo))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<IActionResult> Create([FromBody] RoleTypeCreateRequest request)
+    {
+        var created = await _service.CreateAsync(request);
+        return CreatedAtAction(nameof(GetById), new { id = created.RoleId }, created);
+    }
+
+    [HttpPut("{id}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<IActionResult> Update(int id, [FromBody] RoleTypeUpdateRequest request)
+    {
+        var result = await _service.UpdateAsync(id, request);
+        return result ? NoContent() : NotFound();
+    }
+}

--- a/src/Web/Controllers/SpecialtyTypesController.cs
+++ b/src/Web/Controllers/SpecialtyTypesController.cs
@@ -1,0 +1,61 @@
+using Microsoft.AspNetCore.Mvc;
+using Neurocorp.Api.Core.BusinessObjects.Lookups;
+using Neurocorp.Api.Core.Interfaces.Services;
+
+namespace Neurocorp.Api.Web.Controllers;
+
+[ApiController]
+[Route("api/specialty-types")]
+public class SpecialtyTypesController : ControllerBase
+{
+    private readonly ISpecialtyTypeService _service;
+    private readonly ILogger<SpecialtyTypesController> _logger;
+
+    public SpecialtyTypesController(
+        ILogger<SpecialtyTypesController> logger,
+        ISpecialtyTypeService service)
+    {
+        _logger = logger;
+        _service = service;
+    }
+
+    [HttpGet]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<SpecialtyTypeInfo>))]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<IActionResult> GetAll()
+    {
+        var items = await _service.GetAllAsync();
+        return Ok(items);
+    }
+
+    [HttpGet("{id}")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(SpecialtyTypeInfo))]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<IActionResult> GetById(int id)
+    {
+        var item = await _service.GetByIdAsync(id);
+        if (item == null) return NotFound();
+        return Ok(item);
+    }
+
+    [HttpPost]
+    [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(SpecialtyTypeInfo))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<IActionResult> Create([FromBody] SpecialtyTypeCreateRequest request)
+    {
+        var created = await _service.CreateAsync(request);
+        return CreatedAtAction(nameof(GetById), new { id = created.SpecialtyId }, created);
+    }
+
+    [HttpPut("{id}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<IActionResult> Update(int id, [FromBody] SpecialtyTypeUpdateRequest request)
+    {
+        var result = await _service.UpdateAsync(id, request);
+        return result ? NoContent() : NotFound();
+    }
+}

--- a/tests/Core.Tests/AppointmentStatusServiceTests.cs
+++ b/tests/Core.Tests/AppointmentStatusServiceTests.cs
@@ -1,0 +1,126 @@
+using Neurocorp.Api.Core.Interfaces.Repositories;
+using Moq;
+using Neurocorp.Api.Core.Services;
+using Neurocorp.Api.Core.BusinessObjects.Lookups;
+using Neurocorp.Api.Core.BusinessObjects.Sessions;
+using Neurocorp.Api.Core.Entities;
+using Microsoft.Extensions.Logging;
+
+namespace Core.Tests;
+
+public class AppointmentStatusServiceTests
+{
+    [Fact]
+    public async Task GetAllAsync_ReturnsAllStatuses()
+    {
+        // Arrange
+        var fakeLogger = Mock.Of<ILogger<AppointmentStatusService>>();
+        var statuses = new List<AppointmentStatus>
+        {
+            new() { Id = 1, StatusName = "Proposed", StatusDescription = "Requested" },
+            new() { Id = 2, StatusName = "Confirmed", StatusDescription = "Confirmed by patient" }
+        };
+        var mockRepo = new Mock<IRepository<AppointmentStatus>>(MockBehavior.Strict);
+        mockRepo.Setup(repo => repo.GetAllAsync()).ReturnsAsync(statuses);
+        var svc = new AppointmentStatusService(fakeLogger, mockRepo.Object);
+
+        // Act
+        var result = await svc.GetAllAsync();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.IsAssignableFrom<IEnumerable<AppointmentStatusInfo>>(result);
+        Assert.Equal(2, result.Count());
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ReturnsStatus_WhenExists()
+    {
+        // Arrange
+        var fakeLogger = Mock.Of<ILogger<AppointmentStatusService>>();
+        var expected = new AppointmentStatus { Id = 1, StatusName = "Proposed", StatusDescription = "Requested" };
+        var mockRepo = new Mock<IRepository<AppointmentStatus>>(MockBehavior.Strict);
+        mockRepo.Setup(repo => repo.GetByIdAsync(1)).ReturnsAsync(expected);
+        var svc = new AppointmentStatusService(fakeLogger, mockRepo.Object);
+
+        // Act
+        var result = await svc.GetByIdAsync(1);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(expected.Id, result.AppointmentStatusId);
+        Assert.Equal(expected.StatusName, result.StatusName);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ReturnsNull_WhenNotExists()
+    {
+        // Arrange
+        var fakeLogger = Mock.Of<ILogger<AppointmentStatusService>>();
+        var mockRepo = new Mock<IRepository<AppointmentStatus>>(MockBehavior.Strict);
+        mockRepo.Setup(repo => repo.GetByIdAsync(99)).ReturnsAsync((AppointmentStatus?)null);
+        var svc = new AppointmentStatusService(fakeLogger, mockRepo.Object);
+
+        // Act
+        var result = await svc.GetByIdAsync(99);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task CreateAsync_ReturnsCreatedStatus()
+    {
+        // Arrange
+        var fakeLogger = Mock.Of<ILogger<AppointmentStatusService>>();
+        var request = new AppointmentStatusCreateRequest { StatusName = "NewStatus", StatusDescription = "Desc" };
+        var created = new AppointmentStatus { Id = 10, StatusName = "NewStatus", StatusDescription = "Desc" };
+        var mockRepo = new Mock<IRepository<AppointmentStatus>>(MockBehavior.Strict);
+        mockRepo.Setup(repo => repo.AddAsync(It.IsAny<AppointmentStatus>())).ReturnsAsync(created);
+        var svc = new AppointmentStatusService(fakeLogger, mockRepo.Object);
+
+        // Act
+        var result = await svc.CreateAsync(request);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(10, result.AppointmentStatusId);
+        Assert.Equal("NewStatus", result.StatusName);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ReturnsTrue_WhenExists()
+    {
+        // Arrange
+        var fakeLogger = Mock.Of<ILogger<AppointmentStatusService>>();
+        var existing = new AppointmentStatus { Id = 1, StatusName = "Old" };
+        var request = new AppointmentStatusUpdateRequest { StatusName = "New" };
+        var mockRepo = new Mock<IRepository<AppointmentStatus>>(MockBehavior.Strict);
+        mockRepo.Setup(repo => repo.GetByIdAsync(1)).ReturnsAsync(existing);
+        mockRepo.Setup(repo => repo.UpdateAsync(It.IsAny<AppointmentStatus>())).Returns(Task.CompletedTask);
+        var svc = new AppointmentStatusService(fakeLogger, mockRepo.Object);
+
+        // Act
+        var result = await svc.UpdateAsync(1, request);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ReturnsFalse_WhenNotExists()
+    {
+        // Arrange
+        var fakeLogger = Mock.Of<ILogger<AppointmentStatusService>>();
+        var request = new AppointmentStatusUpdateRequest { StatusName = "New" };
+        var mockRepo = new Mock<IRepository<AppointmentStatus>>(MockBehavior.Strict);
+        mockRepo.Setup(repo => repo.GetByIdAsync(99)).ReturnsAsync((AppointmentStatus?)null);
+        var svc = new AppointmentStatusService(fakeLogger, mockRepo.Object);
+
+        // Act
+        var result = await svc.UpdateAsync(99, request);
+
+        // Assert
+        Assert.False(result);
+    }
+}

--- a/tests/Core.Tests/PaymentTypeServiceTests.cs
+++ b/tests/Core.Tests/PaymentTypeServiceTests.cs
@@ -1,0 +1,127 @@
+using Neurocorp.Api.Core.Interfaces.Repositories;
+using Moq;
+using Neurocorp.Api.Core.Services;
+using Neurocorp.Api.Core.BusinessObjects.Lookups;
+using Neurocorp.Api.Core.BusinessObjects.Payments;
+using Neurocorp.Api.Core.Entities;
+using Microsoft.Extensions.Logging;
+
+namespace Core.Tests;
+
+public class PaymentTypeServiceTests
+{
+    [Fact]
+    public async Task GetAllAsync_ReturnsAllTypes()
+    {
+        // Arrange
+        var fakeLogger = Mock.Of<ILogger<PaymentTypeService>>();
+        var types = new List<PaymentType>
+        {
+            new() { Id = 1, PmtTypeAbbreviation = "CSH", PmtTypeName = "Cash" },
+            new() { Id = 2, PmtTypeAbbreviation = "CHK", PmtTypeName = "Check" }
+        };
+        var mockRepo = new Mock<IRepository<PaymentType>>(MockBehavior.Strict);
+        mockRepo.Setup(repo => repo.GetAllAsync()).ReturnsAsync(types);
+        var svc = new PaymentTypeService(fakeLogger, mockRepo.Object);
+
+        // Act
+        var result = await svc.GetAllAsync();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.IsAssignableFrom<IEnumerable<PaymentTypeInfo>>(result);
+        Assert.Equal(2, result.Count());
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ReturnsType_WhenExists()
+    {
+        // Arrange
+        var fakeLogger = Mock.Of<ILogger<PaymentTypeService>>();
+        var expected = new PaymentType { Id = 1, PmtTypeAbbreviation = "CSH", PmtTypeName = "Cash" };
+        var mockRepo = new Mock<IRepository<PaymentType>>(MockBehavior.Strict);
+        mockRepo.Setup(repo => repo.GetByIdAsync(1)).ReturnsAsync(expected);
+        var svc = new PaymentTypeService(fakeLogger, mockRepo.Object);
+
+        // Act
+        var result = await svc.GetByIdAsync(1);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(1, result.PaymentTypeId);
+        Assert.Equal("CSH", result.Abbreviation);
+        Assert.Equal("Cash", result.Name);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ReturnsNull_WhenNotExists()
+    {
+        // Arrange
+        var fakeLogger = Mock.Of<ILogger<PaymentTypeService>>();
+        var mockRepo = new Mock<IRepository<PaymentType>>(MockBehavior.Strict);
+        mockRepo.Setup(repo => repo.GetByIdAsync(99)).ReturnsAsync((PaymentType?)null);
+        var svc = new PaymentTypeService(fakeLogger, mockRepo.Object);
+
+        // Act
+        var result = await svc.GetByIdAsync(99);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task CreateAsync_ReturnsCreatedType()
+    {
+        // Arrange
+        var fakeLogger = Mock.Of<ILogger<PaymentTypeService>>();
+        var request = new PaymentTypeCreateRequest { Abbreviation = "ZEL", Name = "Zelle" };
+        var created = new PaymentType { Id = 10, PmtTypeAbbreviation = "ZEL", PmtTypeName = "Zelle" };
+        var mockRepo = new Mock<IRepository<PaymentType>>(MockBehavior.Strict);
+        mockRepo.Setup(repo => repo.AddAsync(It.IsAny<PaymentType>())).ReturnsAsync(created);
+        var svc = new PaymentTypeService(fakeLogger, mockRepo.Object);
+
+        // Act
+        var result = await svc.CreateAsync(request);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(10, result.PaymentTypeId);
+        Assert.Equal("ZEL", result.Abbreviation);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ReturnsTrue_WhenExists()
+    {
+        // Arrange
+        var fakeLogger = Mock.Of<ILogger<PaymentTypeService>>();
+        var existing = new PaymentType { Id = 1, PmtTypeAbbreviation = "CSH", PmtTypeName = "Cash" };
+        var request = new PaymentTypeUpdateRequest { Name = "Cash Payment" };
+        var mockRepo = new Mock<IRepository<PaymentType>>(MockBehavior.Strict);
+        mockRepo.Setup(repo => repo.GetByIdAsync(1)).ReturnsAsync(existing);
+        mockRepo.Setup(repo => repo.UpdateAsync(It.IsAny<PaymentType>())).Returns(Task.CompletedTask);
+        var svc = new PaymentTypeService(fakeLogger, mockRepo.Object);
+
+        // Act
+        var result = await svc.UpdateAsync(1, request);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ReturnsFalse_WhenNotExists()
+    {
+        // Arrange
+        var fakeLogger = Mock.Of<ILogger<PaymentTypeService>>();
+        var request = new PaymentTypeUpdateRequest { Name = "Updated" };
+        var mockRepo = new Mock<IRepository<PaymentType>>(MockBehavior.Strict);
+        mockRepo.Setup(repo => repo.GetByIdAsync(99)).ReturnsAsync((PaymentType?)null);
+        var svc = new PaymentTypeService(fakeLogger, mockRepo.Object);
+
+        // Act
+        var result = await svc.UpdateAsync(99, request);
+
+        // Assert
+        Assert.False(result);
+    }
+}

--- a/tests/Core.Tests/RoleTypeServiceTests.cs
+++ b/tests/Core.Tests/RoleTypeServiceTests.cs
@@ -1,0 +1,125 @@
+using Neurocorp.Api.Core.Interfaces.Repositories;
+using Moq;
+using Neurocorp.Api.Core.Services;
+using Neurocorp.Api.Core.BusinessObjects.Lookups;
+using Neurocorp.Api.Core.Entities;
+using Microsoft.Extensions.Logging;
+
+namespace Core.Tests;
+
+public class RoleTypeServiceTests
+{
+    [Fact]
+    public async Task GetAllAsync_ReturnsAllRoles()
+    {
+        // Arrange
+        var fakeLogger = Mock.Of<ILogger<RoleTypeService>>();
+        var roles = new List<RoleType>
+        {
+            new() { Id = 1, RoleName = "Patient" },
+            new() { Id = 2, RoleName = "Therapist" }
+        };
+        var mockRepo = new Mock<IRepository<RoleType>>(MockBehavior.Strict);
+        mockRepo.Setup(repo => repo.GetAllAsync()).ReturnsAsync(roles);
+        var svc = new RoleTypeService(fakeLogger, mockRepo.Object);
+
+        // Act
+        var result = await svc.GetAllAsync();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.IsAssignableFrom<IEnumerable<RoleTypeInfo>>(result);
+        Assert.Equal(2, result.Count());
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ReturnsRole_WhenExists()
+    {
+        // Arrange
+        var fakeLogger = Mock.Of<ILogger<RoleTypeService>>();
+        var expected = new RoleType { Id = 1, RoleName = "Patient" };
+        var mockRepo = new Mock<IRepository<RoleType>>(MockBehavior.Strict);
+        mockRepo.Setup(repo => repo.GetByIdAsync(1)).ReturnsAsync(expected);
+        var svc = new RoleTypeService(fakeLogger, mockRepo.Object);
+
+        // Act
+        var result = await svc.GetByIdAsync(1);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(1, result.RoleId);
+        Assert.Equal("Patient", result.RoleName);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ReturnsNull_WhenNotExists()
+    {
+        // Arrange
+        var fakeLogger = Mock.Of<ILogger<RoleTypeService>>();
+        var mockRepo = new Mock<IRepository<RoleType>>(MockBehavior.Strict);
+        mockRepo.Setup(repo => repo.GetByIdAsync(99)).ReturnsAsync((RoleType?)null);
+        var svc = new RoleTypeService(fakeLogger, mockRepo.Object);
+
+        // Act
+        var result = await svc.GetByIdAsync(99);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task CreateAsync_ReturnsCreatedRole()
+    {
+        // Arrange
+        var fakeLogger = Mock.Of<ILogger<RoleTypeService>>();
+        var request = new RoleTypeCreateRequest { RoleName = "Admin" };
+        var created = new RoleType { Id = 10, RoleName = "Admin" };
+        var mockRepo = new Mock<IRepository<RoleType>>(MockBehavior.Strict);
+        mockRepo.Setup(repo => repo.AddAsync(It.IsAny<RoleType>())).ReturnsAsync(created);
+        var svc = new RoleTypeService(fakeLogger, mockRepo.Object);
+
+        // Act
+        var result = await svc.CreateAsync(request);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(10, result.RoleId);
+        Assert.Equal("Admin", result.RoleName);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ReturnsTrue_WhenExists()
+    {
+        // Arrange
+        var fakeLogger = Mock.Of<ILogger<RoleTypeService>>();
+        var existing = new RoleType { Id = 1, RoleName = "Patient" };
+        var request = new RoleTypeUpdateRequest { RoleName = "Primary Patient" };
+        var mockRepo = new Mock<IRepository<RoleType>>(MockBehavior.Strict);
+        mockRepo.Setup(repo => repo.GetByIdAsync(1)).ReturnsAsync(existing);
+        mockRepo.Setup(repo => repo.UpdateAsync(It.IsAny<RoleType>())).Returns(Task.CompletedTask);
+        var svc = new RoleTypeService(fakeLogger, mockRepo.Object);
+
+        // Act
+        var result = await svc.UpdateAsync(1, request);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ReturnsFalse_WhenNotExists()
+    {
+        // Arrange
+        var fakeLogger = Mock.Of<ILogger<RoleTypeService>>();
+        var request = new RoleTypeUpdateRequest { RoleName = "Updated" };
+        var mockRepo = new Mock<IRepository<RoleType>>(MockBehavior.Strict);
+        mockRepo.Setup(repo => repo.GetByIdAsync(99)).ReturnsAsync((RoleType?)null);
+        var svc = new RoleTypeService(fakeLogger, mockRepo.Object);
+
+        // Act
+        var result = await svc.UpdateAsync(99, request);
+
+        // Assert
+        Assert.False(result);
+    }
+}

--- a/tests/Core.Tests/SpecialtyTypeServiceTests.cs
+++ b/tests/Core.Tests/SpecialtyTypeServiceTests.cs
@@ -1,0 +1,126 @@
+using Neurocorp.Api.Core.Interfaces.Repositories;
+using Moq;
+using Neurocorp.Api.Core.Services;
+using Neurocorp.Api.Core.BusinessObjects.Lookups;
+using Neurocorp.Api.Core.Entities;
+using Microsoft.Extensions.Logging;
+
+namespace Core.Tests;
+
+public class SpecialtyTypeServiceTests
+{
+    [Fact]
+    public async Task GetAllAsync_ReturnsAllSpecialties()
+    {
+        // Arrange
+        var fakeLogger = Mock.Of<ILogger<SpecialtyTypeService>>();
+        var specialties = new List<SpecialtyType>
+        {
+            new() { Id = 1, SpecialtyAbbreviation = "ET", SpecialtyName = "Early Stimulation" },
+            new() { Id = 2, SpecialtyAbbreviation = "FS", SpecialtyName = "Physiotherapy" }
+        };
+        var mockRepo = new Mock<IRepository<SpecialtyType>>(MockBehavior.Strict);
+        mockRepo.Setup(repo => repo.GetAllAsync()).ReturnsAsync(specialties);
+        var svc = new SpecialtyTypeService(fakeLogger, mockRepo.Object);
+
+        // Act
+        var result = await svc.GetAllAsync();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.IsAssignableFrom<IEnumerable<SpecialtyTypeInfo>>(result);
+        Assert.Equal(2, result.Count());
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ReturnsSpecialty_WhenExists()
+    {
+        // Arrange
+        var fakeLogger = Mock.Of<ILogger<SpecialtyTypeService>>();
+        var expected = new SpecialtyType { Id = 1, SpecialtyAbbreviation = "ET", SpecialtyName = "Early Stimulation" };
+        var mockRepo = new Mock<IRepository<SpecialtyType>>(MockBehavior.Strict);
+        mockRepo.Setup(repo => repo.GetByIdAsync(1)).ReturnsAsync(expected);
+        var svc = new SpecialtyTypeService(fakeLogger, mockRepo.Object);
+
+        // Act
+        var result = await svc.GetByIdAsync(1);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(1, result.SpecialtyId);
+        Assert.Equal("ET", result.Abbreviation);
+        Assert.Equal("Early Stimulation", result.Name);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ReturnsNull_WhenNotExists()
+    {
+        // Arrange
+        var fakeLogger = Mock.Of<ILogger<SpecialtyTypeService>>();
+        var mockRepo = new Mock<IRepository<SpecialtyType>>(MockBehavior.Strict);
+        mockRepo.Setup(repo => repo.GetByIdAsync(99)).ReturnsAsync((SpecialtyType?)null);
+        var svc = new SpecialtyTypeService(fakeLogger, mockRepo.Object);
+
+        // Act
+        var result = await svc.GetByIdAsync(99);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task CreateAsync_ReturnsCreatedSpecialty()
+    {
+        // Arrange
+        var fakeLogger = Mock.Of<ILogger<SpecialtyTypeService>>();
+        var request = new SpecialtyTypeCreateRequest { Abbreviation = "OT", Name = "Occupational Therapy" };
+        var created = new SpecialtyType { Id = 10, SpecialtyAbbreviation = "OT", SpecialtyName = "Occupational Therapy" };
+        var mockRepo = new Mock<IRepository<SpecialtyType>>(MockBehavior.Strict);
+        mockRepo.Setup(repo => repo.AddAsync(It.IsAny<SpecialtyType>())).ReturnsAsync(created);
+        var svc = new SpecialtyTypeService(fakeLogger, mockRepo.Object);
+
+        // Act
+        var result = await svc.CreateAsync(request);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(10, result.SpecialtyId);
+        Assert.Equal("OT", result.Abbreviation);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ReturnsTrue_WhenExists()
+    {
+        // Arrange
+        var fakeLogger = Mock.Of<ILogger<SpecialtyTypeService>>();
+        var existing = new SpecialtyType { Id = 1, SpecialtyAbbreviation = "ET", SpecialtyName = "Old Name" };
+        var request = new SpecialtyTypeUpdateRequest { Name = "Early Stimulation Therapy" };
+        var mockRepo = new Mock<IRepository<SpecialtyType>>(MockBehavior.Strict);
+        mockRepo.Setup(repo => repo.GetByIdAsync(1)).ReturnsAsync(existing);
+        mockRepo.Setup(repo => repo.UpdateAsync(It.IsAny<SpecialtyType>())).Returns(Task.CompletedTask);
+        var svc = new SpecialtyTypeService(fakeLogger, mockRepo.Object);
+
+        // Act
+        var result = await svc.UpdateAsync(1, request);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ReturnsFalse_WhenNotExists()
+    {
+        // Arrange
+        var fakeLogger = Mock.Of<ILogger<SpecialtyTypeService>>();
+        var request = new SpecialtyTypeUpdateRequest { Name = "Updated" };
+        var mockRepo = new Mock<IRepository<SpecialtyType>>(MockBehavior.Strict);
+        mockRepo.Setup(repo => repo.GetByIdAsync(99)).ReturnsAsync((SpecialtyType?)null);
+        var svc = new SpecialtyTypeService(fakeLogger, mockRepo.Object);
+
+        // Act
+        var result = await svc.UpdateAsync(99, request);
+
+        // Assert
+        Assert.False(result);
+    }
+}

--- a/tests/Web.Tests/AppointmentStatusesControllerTests.cs
+++ b/tests/Web.Tests/AppointmentStatusesControllerTests.cs
@@ -1,0 +1,116 @@
+using Moq;
+using Xunit;
+using Microsoft.AspNetCore.Mvc;
+using Neurocorp.Api.Core.BusinessObjects.Lookups;
+using Neurocorp.Api.Core.BusinessObjects.Sessions;
+using Neurocorp.Api.Core.Interfaces.Services;
+using Neurocorp.Api.Web.Controllers;
+using Microsoft.Extensions.Logging;
+
+namespace Web.Tests.Controllers;
+
+public class AppointmentStatusesControllerTests
+{
+    private readonly Mock<IAppointmentStatusService> _mockService;
+    private readonly AppointmentStatusesController _controller;
+
+    public AppointmentStatusesControllerTests()
+    {
+        var fakeLogger = Mock.Of<ILogger<AppointmentStatusesController>>();
+        _mockService = new Mock<IAppointmentStatusService>();
+        _controller = new AppointmentStatusesController(fakeLogger, _mockService.Object);
+    }
+
+    [Fact]
+    public async Task GetAll_ReturnsOkResult_WithStatuses()
+    {
+        // Arrange
+        var mockItems = new List<AppointmentStatusInfo>
+        {
+            new() { AppointmentStatusId = 1, StatusName = "Proposed" },
+            new() { AppointmentStatusId = 2, StatusName = "Confirmed" }
+        };
+        _mockService.Setup(s => s.GetAllAsync()).ReturnsAsync(mockItems);
+
+        // Act
+        var result = await _controller.GetAll();
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var returned = Assert.IsType<List<AppointmentStatusInfo>>(okResult.Value);
+        Assert.Equal(2, returned.Count);
+    }
+
+    [Fact]
+    public async Task GetById_ReturnsOkResult_WhenExists()
+    {
+        // Arrange
+        var item = new AppointmentStatusInfo { AppointmentStatusId = 1, StatusName = "Proposed" };
+        _mockService.Setup(s => s.GetByIdAsync(1)).ReturnsAsync(item);
+
+        // Act
+        var result = await _controller.GetById(1);
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        Assert.IsType<AppointmentStatusInfo>(okResult.Value);
+    }
+
+    [Fact]
+    public async Task GetById_ReturnsNotFound_WhenNotExists()
+    {
+        // Arrange
+        _mockService.Setup(s => s.GetByIdAsync(99)).ReturnsAsync((AppointmentStatusInfo?)null);
+
+        // Act
+        var result = await _controller.GetById(99);
+
+        // Assert
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task Create_ReturnsCreatedAtAction()
+    {
+        // Arrange
+        var request = new AppointmentStatusCreateRequest { StatusName = "NewStatus" };
+        var created = new AppointmentStatusInfo { AppointmentStatusId = 10, StatusName = "NewStatus" };
+        _mockService.Setup(s => s.CreateAsync(request)).ReturnsAsync(created);
+
+        // Act
+        var result = await _controller.Create(request);
+
+        // Assert
+        var createdResult = Assert.IsType<CreatedAtActionResult>(result);
+        var returned = Assert.IsType<AppointmentStatusInfo>(createdResult.Value);
+        Assert.Equal(10, returned.AppointmentStatusId);
+    }
+
+    [Fact]
+    public async Task Update_ReturnsNoContent_WhenExists()
+    {
+        // Arrange
+        var request = new AppointmentStatusUpdateRequest { StatusName = "Updated" };
+        _mockService.Setup(s => s.UpdateAsync(1, request)).ReturnsAsync(true);
+
+        // Act
+        var result = await _controller.Update(1, request);
+
+        // Assert
+        Assert.IsType<NoContentResult>(result);
+    }
+
+    [Fact]
+    public async Task Update_ReturnsNotFound_WhenNotExists()
+    {
+        // Arrange
+        var request = new AppointmentStatusUpdateRequest { StatusName = "Updated" };
+        _mockService.Setup(s => s.UpdateAsync(99, request)).ReturnsAsync(false);
+
+        // Act
+        var result = await _controller.Update(99, request);
+
+        // Assert
+        Assert.IsType<NotFoundResult>(result);
+    }
+}

--- a/tests/Web.Tests/PaymentTypesControllerTests.cs
+++ b/tests/Web.Tests/PaymentTypesControllerTests.cs
@@ -1,0 +1,116 @@
+using Moq;
+using Xunit;
+using Microsoft.AspNetCore.Mvc;
+using Neurocorp.Api.Core.BusinessObjects.Lookups;
+using Neurocorp.Api.Core.BusinessObjects.Payments;
+using Neurocorp.Api.Core.Interfaces.Services;
+using Neurocorp.Api.Web.Controllers;
+using Microsoft.Extensions.Logging;
+
+namespace Web.Tests.Controllers;
+
+public class PaymentTypesControllerTests
+{
+    private readonly Mock<IPaymentTypeService> _mockService;
+    private readonly PaymentTypesController _controller;
+
+    public PaymentTypesControllerTests()
+    {
+        var fakeLogger = Mock.Of<ILogger<PaymentTypesController>>();
+        _mockService = new Mock<IPaymentTypeService>();
+        _controller = new PaymentTypesController(fakeLogger, _mockService.Object);
+    }
+
+    [Fact]
+    public async Task GetAll_ReturnsOkResult_WithTypes()
+    {
+        // Arrange
+        var mockItems = new List<PaymentTypeInfo>
+        {
+            new() { PaymentTypeId = 1, Abbreviation = "CSH", Name = "Cash" },
+            new() { PaymentTypeId = 2, Abbreviation = "CHK", Name = "Check" }
+        };
+        _mockService.Setup(s => s.GetAllAsync()).ReturnsAsync(mockItems);
+
+        // Act
+        var result = await _controller.GetAll();
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var returned = Assert.IsType<List<PaymentTypeInfo>>(okResult.Value);
+        Assert.Equal(2, returned.Count);
+    }
+
+    [Fact]
+    public async Task GetById_ReturnsOkResult_WhenExists()
+    {
+        // Arrange
+        var item = new PaymentTypeInfo { PaymentTypeId = 1, Abbreviation = "CSH", Name = "Cash" };
+        _mockService.Setup(s => s.GetByIdAsync(1)).ReturnsAsync(item);
+
+        // Act
+        var result = await _controller.GetById(1);
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        Assert.IsType<PaymentTypeInfo>(okResult.Value);
+    }
+
+    [Fact]
+    public async Task GetById_ReturnsNotFound_WhenNotExists()
+    {
+        // Arrange
+        _mockService.Setup(s => s.GetByIdAsync(99)).ReturnsAsync((PaymentTypeInfo?)null);
+
+        // Act
+        var result = await _controller.GetById(99);
+
+        // Assert
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task Create_ReturnsCreatedAtAction()
+    {
+        // Arrange
+        var request = new PaymentTypeCreateRequest { Abbreviation = "ZEL", Name = "Zelle" };
+        var created = new PaymentTypeInfo { PaymentTypeId = 10, Abbreviation = "ZEL", Name = "Zelle" };
+        _mockService.Setup(s => s.CreateAsync(request)).ReturnsAsync(created);
+
+        // Act
+        var result = await _controller.Create(request);
+
+        // Assert
+        var createdResult = Assert.IsType<CreatedAtActionResult>(result);
+        var returned = Assert.IsType<PaymentTypeInfo>(createdResult.Value);
+        Assert.Equal(10, returned.PaymentTypeId);
+    }
+
+    [Fact]
+    public async Task Update_ReturnsNoContent_WhenExists()
+    {
+        // Arrange
+        var request = new PaymentTypeUpdateRequest { Name = "Updated" };
+        _mockService.Setup(s => s.UpdateAsync(1, request)).ReturnsAsync(true);
+
+        // Act
+        var result = await _controller.Update(1, request);
+
+        // Assert
+        Assert.IsType<NoContentResult>(result);
+    }
+
+    [Fact]
+    public async Task Update_ReturnsNotFound_WhenNotExists()
+    {
+        // Arrange
+        var request = new PaymentTypeUpdateRequest { Name = "Updated" };
+        _mockService.Setup(s => s.UpdateAsync(99, request)).ReturnsAsync(false);
+
+        // Act
+        var result = await _controller.Update(99, request);
+
+        // Assert
+        Assert.IsType<NotFoundResult>(result);
+    }
+}

--- a/tests/Web.Tests/RoleTypesControllerTests.cs
+++ b/tests/Web.Tests/RoleTypesControllerTests.cs
@@ -1,0 +1,115 @@
+using Moq;
+using Xunit;
+using Microsoft.AspNetCore.Mvc;
+using Neurocorp.Api.Core.BusinessObjects.Lookups;
+using Neurocorp.Api.Core.Interfaces.Services;
+using Neurocorp.Api.Web.Controllers;
+using Microsoft.Extensions.Logging;
+
+namespace Web.Tests.Controllers;
+
+public class RoleTypesControllerTests
+{
+    private readonly Mock<IRoleTypeService> _mockService;
+    private readonly RoleTypesController _controller;
+
+    public RoleTypesControllerTests()
+    {
+        var fakeLogger = Mock.Of<ILogger<RoleTypesController>>();
+        _mockService = new Mock<IRoleTypeService>();
+        _controller = new RoleTypesController(fakeLogger, _mockService.Object);
+    }
+
+    [Fact]
+    public async Task GetAll_ReturnsOkResult_WithRoles()
+    {
+        // Arrange
+        var mockItems = new List<RoleTypeInfo>
+        {
+            new() { RoleId = 1, RoleName = "Patient" },
+            new() { RoleId = 2, RoleName = "Therapist" }
+        };
+        _mockService.Setup(s => s.GetAllAsync()).ReturnsAsync(mockItems);
+
+        // Act
+        var result = await _controller.GetAll();
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var returned = Assert.IsType<List<RoleTypeInfo>>(okResult.Value);
+        Assert.Equal(2, returned.Count);
+    }
+
+    [Fact]
+    public async Task GetById_ReturnsOkResult_WhenExists()
+    {
+        // Arrange
+        var item = new RoleTypeInfo { RoleId = 1, RoleName = "Patient" };
+        _mockService.Setup(s => s.GetByIdAsync(1)).ReturnsAsync(item);
+
+        // Act
+        var result = await _controller.GetById(1);
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        Assert.IsType<RoleTypeInfo>(okResult.Value);
+    }
+
+    [Fact]
+    public async Task GetById_ReturnsNotFound_WhenNotExists()
+    {
+        // Arrange
+        _mockService.Setup(s => s.GetByIdAsync(99)).ReturnsAsync((RoleTypeInfo?)null);
+
+        // Act
+        var result = await _controller.GetById(99);
+
+        // Assert
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task Create_ReturnsCreatedAtAction()
+    {
+        // Arrange
+        var request = new RoleTypeCreateRequest { RoleName = "Admin" };
+        var created = new RoleTypeInfo { RoleId = 10, RoleName = "Admin" };
+        _mockService.Setup(s => s.CreateAsync(request)).ReturnsAsync(created);
+
+        // Act
+        var result = await _controller.Create(request);
+
+        // Assert
+        var createdResult = Assert.IsType<CreatedAtActionResult>(result);
+        var returned = Assert.IsType<RoleTypeInfo>(createdResult.Value);
+        Assert.Equal(10, returned.RoleId);
+    }
+
+    [Fact]
+    public async Task Update_ReturnsNoContent_WhenExists()
+    {
+        // Arrange
+        var request = new RoleTypeUpdateRequest { RoleName = "Updated" };
+        _mockService.Setup(s => s.UpdateAsync(1, request)).ReturnsAsync(true);
+
+        // Act
+        var result = await _controller.Update(1, request);
+
+        // Assert
+        Assert.IsType<NoContentResult>(result);
+    }
+
+    [Fact]
+    public async Task Update_ReturnsNotFound_WhenNotExists()
+    {
+        // Arrange
+        var request = new RoleTypeUpdateRequest { RoleName = "Updated" };
+        _mockService.Setup(s => s.UpdateAsync(99, request)).ReturnsAsync(false);
+
+        // Act
+        var result = await _controller.Update(99, request);
+
+        // Assert
+        Assert.IsType<NotFoundResult>(result);
+    }
+}

--- a/tests/Web.Tests/SpecialtyTypesControllerTests.cs
+++ b/tests/Web.Tests/SpecialtyTypesControllerTests.cs
@@ -1,0 +1,115 @@
+using Moq;
+using Xunit;
+using Microsoft.AspNetCore.Mvc;
+using Neurocorp.Api.Core.BusinessObjects.Lookups;
+using Neurocorp.Api.Core.Interfaces.Services;
+using Neurocorp.Api.Web.Controllers;
+using Microsoft.Extensions.Logging;
+
+namespace Web.Tests.Controllers;
+
+public class SpecialtyTypesControllerTests
+{
+    private readonly Mock<ISpecialtyTypeService> _mockService;
+    private readonly SpecialtyTypesController _controller;
+
+    public SpecialtyTypesControllerTests()
+    {
+        var fakeLogger = Mock.Of<ILogger<SpecialtyTypesController>>();
+        _mockService = new Mock<ISpecialtyTypeService>();
+        _controller = new SpecialtyTypesController(fakeLogger, _mockService.Object);
+    }
+
+    [Fact]
+    public async Task GetAll_ReturnsOkResult_WithSpecialties()
+    {
+        // Arrange
+        var mockItems = new List<SpecialtyTypeInfo>
+        {
+            new() { SpecialtyId = 1, Abbreviation = "ET", Name = "Early Stimulation" },
+            new() { SpecialtyId = 2, Abbreviation = "FS", Name = "Physiotherapy" }
+        };
+        _mockService.Setup(s => s.GetAllAsync()).ReturnsAsync(mockItems);
+
+        // Act
+        var result = await _controller.GetAll();
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var returned = Assert.IsType<List<SpecialtyTypeInfo>>(okResult.Value);
+        Assert.Equal(2, returned.Count);
+    }
+
+    [Fact]
+    public async Task GetById_ReturnsOkResult_WhenExists()
+    {
+        // Arrange
+        var item = new SpecialtyTypeInfo { SpecialtyId = 1, Abbreviation = "ET", Name = "Early Stimulation" };
+        _mockService.Setup(s => s.GetByIdAsync(1)).ReturnsAsync(item);
+
+        // Act
+        var result = await _controller.GetById(1);
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        Assert.IsType<SpecialtyTypeInfo>(okResult.Value);
+    }
+
+    [Fact]
+    public async Task GetById_ReturnsNotFound_WhenNotExists()
+    {
+        // Arrange
+        _mockService.Setup(s => s.GetByIdAsync(99)).ReturnsAsync((SpecialtyTypeInfo?)null);
+
+        // Act
+        var result = await _controller.GetById(99);
+
+        // Assert
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task Create_ReturnsCreatedAtAction()
+    {
+        // Arrange
+        var request = new SpecialtyTypeCreateRequest { Abbreviation = "OT", Name = "Occupational Therapy" };
+        var created = new SpecialtyTypeInfo { SpecialtyId = 10, Abbreviation = "OT", Name = "Occupational Therapy" };
+        _mockService.Setup(s => s.CreateAsync(request)).ReturnsAsync(created);
+
+        // Act
+        var result = await _controller.Create(request);
+
+        // Assert
+        var createdResult = Assert.IsType<CreatedAtActionResult>(result);
+        var returned = Assert.IsType<SpecialtyTypeInfo>(createdResult.Value);
+        Assert.Equal(10, returned.SpecialtyId);
+    }
+
+    [Fact]
+    public async Task Update_ReturnsNoContent_WhenExists()
+    {
+        // Arrange
+        var request = new SpecialtyTypeUpdateRequest { Name = "Updated" };
+        _mockService.Setup(s => s.UpdateAsync(1, request)).ReturnsAsync(true);
+
+        // Act
+        var result = await _controller.Update(1, request);
+
+        // Assert
+        Assert.IsType<NoContentResult>(result);
+    }
+
+    [Fact]
+    public async Task Update_ReturnsNotFound_WhenNotExists()
+    {
+        // Arrange
+        var request = new SpecialtyTypeUpdateRequest { Name = "Updated" };
+        _mockService.Setup(s => s.UpdateAsync(99, request)).ReturnsAsync(false);
+
+        // Act
+        var result = await _controller.Update(99, request);
+
+        // Assert
+        Assert.IsType<NotFoundResult>(result);
+    }
+}


### PR DESCRIPTION
…Type, RoleType, SpecialtyType

Add full CRUD controllers, services, DTOs, and entities for managing reference/lookup tables via the Admin UI. RoleType and SpecialtyType entities are new; AppointmentStatus and PaymentType had read-only endpoints which remain untouched at their existing routes.