### PR TITLE
WP-10B: Treatment plan CRUD + discovery-first enforcement

### DIFF
--- a/src/Core/BusinessObjects/TreatmentPlans/TreatmentPlanLineProfile.cs
+++ b/src/Core/BusinessObjects/TreatmentPlans/TreatmentPlanLineProfile.cs
@@ -1,0 +1,16 @@
+namespace Neurocorp.Api.Core.BusinessObjects.TreatmentPlans;
+
+public class TreatmentPlanLineProfile
+{
+    public int Id { get; set; }
+    public int TreatmentPlanId { get; set; }
+    public int SpecialtyTypeId { get; set; }
+    public string SpecialtyAbbreviation { get; set; } = string.Empty;
+    public string SpecialtyName { get; set; } = string.Empty;
+    public int? PreferredTherapistId { get; set; }
+    public string? PreferredTherapistName { get; set; }
+    public byte? DayOfWeek { get; set; }
+    public TimeOnly? PreferredTime { get; set; }
+    public int Duration { get; set; }
+    public byte SortOrder { get; set; }
+}

--- a/src/Core/BusinessObjects/TreatmentPlans/TreatmentPlanLineRequest.cs
+++ b/src/Core/BusinessObjects/TreatmentPlans/TreatmentPlanLineRequest.cs
@@ -1,0 +1,11 @@
+namespace Neurocorp.Api.Core.BusinessObjects.TreatmentPlans;
+
+public class TreatmentPlanLineRequest
+{
+    public int SpecialtyTypeId { get; set; }
+    public int? PreferredTherapistId { get; set; }
+    public byte? DayOfWeek { get; set; }
+    public TimeOnly? PreferredTime { get; set; }
+    public int Duration { get; set; } = 60;
+    public byte SortOrder { get; set; }
+}

--- a/src/Core/BusinessObjects/TreatmentPlans/TreatmentPlanProfile.cs
+++ b/src/Core/BusinessObjects/TreatmentPlans/TreatmentPlanProfile.cs
@@ -1,0 +1,21 @@
+namespace Neurocorp.Api.Core.BusinessObjects.TreatmentPlans;
+
+public class TreatmentPlanProfile
+{
+    public int Id { get; set; }
+    public int PatientId { get; set; }
+    public string PatientName { get; set; } = string.Empty;
+    public int DiscoverySessionId { get; set; }
+    public DateOnly DiscoveryDate { get; set; }
+    public string DiscoverySpecialty { get; set; } = string.Empty;
+    public int CreatedByTherapistId { get; set; }
+    public string CreatedByTherapistName { get; set; } = string.Empty;
+    public string PlanStatus { get; set; } = string.Empty;
+    public string? ResultsDocumentUrl { get; set; }
+    public int WeeklyFrequency { get; set; }
+    public int DurationWeeks { get; set; }
+    public string? Notes { get; set; }
+    public DateTime CreatedTimestamp { get; set; }
+    public DateTime LastUpdatedTimestamp { get; set; }
+    public List<TreatmentPlanLineProfile> Lines { get; set; } = [];
+}

--- a/src/Core/BusinessObjects/TreatmentPlans/TreatmentPlanRequest.cs
+++ b/src/Core/BusinessObjects/TreatmentPlans/TreatmentPlanRequest.cs
@@ -1,0 +1,13 @@
+namespace Neurocorp.Api.Core.BusinessObjects.TreatmentPlans;
+
+public class TreatmentPlanRequest
+{
+    public int PatientId { get; set; }
+    public int DiscoverySessionId { get; set; }
+    public int CreatedByTherapistId { get; set; }
+    public string? ResultsDocumentUrl { get; set; }
+    public int WeeklyFrequency { get; set; } = 1;
+    public int DurationWeeks { get; set; } = 4;
+    public string? Notes { get; set; }
+    public List<TreatmentPlanLineRequest> Lines { get; set; } = [];
+}

--- a/src/Core/Configurations/Dependencies.cs
+++ b/src/Core/Configurations/Dependencies.cs
@@ -23,6 +23,7 @@ public static class NeurocorpConfigurationExtensions
         services.AddScoped<IBookingService, BookingService>();
         services.AddScoped<ISiteProfileService, SiteProfileService>();
         services.AddScoped<ILookupService, LookupService>();
+        services.AddScoped<ITreatmentPlanService, TreatmentPlanService>();
         return services;
     }
 }

--- a/src/Core/Interfaces/Repositories/ITherapySessionRepository.cs
+++ b/src/Core/Interfaces/Repositories/ITherapySessionRepository.cs
@@ -6,4 +6,6 @@ public interface ITherapySessionRepository : IRepository<TherapySession>
 {
     Task<IReadOnlyList<TherapySession>> GetUnpaidByPatientIdsAsync(IEnumerable<int> patientIds);
     Task<IReadOnlyList<TherapySession>> GetByPatientIdsAndDateRangeAsync(IEnumerable<int> patientIds, DateOnly from, DateOnly to);
+    Task<bool> HasCompletedDiscoveryAsync(int patientId);
+    Task<TherapySession?> GetByIdWithSpecialtyAsync(int id);
 }

--- a/src/Core/Interfaces/Repositories/ITreatmentPlanRepository.cs
+++ b/src/Core/Interfaces/Repositories/ITreatmentPlanRepository.cs
@@ -1,0 +1,9 @@
+using Neurocorp.Api.Core.Entities;
+
+namespace Neurocorp.Api.Core.Interfaces.Repositories;
+
+public interface ITreatmentPlanRepository : IRepository<TreatmentPlan>
+{
+    Task<TreatmentPlan?> GetByIdWithLinesAsync(int id);
+    Task<IReadOnlyList<TreatmentPlan>> GetByPatientIdAsync(int patientId);
+}

--- a/src/Core/Interfaces/Services/ITreatmentPlanService.cs
+++ b/src/Core/Interfaces/Services/ITreatmentPlanService.cs
@@ -1,0 +1,14 @@
+using Neurocorp.Api.Core.BusinessObjects.TreatmentPlans;
+
+namespace Neurocorp.Api.Core.Interfaces.Services;
+
+public interface ITreatmentPlanService
+{
+    Task<TreatmentPlanProfile> CreateAsync(TreatmentPlanRequest request);
+    Task<TreatmentPlanProfile?> GetByIdAsync(int id);
+    Task<IReadOnlyList<TreatmentPlanProfile>> GetByPatientIdAsync(int patientId);
+    Task<TreatmentPlanProfile> UpdateAsync(int id, TreatmentPlanRequest request);
+    Task<TreatmentPlanProfile> ActivateAsync(int id);
+    Task<TreatmentPlanProfile> CompleteAsync(int id);
+    Task<TreatmentPlanProfile> CancelAsync(int id);
+}

--- a/src/Core/Services/SessionEventHandler.cs
+++ b/src/Core/Services/SessionEventHandler.cs
@@ -130,6 +130,16 @@ public class SessionEventHandler : IHandleSessionEvent
         _logger.LogInformation("Started creating a new therapy session from request.");
         var (pProfile, tProfile) = await FetchTargetPartiesAsync(request);
         var specialty = await ResolveSpecialtyAsync(request);
+
+        // Discovery-first enforcement: treatment specialties require a completed discovery session
+        if (specialty != null && !specialty.IsDiscovery)
+        {
+            var hasDiscovery = await _therapySessionRepository.HasCompletedDiscoveryAsync(request.PatientId);
+            if (!hasDiscovery)
+                throw new ArgumentException(
+                    "Patient requires a completed discovery session before treatment sessions can be scheduled.");
+        }
+
         var newTherapySession = await _therapySessionRepository.AddAsync(MapToNewSessionEvent(pProfile!, tProfile!, request, specialty));
         _logger.LogInformation($"New TherapySession was created TSid:[{newTherapySession.Id}]");
         var confirmedStatuses = new HashSet<int> { 2, 4, 6, 7 };

--- a/src/Core/Services/TreatmentPlanService.cs
+++ b/src/Core/Services/TreatmentPlanService.cs
@@ -1,0 +1,223 @@
+using Microsoft.Extensions.Logging;
+using Neurocorp.Api.Core.BusinessObjects.TreatmentPlans;
+using Neurocorp.Api.Core.Entities;
+using Neurocorp.Api.Core.Interfaces.Repositories;
+using Neurocorp.Api.Core.Interfaces.Services;
+
+namespace Neurocorp.Api.Core.Services;
+
+public class TreatmentPlanService : ITreatmentPlanService
+{
+    private readonly ILogger<TreatmentPlanService> _logger;
+    private readonly ITreatmentPlanRepository _planRepository;
+    private readonly ITherapySessionRepository _sessionRepository;
+    private readonly IRepository<SpecialtyType> _specialtyTypeRepository;
+
+    public TreatmentPlanService(
+        ILogger<TreatmentPlanService> logger,
+        ITreatmentPlanRepository planRepository,
+        ITherapySessionRepository sessionRepository,
+        IRepository<SpecialtyType> specialtyTypeRepository)
+    {
+        _logger = logger;
+        _planRepository = planRepository;
+        _sessionRepository = sessionRepository;
+        _specialtyTypeRepository = specialtyTypeRepository;
+    }
+
+    public async Task<TreatmentPlanProfile> CreateAsync(TreatmentPlanRequest request)
+    {
+        _logger.LogInformation("Creating treatment plan for PatientId:{PatientId}", request.PatientId);
+
+        // Validate discovery session
+        var discoverySession = await _sessionRepository.GetByIdWithSpecialtyAsync(request.DiscoverySessionId);
+        if (discoverySession is null)
+            throw new ArgumentException($"Discovery session {request.DiscoverySessionId} not found.");
+        if (discoverySession.PatientId != request.PatientId)
+            throw new ArgumentException("Discovery session does not belong to the specified patient.");
+        if (discoverySession.SpecialtyType is null || !discoverySession.SpecialtyType.IsDiscovery)
+            throw new ArgumentException("The referenced session is not a discovery session.");
+        if (discoverySession.AppointmentStatusId != 4)
+            throw new ArgumentException("Discovery session must be completed before creating a treatment plan.");
+
+        // Validate lines
+        if (request.Lines.Count == 0)
+            throw new ArgumentException("Treatment plan must have at least one line.");
+
+        var allSpecialties = await _specialtyTypeRepository.GetAllAsync();
+        var specialtyMap = allSpecialties.ToDictionary(s => s.Id);
+
+        foreach (var line in request.Lines)
+        {
+            if (!specialtyMap.TryGetValue(line.SpecialtyTypeId, out var specialty))
+                throw new ArgumentException($"Specialty type {line.SpecialtyTypeId} not found.");
+            if (specialty.IsDiscovery)
+                throw new ArgumentException($"Treatment plan lines must use treatment specialties, not discovery type '{specialty.Abbreviation}'.");
+        }
+
+        // Map to entity
+        var plan = new TreatmentPlan
+        {
+            PatientId = request.PatientId,
+            DiscoverySessionId = request.DiscoverySessionId,
+            CreatedByTherapistId = request.CreatedByTherapistId,
+            PlanStatus = "Draft",
+            ResultsDocumentUrl = request.ResultsDocumentUrl,
+            WeeklyFrequency = request.WeeklyFrequency,
+            DurationWeeks = request.DurationWeeks,
+            Notes = request.Notes,
+            Lines = request.Lines.Select((l, i) => new TreatmentPlanLine
+            {
+                SpecialtyTypeId = l.SpecialtyTypeId,
+                PreferredTherapistId = l.PreferredTherapistId,
+                DayOfWeek = l.DayOfWeek,
+                PreferredTime = l.PreferredTime,
+                Duration = l.Duration,
+                SortOrder = l.SortOrder > 0 ? l.SortOrder : (byte)i,
+            }).ToList()
+        };
+
+        var saved = await _planRepository.AddAsync(plan);
+        _logger.LogInformation("Treatment plan {PlanId} created for PatientId:{PatientId}", saved.Id, request.PatientId);
+
+        // Reload with navigations
+        var loaded = await _planRepository.GetByIdWithLinesAsync(saved.Id);
+        return MapToProfile(loaded!);
+    }
+
+    public async Task<TreatmentPlanProfile?> GetByIdAsync(int id)
+    {
+        var plan = await _planRepository.GetByIdWithLinesAsync(id);
+        return plan is null ? null : MapToProfile(plan);
+    }
+
+    public async Task<IReadOnlyList<TreatmentPlanProfile>> GetByPatientIdAsync(int patientId)
+    {
+        var plans = await _planRepository.GetByPatientIdAsync(patientId);
+        return plans.Select(MapToProfile).ToList();
+    }
+
+    public async Task<TreatmentPlanProfile> UpdateAsync(int id, TreatmentPlanRequest request)
+    {
+        var plan = await _planRepository.GetByIdWithLinesAsync(id)
+            ?? throw new ArgumentException($"Treatment plan {id} not found.");
+
+        if (plan.PlanStatus != "Draft")
+            throw new ArgumentException("Only draft treatment plans can be edited.");
+
+        // Validate lines (same as create)
+        if (request.Lines.Count == 0)
+            throw new ArgumentException("Treatment plan must have at least one line.");
+
+        var allSpecialties = await _specialtyTypeRepository.GetAllAsync();
+        var specialtyMap = allSpecialties.ToDictionary(s => s.Id);
+        foreach (var line in request.Lines)
+        {
+            if (!specialtyMap.TryGetValue(line.SpecialtyTypeId, out var specialty))
+                throw new ArgumentException($"Specialty type {line.SpecialtyTypeId} not found.");
+            if (specialty.IsDiscovery)
+                throw new ArgumentException($"Treatment plan lines must use treatment specialties, not discovery type '{specialty.Abbreviation}'.");
+        }
+
+        // Update scalar fields
+        plan.ResultsDocumentUrl = request.ResultsDocumentUrl;
+        plan.WeeklyFrequency = request.WeeklyFrequency;
+        plan.DurationWeeks = request.DurationWeeks;
+        plan.Notes = request.Notes;
+
+        // Replace lines
+        plan.Lines.Clear();
+        foreach (var (line, i) in request.Lines.Select((l, i) => (l, i)))
+        {
+            plan.Lines.Add(new TreatmentPlanLine
+            {
+                TreatmentPlanId = id,
+                SpecialtyTypeId = line.SpecialtyTypeId,
+                PreferredTherapistId = line.PreferredTherapistId,
+                DayOfWeek = line.DayOfWeek,
+                PreferredTime = line.PreferredTime,
+                Duration = line.Duration,
+                SortOrder = line.SortOrder > 0 ? line.SortOrder : (byte)i,
+            });
+        }
+
+        await _planRepository.UpdateAsync(plan);
+        var loaded = await _planRepository.GetByIdWithLinesAsync(id);
+        return MapToProfile(loaded!);
+    }
+
+    public async Task<TreatmentPlanProfile> ActivateAsync(int id)
+    {
+        var plan = await _planRepository.GetByIdWithLinesAsync(id)
+            ?? throw new ArgumentException($"Treatment plan {id} not found.");
+        if (plan.PlanStatus != "Draft")
+            throw new ArgumentException($"Cannot activate a plan with status '{plan.PlanStatus}'. Only Draft plans can be activated.");
+        plan.PlanStatus = "Active";
+        await _planRepository.UpdateAsync(plan);
+        return MapToProfile(plan);
+    }
+
+    public async Task<TreatmentPlanProfile> CompleteAsync(int id)
+    {
+        var plan = await _planRepository.GetByIdWithLinesAsync(id)
+            ?? throw new ArgumentException($"Treatment plan {id} not found.");
+        if (plan.PlanStatus != "Active")
+            throw new ArgumentException($"Cannot complete a plan with status '{plan.PlanStatus}'. Only Active plans can be completed.");
+        plan.PlanStatus = "Completed";
+        await _planRepository.UpdateAsync(plan);
+        return MapToProfile(plan);
+    }
+
+    public async Task<TreatmentPlanProfile> CancelAsync(int id)
+    {
+        var plan = await _planRepository.GetByIdWithLinesAsync(id)
+            ?? throw new ArgumentException($"Treatment plan {id} not found.");
+        if (plan.PlanStatus == "Cancelled")
+            throw new ArgumentException("Plan is already cancelled.");
+        plan.PlanStatus = "Cancelled";
+        await _planRepository.UpdateAsync(plan);
+        return MapToProfile(plan);
+    }
+
+    private static TreatmentPlanProfile MapToProfile(TreatmentPlan plan)
+    {
+        return new TreatmentPlanProfile
+        {
+            Id = plan.Id,
+            PatientId = plan.PatientId,
+            PatientName = plan.Patient?.User != null
+                ? $"{plan.Patient.User.FirstName} {plan.Patient.User.LastName}".Trim()
+                : string.Empty,
+            DiscoverySessionId = plan.DiscoverySessionId,
+            DiscoveryDate = plan.DiscoverySession?.SessionDate ?? default,
+            DiscoverySpecialty = plan.DiscoverySession?.SpecialtyType?.Abbreviation ?? string.Empty,
+            CreatedByTherapistId = plan.CreatedByTherapistId,
+            CreatedByTherapistName = plan.CreatedByTherapist?.User != null
+                ? $"{plan.CreatedByTherapist.User.FirstName} {plan.CreatedByTherapist.User.LastName}".Trim()
+                : string.Empty,
+            PlanStatus = plan.PlanStatus,
+            ResultsDocumentUrl = plan.ResultsDocumentUrl,
+            WeeklyFrequency = plan.WeeklyFrequency,
+            DurationWeeks = plan.DurationWeeks,
+            Notes = plan.Notes,
+            CreatedTimestamp = plan.CreatedTimestamp,
+            LastUpdatedTimestamp = plan.LastUpdatedTimestamp,
+            Lines = plan.Lines.OrderBy(l => l.SortOrder).Select(l => new TreatmentPlanLineProfile
+            {
+                Id = l.Id,
+                TreatmentPlanId = l.TreatmentPlanId,
+                SpecialtyTypeId = l.SpecialtyTypeId,
+                SpecialtyAbbreviation = l.SpecialtyType?.Abbreviation ?? string.Empty,
+                SpecialtyName = l.SpecialtyType?.Name ?? string.Empty,
+                PreferredTherapistId = l.PreferredTherapistId,
+                PreferredTherapistName = l.PreferredTherapist?.User != null
+                    ? $"{l.PreferredTherapist.User.FirstName} {l.PreferredTherapist.User.LastName}".Trim()
+                    : null,
+                DayOfWeek = l.DayOfWeek,
+                PreferredTime = l.PreferredTime,
+                Duration = l.Duration,
+                SortOrder = l.SortOrder,
+            }).ToList()
+        };
+    }
+}

--- a/src/Infrastructure/Configurations/Dependencies.cs
+++ b/src/Infrastructure/Configurations/Dependencies.cs
@@ -59,6 +59,7 @@ public static class NeurocorpConfigurationExtensions
         services.AddScoped<IBookingRepository, BookingRepository>();
         services.AddScoped<ISiteRepository, SiteRepository>();
         services.AddScoped<ITherapistSpecialtyRepository, TherapistSpecialtyRepository>();
+        services.AddScoped<ITreatmentPlanRepository, TreatmentPlanRepository>();
         return services;
     }
 }

--- a/src/Infrastructure/Repositories/TherapySessionRepository.cs
+++ b/src/Infrastructure/Repositories/TherapySessionRepository.cs
@@ -30,4 +30,21 @@ public class TherapySessionRepository(ApplicationDbContext dbContext) :
             .ThenBy(s => s.SessionTime)
             .ToListAsync();
     }
+
+    public async Task<bool> HasCompletedDiscoveryAsync(int patientId)
+    {
+        return await _dbContext.TherapySessions
+            .Include(s => s.SpecialtyType)
+            .AnyAsync(s => s.PatientId == patientId
+                && s.AppointmentStatusId == 4
+                && s.SpecialtyType != null
+                && s.SpecialtyType.IsDiscovery);
+    }
+
+    public async Task<TherapySession?> GetByIdWithSpecialtyAsync(int id)
+    {
+        return await _dbContext.TherapySessions
+            .Include(s => s.SpecialtyType)
+            .FirstOrDefaultAsync(s => s.Id == id);
+    }
 }

--- a/src/Infrastructure/Repositories/TreatmentPlanRepository.cs
+++ b/src/Infrastructure/Repositories/TreatmentPlanRepository.cs
@@ -1,0 +1,34 @@
+using Microsoft.EntityFrameworkCore;
+using Neurocorp.Api.Core.Entities;
+using Neurocorp.Api.Core.Interfaces.Repositories;
+using Neurocorp.Api.Infrastructure.Data;
+
+namespace Neurocorp.Api.Infrastructure.Repositories;
+
+public class TreatmentPlanRepository(ApplicationDbContext dbContext) :
+    EfRepository<TreatmentPlan>(dbContext), ITreatmentPlanRepository
+{
+    public async Task<TreatmentPlan?> GetByIdWithLinesAsync(int id)
+    {
+        return await _dbContext.TreatmentPlans
+            .Include(tp => tp.Patient).ThenInclude(p => p!.User)
+            .Include(tp => tp.DiscoverySession).ThenInclude(ds => ds!.SpecialtyType)
+            .Include(tp => tp.CreatedByTherapist).ThenInclude(t => t!.User)
+            .Include(tp => tp.Lines).ThenInclude(l => l.SpecialtyType)
+            .Include(tp => tp.Lines).ThenInclude(l => l.PreferredTherapist).ThenInclude(t => t!.User)
+            .FirstOrDefaultAsync(tp => tp.Id == id);
+    }
+
+    public async Task<IReadOnlyList<TreatmentPlan>> GetByPatientIdAsync(int patientId)
+    {
+        return await _dbContext.TreatmentPlans
+            .Include(tp => tp.Patient).ThenInclude(p => p!.User)
+            .Include(tp => tp.DiscoverySession).ThenInclude(ds => ds!.SpecialtyType)
+            .Include(tp => tp.CreatedByTherapist).ThenInclude(t => t!.User)
+            .Include(tp => tp.Lines).ThenInclude(l => l.SpecialtyType)
+            .Include(tp => tp.Lines).ThenInclude(l => l.PreferredTherapist).ThenInclude(t => t!.User)
+            .Where(tp => tp.PatientId == patientId)
+            .OrderByDescending(tp => tp.CreatedTimestamp)
+            .ToListAsync();
+    }
+}

--- a/src/Web/Controllers/SessionsController.cs
+++ b/src/Web/Controllers/SessionsController.cs
@@ -49,8 +49,15 @@ public class SessionsController : ControllerBase
     [HttpPost]
     public async Task<IActionResult> CreateSession([FromBody] SessionEventRequest sessionRequest)
     {
-        var createdSession = await _sessionEventHandler.CreateAsync(sessionRequest);
-        return CreatedAtAction(nameof(CreateSession), new { id = createdSession.SessionId }, createdSession);
+        try
+        {
+            var createdSession = await _sessionEventHandler.CreateAsync(sessionRequest);
+            return CreatedAtAction(nameof(CreateSession), new { id = createdSession.SessionId }, createdSession);
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
     }
 
     [HttpPut("{id}")]

--- a/src/Web/Controllers/TreatmentPlansController.cs
+++ b/src/Web/Controllers/TreatmentPlansController.cs
@@ -1,0 +1,116 @@
+using Microsoft.AspNetCore.Mvc;
+using Neurocorp.Api.Core.BusinessObjects.TreatmentPlans;
+using Neurocorp.Api.Core.Interfaces.Services;
+
+namespace Neurocorp.Api.Web.Controllers;
+
+[ApiController]
+[Route("api/treatment-plans")]
+public class TreatmentPlansController : ControllerBase
+{
+    private readonly ILogger<TreatmentPlansController> _logger;
+    private readonly ITreatmentPlanService _service;
+
+    public TreatmentPlansController(ILogger<TreatmentPlansController> logger, ITreatmentPlanService service)
+    {
+        _logger = logger;
+        _service = service;
+    }
+
+    [HttpPost]
+    [ProducesResponseType(typeof(TreatmentPlanProfile), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> Create([FromBody] TreatmentPlanRequest request)
+    {
+        try
+        {
+            var result = await _service.CreateAsync(request);
+            return CreatedAtAction(nameof(GetById), new { id = result.Id }, result);
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+    }
+
+    [HttpGet("{id}")]
+    [ProducesResponseType(typeof(TreatmentPlanProfile), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetById(int id)
+    {
+        var result = await _service.GetByIdAsync(id);
+        return result is null ? NotFound() : Ok(result);
+    }
+
+    [HttpGet("patient/{patientId}")]
+    [ProducesResponseType(typeof(IReadOnlyList<TreatmentPlanProfile>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetByPatient(int patientId)
+    {
+        var results = await _service.GetByPatientIdAsync(patientId);
+        return Ok(results);
+    }
+
+    [HttpPut("{id}")]
+    [ProducesResponseType(typeof(TreatmentPlanProfile), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> Update(int id, [FromBody] TreatmentPlanRequest request)
+    {
+        try
+        {
+            var result = await _service.UpdateAsync(id, request);
+            return Ok(result);
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+    }
+
+    [HttpPut("{id}/activate")]
+    [ProducesResponseType(typeof(TreatmentPlanProfile), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> Activate(int id)
+    {
+        try
+        {
+            var result = await _service.ActivateAsync(id);
+            return Ok(result);
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+    }
+
+    [HttpPut("{id}/complete")]
+    [ProducesResponseType(typeof(TreatmentPlanProfile), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> Complete(int id)
+    {
+        try
+        {
+            var result = await _service.CompleteAsync(id);
+            return Ok(result);
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+    }
+
+    [HttpPut("{id}/cancel")]
+    [ProducesResponseType(typeof(TreatmentPlanProfile), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> Cancel(int id)
+    {
+        try
+        {
+            var result = await _service.CancelAsync(id);
+            return Ok(result);
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+    }
+}

--- a/tests/Core.Tests/SessionEventHandlerTests.cs
+++ b/tests/Core.Tests/SessionEventHandlerTests.cs
@@ -124,6 +124,9 @@ public class SessionEventHandlerTests
         _mockTherapySessionRepository
             .Setup(r => r.AddAsync(It.IsAny<TherapySession>()))
             .ReturnsAsync((TherapySession ts) => ts);
+        _mockTherapySessionRepository
+            .Setup(r => r.HasCompletedDiscoveryAsync(It.IsAny<int>()))
+            .ReturnsAsync(true);
     }
 
     [Fact]


### PR DESCRIPTION
Add TreatmentPlansController with 7 endpoints (create, get by id, get by patient, update draft, activate, complete, cancel). Enforce discovery-first rule in SessionEventHandler — patients must have a completed discovery session before treatment sessions can be booked.