### PR TITLE
WP-10C API: HasCompletedDiscovery, patient sessions endpoint, single …

### DIFF
--- a/src/Core/BusinessObjects/Patients/PatientProfile.cs
+++ b/src/Core/BusinessObjects/Patients/PatientProfile.cs
@@ -23,6 +23,7 @@ public class PatientProfile : IProfile
     public DateTime CreatedTimestamp { get; set; }
     public string Gender { get; set; }
     public bool IsActive { get; set; }
+    public bool? HasCompletedDiscovery { get; set; }
     public List<PatientCaretakerSummary> Caretakers { get; set; } = new();
 
     int IProfile.Id => this.PatientId;

--- a/src/Core/Interfaces/Repositories/ISessionEventRepository.cs
+++ b/src/Core/Interfaces/Repositories/ISessionEventRepository.cs
@@ -7,5 +7,6 @@ public interface ISessionEventRepository : IRepository<SessionEvent>
 {
     public Task<IReadOnlyList<SessionEvent>> GetAllByTargetDateAsync(DateOnly targetDate);
     public Task<IReadOnlyList<SessionEvent>> GetAllPastDueAsync();
+    public Task<IReadOnlyList<SessionEvent>> GetByPatientIdAsync(int patientId, bool? isDiscovery = null, string? status = null);
     public Task<SessionEvent> UpdateAsync(int therapySessionId, SessionEventUpdateRequest updateRequest);
 }

--- a/src/Core/Services/PatientProfileService.cs
+++ b/src/Core/Services/PatientProfileService.cs
@@ -16,6 +16,7 @@ public class PatientProfileService : IPatientProfileService
     private readonly IUserRepository _userRepo;
     private readonly IUserRoleRepository _userRoleRepo;
     private readonly IPatientCaretakerRepository _patientCaretakerRepo;
+    private readonly ITherapySessionRepository _therapySessionRepo;
     private readonly ILogger<PatientProfileService> _logger;
 
     public PatientProfileService(
@@ -24,13 +25,15 @@ public class PatientProfileService : IPatientProfileService
         IPatientRepository patientRepository,
         IUserRepository userRepo,
         IUserRoleRepository userRoleRepo,
-        IPatientCaretakerRepository patientCaretakerRepo)
+        IPatientCaretakerRepository patientCaretakerRepo,
+        ITherapySessionRepository therapySessionRepo)
     {
         _repository = patientProfileRepository;
         _patientRepo = patientRepository;
         _userRepo = userRepo;
         _userRoleRepo = userRoleRepo;
         _patientCaretakerRepo = patientCaretakerRepo;
+        _therapySessionRepo = therapySessionRepo;
         _logger = logger;
     }
 
@@ -43,7 +46,12 @@ public class PatientProfileService : IPatientProfileService
     public async Task<PatientProfile?> GetByIdAsync(int id)
     {
         _logger.LogInformation("Getting patient profile by ID: {Id}", id);
-        return await _repository.GetByIdAsync(id);
+        var profile = await _repository.GetByIdAsync(id);
+        if (profile != null)
+        {
+            profile.HasCompletedDiscovery = await _therapySessionRepo.HasCompletedDiscoveryAsync(profile.PatientId);
+        }
+        return profile;
     }
 
     public async Task<PatientProfile> CreateAsync(PatientProfile patient)

--- a/src/Core/Services/TreatmentPlanService.cs
+++ b/src/Core/Services/TreatmentPlanService.cs
@@ -152,6 +152,13 @@ public class TreatmentPlanService : ITreatmentPlanService
             ?? throw new ArgumentException($"Treatment plan {id} not found.");
         if (plan.PlanStatus != "Draft")
             throw new ArgumentException($"Cannot activate a plan with status '{plan.PlanStatus}'. Only Draft plans can be activated.");
+
+        // Check for existing active plan
+        var existingPlans = await _planRepository.GetByPatientIdAsync(plan.PatientId);
+        var activePlan = existingPlans.FirstOrDefault(p => p.PlanStatus == "Active" && p.Id != id);
+        if (activePlan != null)
+            throw new ArgumentException($"Patient already has an active treatment plan (Plan #{activePlan.Id}). Cancel or complete it before activating another.");
+
         plan.PlanStatus = "Active";
         await _planRepository.UpdateAsync(plan);
         return MapToProfile(plan);

--- a/src/Infrastructure/Repositories/SessionEventRepository.cs
+++ b/src/Infrastructure/Repositories/SessionEventRepository.cs
@@ -62,6 +62,32 @@ public class SessionEventRepository(ApplicationDbContext dbContext) :
         return result;
     }
 
+    public async Task<IReadOnlyList<SessionEvent>> GetByPatientIdAsync(int patientId, bool? isDiscovery = null, string? status = null)
+    {
+        var query = _dbContext.TherapySessions
+            .Where(ts => ts.PatientId == patientId &&
+                         ts.Patient != null &&
+                         ts.Therapist != null);
+
+        if (isDiscovery.HasValue)
+            query = query.Where(ts => ts.SpecialtyType != null && ts.SpecialtyType.IsDiscovery == isDiscovery.Value);
+
+        if (!string.IsNullOrEmpty(status))
+            query = query.Where(ts => ts.AppointmentStatus != null && ts.AppointmentStatus.Name == status);
+
+        var result = await query
+            .Include(ts => ts.Patient)
+                .ThenInclude(p => p!.User)
+            .Include(ts => ts.Therapist)
+                .ThenInclude(t => t!.User)
+            .Include(ts => ts.AppointmentStatus)
+            .Include(ts => ts.Site)
+            .Include(ts => ts.SpecialtyType)
+            .Select(ts => ExtractSessionEvent(ts))
+            .ToListAsync();
+        return result;
+    }
+
     public override async Task<SessionEvent?> GetByIdAsync(int id)
     {
         var result = await _dbContext.TherapySessions

--- a/src/Web/Controllers/PatientsController.cs
+++ b/src/Web/Controllers/PatientsController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using Neurocorp.Api.Core.BusinessObjects.Patients;
 using Neurocorp.Api.Core.Interfaces.Services;
 using Neurocorp.Api.Core.Interfaces;
+using Neurocorp.Api.Core.Interfaces.Repositories;
 using Neurocorp.Api.Core.BusinessObjects.Sessions;
 using Neurocorp.Api.Core.BusinessObjects.Common;
 
@@ -13,12 +14,18 @@ public class PatientsController : ControllerBase
 {
     private readonly IPatientProfileService _patientProfileService;
     private readonly IHandleSessionEvent _sessionEventHandler;
+    private readonly ISessionEventRepository _sessionEventRepository;
     private readonly ILogger<PatientsController> _logger;
 
-    public PatientsController(ILogger<PatientsController> logger, IPatientProfileService patientProfileService, IHandleSessionEvent sessionEventHandler)
+    public PatientsController(
+        ILogger<PatientsController> logger,
+        IPatientProfileService patientProfileService,
+        IHandleSessionEvent sessionEventHandler,
+        ISessionEventRepository sessionEventRepository)
     {
         _patientProfileService = patientProfileService;
         _sessionEventHandler = sessionEventHandler;
+        _sessionEventRepository = sessionEventRepository;
         _logger = logger;
     }
 
@@ -72,6 +79,17 @@ public class PatientsController : ControllerBase
     {
         var caretakers = await _patientProfileService.GetCaretakersForPatientAsync(id);
         return Ok(caretakers);
+    }
+
+    [HttpGet("{patientId}/sessions")]
+    [ProducesResponseType(typeof(IEnumerable<SessionEvent>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetPatientSessions(
+        int patientId,
+        [FromQuery] bool? isDiscovery = null,
+        [FromQuery] string? status = null)
+    {
+        var sessions = await _sessionEventRepository.GetByPatientIdAsync(patientId, isDiscovery, status);
+        return Ok(sessions);
     }
 
     [HttpPost]

--- a/tests/Core.Tests/PatientProfileServiceTests.cs
+++ b/tests/Core.Tests/PatientProfileServiceTests.cs
@@ -9,6 +9,8 @@ namespace Core.Tests;
 
 public class PatientProfileServiceTests
 {
+    private static ITherapySessionRepository FakeTherapySessionRepo() => Mock.Of<ITherapySessionRepository>();
+
     [Fact]
     public void GoodConstructorTest()
     {
@@ -21,7 +23,7 @@ public class PatientProfileServiceTests
 
         // act
         var fakePatientCaretakerRepo = Mock.Of<IPatientCaretakerRepository>();
-        var svc = new PatientProfileService(fakeLogger, fakeRepo, fakePatientRepo, fakeUserRepo, fakeUserRoleRepo, fakePatientCaretakerRepo);
+        var svc = new PatientProfileService(fakeLogger, fakeRepo, fakePatientRepo, fakeUserRepo, fakeUserRoleRepo, fakePatientCaretakerRepo, FakeTherapySessionRepo());
 
         // assert
         Assert.IsType<PatientProfileService>(svc);
@@ -40,7 +42,7 @@ public class PatientProfileServiceTests
         var _mockRepository = new Mock<IPatientProfileRepository>(MockBehavior.Strict);
         _mockRepository.Setup(repo => repo.GetByIdAsync(testId)).ReturnsAsync(expectedPatient);
         var fakePatientCaretakerRepo = Mock.Of<IPatientCaretakerRepository>();
-        var svc = new PatientProfileService(fakeLogger, _mockRepository.Object, fakePatientRepo, fakeUserRepo, fakeUserRoleRepo, fakePatientCaretakerRepo);
+        var svc = new PatientProfileService(fakeLogger, _mockRepository.Object, fakePatientRepo, fakeUserRepo, fakeUserRoleRepo, fakePatientCaretakerRepo, FakeTherapySessionRepo());
 
         // Act
         var result = await svc.GetByIdAsync(testId);
@@ -64,7 +66,7 @@ public class PatientProfileServiceTests
         var _mockRepository = new Mock<IPatientProfileRepository>(MockBehavior.Strict);
         _mockRepository.Setup(repo => repo.GetByIdAsync(testId)).ReturnsAsync((PatientProfile?)null);
         var fakePatientCaretakerRepo = Mock.Of<IPatientCaretakerRepository>();
-        var svc = new PatientProfileService(fakeLogger, _mockRepository.Object, fakePatientRepo, fakeUserRepo, fakeUserRoleRepo, fakePatientCaretakerRepo);
+        var svc = new PatientProfileService(fakeLogger, _mockRepository.Object, fakePatientRepo, fakeUserRepo, fakeUserRoleRepo, fakePatientCaretakerRepo, FakeTherapySessionRepo());
 
         // Act
         var result = await svc.GetByIdAsync(testId);
@@ -84,7 +86,7 @@ public class PatientProfileServiceTests
         var fakeLogger = Mock.Of<ILogger<PatientProfileService>>(); 
 
         var fakePatientCaretakerRepo = Mock.Of<IPatientCaretakerRepository>();
-        var svc = new PatientProfileService(fakeLogger, fakeRepo, fakePatientRepo, fakeUserRepo, fakeUserRoleRepo, fakePatientCaretakerRepo);
+        var svc = new PatientProfileService(fakeLogger, fakeRepo, fakePatientRepo, fakeUserRepo, fakeUserRoleRepo, fakePatientCaretakerRepo, FakeTherapySessionRepo());
 
         // Act & Assert
         await Assert.ThrowsAsync<NotImplementedException>(() => 
@@ -104,7 +106,7 @@ public class PatientProfileServiceTests
         _mockRepository.Setup(repo => repo.GetAllAsync())
             .ReturnsAsync([]);
         var fakePatientCaretakerRepo = Mock.Of<IPatientCaretakerRepository>();
-        var svc = new PatientProfileService(fakeLogger, _mockRepository.Object, fakePatientRepo, fakeUserRepo, fakeUserRoleRepo, fakePatientCaretakerRepo);
+        var svc = new PatientProfileService(fakeLogger, _mockRepository.Object, fakePatientRepo, fakeUserRepo, fakeUserRoleRepo, fakePatientCaretakerRepo, FakeTherapySessionRepo());
 
         // Act
         var result = await svc.GetAllAsync();
@@ -134,7 +136,7 @@ public class PatientProfileServiceTests
         mockUserRoleRepo.Setup(r => r.AddAsync(It.IsAny<UserRole>())).ReturnsAsync(new UserRole { UserRoleId = 1 });
 
         var fakePatientCaretakerRepo = Mock.Of<IPatientCaretakerRepository>();
-        var svc = new PatientProfileService(fakeLogger, mockProfileRepo, mockPatientRepo.Object, mockUserRepo.Object, mockUserRoleRepo.Object, fakePatientCaretakerRepo);
+        var svc = new PatientProfileService(fakeLogger, mockProfileRepo, mockPatientRepo.Object, mockUserRepo.Object, mockUserRoleRepo.Object, fakePatientCaretakerRepo, FakeTherapySessionRepo());
         var request = new PatientProfileRequest { FirstName = "Jane", LastName = "Doe", Email = "j@d.com", PhoneNumber = "555", Gender = "F", DateOfBirth = DateTime.Today, MedicalRecordNumber = "" };
 
         // Act
@@ -165,7 +167,7 @@ public class PatientProfileServiceTests
         mockUserRoleRepo.Setup(r => r.AddAsync(It.IsAny<UserRole>())).ReturnsAsync(new UserRole { UserRoleId = 1 });
 
         var fakePatientCaretakerRepo = Mock.Of<IPatientCaretakerRepository>();
-        var svc = new PatientProfileService(fakeLogger, mockProfileRepo, mockPatientRepo.Object, mockUserRepo.Object, mockUserRoleRepo.Object, fakePatientCaretakerRepo);
+        var svc = new PatientProfileService(fakeLogger, mockProfileRepo, mockPatientRepo.Object, mockUserRepo.Object, mockUserRoleRepo.Object, fakePatientCaretakerRepo, FakeTherapySessionRepo());
         var request = new PatientProfileRequest { FirstName = "Jane", LastName = "Doe", Email = "j@d.com", PhoneNumber = "555", Gender = "F", DateOfBirth = DateTime.Today, MedicalRecordNumber = "MRN-001" };
 
         // Act
@@ -191,7 +193,7 @@ public class PatientProfileServiceTests
         mockProfileRepo.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(profileOnFile);
 
         var fakePatientCaretakerRepo = Mock.Of<IPatientCaretakerRepository>();
-        var svc = new PatientProfileService(fakeLogger, mockProfileRepo.Object, fakePatientRepo, fakeUserRepo, fakeUserRoleRepo, fakePatientCaretakerRepo);
+        var svc = new PatientProfileService(fakeLogger, mockProfileRepo.Object, fakePatientRepo, fakeUserRepo, fakeUserRoleRepo, fakePatientCaretakerRepo, FakeTherapySessionRepo());
         var updateRequest = new PatientProfileUpdateRequest { ActiveStatus = true };
 
         // Act & Assert
@@ -213,7 +215,7 @@ public class PatientProfileServiceTests
         mockProfileRepo.Setup(r => r.UpdateAsync(1, 10, It.IsAny<PatientProfileUpdateRequest>())).ReturnsAsync(profileOnFile);
 
         var fakePatientCaretakerRepo = Mock.Of<IPatientCaretakerRepository>();
-        var svc = new PatientProfileService(fakeLogger, mockProfileRepo.Object, fakePatientRepo, fakeUserRepo, fakeUserRoleRepo, fakePatientCaretakerRepo);
+        var svc = new PatientProfileService(fakeLogger, mockProfileRepo.Object, fakePatientRepo, fakeUserRepo, fakeUserRoleRepo, fakePatientCaretakerRepo, FakeTherapySessionRepo());
         var updateRequest = new PatientProfileUpdateRequest { ActiveStatus = true };
 
         // Act
@@ -238,7 +240,7 @@ public class PatientProfileServiceTests
         mockProfileRepo.Setup(r => r.UpdateAsync(1, 10, It.IsAny<PatientProfileUpdateRequest>())).ReturnsAsync(profileOnFile);
 
         var fakePatientCaretakerRepo = Mock.Of<IPatientCaretakerRepository>();
-        var svc = new PatientProfileService(fakeLogger, mockProfileRepo.Object, fakePatientRepo, fakeUserRepo, fakeUserRoleRepo, fakePatientCaretakerRepo);
+        var svc = new PatientProfileService(fakeLogger, mockProfileRepo.Object, fakePatientRepo, fakeUserRepo, fakeUserRoleRepo, fakePatientCaretakerRepo, FakeTherapySessionRepo());
         var updateRequest = new PatientProfileUpdateRequest { ActiveStatus = false };
 
         // Act

--- a/tests/Web.Tests/PatientsControllerTests.cs
+++ b/tests/Web.Tests/PatientsControllerTests.cs
@@ -7,6 +7,7 @@ using Neurocorp.Api.Web.Controllers;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Neurocorp.Api.Core.BusinessObjects.Sessions;
+using Neurocorp.Api.Core.Interfaces.Repositories;
 using FluentAssertions;
 using System.Linq;
 using Castle.Core.Logging;
@@ -18,6 +19,7 @@ public class PatientsControllerTests
 {
     private readonly Mock<IPatientProfileService> _mockPatientProfileService;
     private readonly Mock<IHandleSessionEvent> _mockSessionEventHandler;
+    private readonly Mock<ISessionEventRepository> _mockSessionEventRepository;
     private readonly PatientsController _controller;
 
     public PatientsControllerTests()
@@ -25,7 +27,8 @@ public class PatientsControllerTests
         var fakeLogger = Mock.Of<ILogger<PatientsController>>();
         _mockPatientProfileService = new Mock<IPatientProfileService>();
         _mockSessionEventHandler = new Mock<IHandleSessionEvent>();
-        _controller = new PatientsController(fakeLogger, _mockPatientProfileService.Object, _mockSessionEventHandler.Object);
+        _mockSessionEventRepository = new Mock<ISessionEventRepository>();
+        _controller = new PatientsController(fakeLogger, _mockPatientProfileService.Object, _mockSessionEventHandler.Object, _mockSessionEventRepository.Object);
     }
 
     [Fact]


### PR DESCRIPTION
…active plan

Add HasCompletedDiscovery to PatientProfile (computed on detail, null on list). Add GET /api/patients/{patientId}/sessions with optional isDiscovery and status filters. Enforce single active treatment plan per patient in TreatmentPlanService.ActivateAsync.