### PR TITLE
WP-10D-B: ProviderAmount in sessions, discovery endpoint, activation …

### DIFF
--- a/src/Core/BusinessObjects/Sessions/DiscoverySessionSummary.cs
+++ b/src/Core/BusinessObjects/Sessions/DiscoverySessionSummary.cs
@@ -1,0 +1,9 @@
+namespace Neurocorp.Api.Core.BusinessObjects.Sessions;
+
+public class DiscoverySessionSummary
+{
+    public int SessionId { get; set; }
+    public DateOnly SessionDate { get; set; }
+    public string SpecialtyAbbreviation { get; set; } = string.Empty;
+    public string TherapistName { get; set; } = string.Empty;
+}

--- a/src/Core/BusinessObjects/Sessions/SessionEvent.cs
+++ b/src/Core/BusinessObjects/Sessions/SessionEvent.cs
@@ -33,4 +33,5 @@ public class SessionEvent
     public string? SpecialtyAbbreviation { get; set; }
     public string? SpecialtyName { get; set; }
     public bool? IsDiscovery { get; set; }
+    public decimal ProviderAmount { get; set; }
 }

--- a/src/Core/Interfaces/Repositories/ITherapySessionRepository.cs
+++ b/src/Core/Interfaces/Repositories/ITherapySessionRepository.cs
@@ -8,4 +8,5 @@ public interface ITherapySessionRepository : IRepository<TherapySession>
     Task<IReadOnlyList<TherapySession>> GetByPatientIdsAndDateRangeAsync(IEnumerable<int> patientIds, DateOnly from, DateOnly to);
     Task<bool> HasCompletedDiscoveryAsync(int patientId);
     Task<TherapySession?> GetByIdWithSpecialtyAsync(int id);
+    Task<IReadOnlyList<TherapySession>> GetCompletedDiscoverySessionsAsync(int patientId);
 }

--- a/src/Core/Interfaces/Services/IHandleSessionEvent.cs
+++ b/src/Core/Interfaces/Services/IHandleSessionEvent.cs
@@ -11,4 +11,5 @@ public interface IHandleSessionEvent : IService<SessionEvent>
     public Task<SessionEvent> CreateAsync(SessionEventRequest request);
     public Task<bool> UpdateAsync(int SessionEventId, SessionEventUpdateRequest request);
     public Task<bool> VerifyRequestAsync(int sessionAggId, SessionEventUpdateRequest request);
+    public Task<IEnumerable<DiscoverySessionSummary>> GetCompletedDiscoverySessionsAsync(int patientId);
 }

--- a/src/Core/Services/SessionEventHandler.cs
+++ b/src/Core/Services/SessionEventHandler.cs
@@ -257,6 +257,18 @@ public class SessionEventHandler : IHandleSessionEvent
         return null;
     }
 
+    public async Task<IEnumerable<DiscoverySessionSummary>> GetCompletedDiscoverySessionsAsync(int patientId)
+    {
+        var sessions = await _therapySessionRepository.GetCompletedDiscoverySessionsAsync(patientId);
+        return sessions.Select(s => new DiscoverySessionSummary
+        {
+            SessionId = s.Id,
+            SessionDate = s.SessionDate,
+            SpecialtyAbbreviation = s.SpecialtyType?.Abbreviation ?? "N/A",
+            TherapistName = s.Therapist?.User?.GetFullName() ?? "Unknown",
+        });
+    }
+
     private async Task<(PatientProfile?, TherapistProfile?)> FetchTargetPartiesAsync(SessionEventRequest request)
     {
         return await FetchTargetPartiesAsync(request.PatientId, request.TherapistId);

--- a/src/Core/Services/TreatmentPlanService.cs
+++ b/src/Core/Services/TreatmentPlanService.cs
@@ -153,6 +153,11 @@ public class TreatmentPlanService : ITreatmentPlanService
         if (plan.PlanStatus != "Draft")
             throw new ArgumentException($"Cannot activate a plan with status '{plan.PlanStatus}'. Only Draft plans can be activated.");
 
+        // Line count must match weekly frequency
+        var lineCount = plan.Lines.Count;
+        if (lineCount != plan.WeeklyFrequency)
+            throw new ArgumentException($"Cannot activate: line count ({lineCount}) does not match sessions per week ({plan.WeeklyFrequency}). Adjust the plan lines or weekly frequency first.");
+
         // Check for existing active plan
         var existingPlans = await _planRepository.GetByPatientIdAsync(plan.PatientId);
         var activePlan = existingPlans.FirstOrDefault(p => p.PlanStatus == "Active" && p.Id != id);

--- a/src/Infrastructure/Repositories/SessionEventRepository.cs
+++ b/src/Infrastructure/Repositories/SessionEventRepository.cs
@@ -188,6 +188,7 @@ public class SessionEventRepository(ApplicationDbContext dbContext) :
             SpecialtyAbbreviation = ts.SpecialtyType?.Abbreviation,
             SpecialtyName = ts.SpecialtyType?.Name,
             IsDiscovery = ts.SpecialtyType?.IsDiscovery,
+            ProviderAmount = ts.ProviderAmount,
         };
     }
 }

--- a/src/Infrastructure/Repositories/TherapySessionRepository.cs
+++ b/src/Infrastructure/Repositories/TherapySessionRepository.cs
@@ -47,4 +47,18 @@ public class TherapySessionRepository(ApplicationDbContext dbContext) :
             .Include(s => s.SpecialtyType)
             .FirstOrDefaultAsync(s => s.Id == id);
     }
+
+    public async Task<IReadOnlyList<TherapySession>> GetCompletedDiscoverySessionsAsync(int patientId)
+    {
+        return await _dbContext.TherapySessions
+            .Include(s => s.SpecialtyType)
+            .Include(s => s.Therapist).ThenInclude(t => t!.User)
+            .Where(s => s.PatientId == patientId
+                && s.AppointmentStatusId == 4
+                && s.SpecialtyType != null
+                && s.SpecialtyType.IsDiscovery)
+            .OrderByDescending(s => s.SessionDate)
+            .ThenByDescending(s => s.SessionTime)
+            .ToListAsync();
+    }
 }

--- a/src/Web/Controllers/SessionsController.cs
+++ b/src/Web/Controllers/SessionsController.cs
@@ -78,6 +78,14 @@ public class SessionsController : ControllerBase
         return BadRequest();
     }
 
+    [HttpGet("patient/{patientId}/discovery")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<DiscoverySessionSummary>))]
+    public async Task<IActionResult> GetCompletedDiscoverySessions(int patientId)
+    {
+        var sessions = await _sessionEventHandler.GetCompletedDiscoverySessionsAsync(patientId);
+        return Ok(sessions);
+    }
+
     [HttpGet("{id}/payments")]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<SessionPaymentDetail>))]
     public async Task<IActionResult> GetSessionPayments(int id)


### PR DESCRIPTION
…validation

Add ProviderAmount to SessionEvent DTO so the dashboard can display therapist commission. Expose GET /api/sessions/patient/{id}/discovery for completed discovery sessions (used by treatment plan form dropdown). Block plan activation when line count != weekly frequency.