### PR TITLE
Fix WP-11 bugs + UX enhancements from testing

### DIFF
--- a/src/Core/BusinessObjects/Sessions/SessionEventUpdateRequest.cs
+++ b/src/Core/BusinessObjects/Sessions/SessionEventUpdateRequest.cs
@@ -19,6 +19,7 @@ public class SessionEventUpdateRequest
     public bool IsPaidOff { get; set; } = false;
     public string Notes { get; set; }
     public int? AppointmentStatusId { get; set; }
+    public int? TherapistId { get; set; }
     public int? SiteId { get; set; }
     public int? SpecialtyTypeId { get; set; }
 }

--- a/src/Core/BusinessObjects/TreatmentPlans/TreatmentPlanProfile.cs
+++ b/src/Core/BusinessObjects/TreatmentPlans/TreatmentPlanProfile.cs
@@ -3,6 +3,7 @@ namespace Neurocorp.Api.Core.BusinessObjects.TreatmentPlans;
 public class TreatmentPlanProfile
 {
     public int Id { get; set; }
+    public string DisplayTitle { get; set; } = string.Empty;
     public int PatientId { get; set; }
     public string PatientName { get; set; } = string.Empty;
     public int DiscoverySessionId { get; set; }

--- a/src/Core/Services/BulkSchedulingService.cs
+++ b/src/Core/Services/BulkSchedulingService.cs
@@ -208,6 +208,19 @@ public class BulkSchedulingService : IBulkSchedulingService
             }
         }
 
+        // Only persist if there are zero conflicts (atomic: all-or-nothing)
+        if (result.Conflicts.Count > 0)
+        {
+            result.Sessions.Clear();
+            result.SessionsCreated = 0;
+
+            _logger.LogInformation(
+                "Bulk scheduling aborted for PlanId:{PlanId}: {Conflicts} conflicts found, no sessions created",
+                planId, result.Conflicts.Count);
+
+            return result;
+        }
+
         // Batch save
         if (sessionsToCreate.Count > 0)
         {

--- a/src/Core/Services/TreatmentPlanService.cs
+++ b/src/Core/Services/TreatmentPlanService.cs
@@ -191,11 +191,23 @@ public class TreatmentPlanService : ITreatmentPlanService
         return MapToProfile(plan);
     }
 
+    private static string BuildDisplayTitle(TreatmentPlan plan)
+    {
+        var lastName = plan.Patient?.User?.LastName ?? "?";
+        var firstInitial = plan.Patient?.User?.FirstName?.Length > 0
+            ? $"{plan.Patient.User.FirstName[0]}."
+            : "?";
+        var dateStr = plan.CreatedTimestamp.ToString("yyyy-MM-dd");
+        var freq = $"{plan.WeeklyFrequency}x/week";
+        return $"TP | {lastName}, {firstInitial} | {dateStr} | {freq}";
+    }
+
     private static TreatmentPlanProfile MapToProfile(TreatmentPlan plan)
     {
         return new TreatmentPlanProfile
         {
             Id = plan.Id,
+            DisplayTitle = BuildDisplayTitle(plan),
             PatientId = plan.PatientId,
             PatientName = plan.Patient?.User != null
                 ? $"{plan.Patient.User.FirstName} {plan.Patient.User.LastName}".Trim()

--- a/src/Infrastructure/Repositories/SessionEventRepository.cs
+++ b/src/Infrastructure/Repositories/SessionEventRepository.cs
@@ -142,6 +142,10 @@ public class SessionEventRepository(ApplicationDbContext dbContext) :
         {
             therapySessionToUpdate.AppointmentStatusId = updateRequest.AppointmentStatusId.Value;
         }
+        if (updateRequest.TherapistId.HasValue)
+        {
+            therapySessionToUpdate.TherapistId = updateRequest.TherapistId.Value;
+        }
         if (updateRequest.SiteId.HasValue)
         {
             therapySessionToUpdate.SiteId = updateRequest.SiteId.Value;

--- a/src/Web/Middleware/TimeOnlyJsonConverter.cs
+++ b/src/Web/Middleware/TimeOnlyJsonConverter.cs
@@ -1,0 +1,61 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Neurocorp.Api.Web.Middleware;
+
+public class TimeOnlyJsonConverterFactory : JsonConverterFactory
+{
+    private static readonly string[] Formats = ["HH:mm", "HH:mm:ss"];
+
+    public override bool CanConvert(Type typeToConvert) =>
+        typeToConvert == typeof(TimeOnly) || typeToConvert == typeof(TimeOnly?);
+
+    public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (typeToConvert == typeof(TimeOnly?))
+            return new NullableTimeOnlyConverter();
+        return new TimeOnlyConverter();
+    }
+
+    private class TimeOnlyConverter : JsonConverter<TimeOnly>
+    {
+        public override TimeOnly Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetString()
+                ?? throw new JsonException("Expected a string value for TimeOnly.");
+            return Parse(value);
+        }
+
+        public override void Write(Utf8JsonWriter writer, TimeOnly value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(value.ToString("HH:mm:ss"));
+        }
+    }
+
+    private class NullableTimeOnlyConverter : JsonConverter<TimeOnly?>
+    {
+        public override TimeOnly? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+                return null;
+            var value = reader.GetString()
+                ?? throw new JsonException("Expected a string value for TimeOnly.");
+            return Parse(value);
+        }
+
+        public override void Write(Utf8JsonWriter writer, TimeOnly? value, JsonSerializerOptions options)
+        {
+            if (value is null)
+                writer.WriteNullValue();
+            else
+                writer.WriteStringValue(value.Value.ToString("HH:mm:ss"));
+        }
+    }
+
+    private static TimeOnly Parse(string value)
+    {
+        if (TimeOnly.TryParseExact(value, Formats, null, System.Globalization.DateTimeStyles.None, out var result))
+            return result;
+        throw new JsonException($"Unable to parse '{value}' as TimeOnly. Expected format: HH:mm or HH:mm:ss.");
+    }
+}

--- a/src/Web/Startup.cs
+++ b/src/Web/Startup.cs
@@ -45,6 +45,10 @@ public class Startup(IConfiguration configuration)
         services.AddControllers(options =>
         {
             options.Filters.Add<DuplicateKeyExceptionFilter>();
+        })
+        .AddJsonOptions(options =>
+        {
+            options.JsonSerializerOptions.Converters.Add(new TimeOnlyJsonConverterFactory());
         });
 
         // Register the Swagger generator, defining one or more Swagger documents

--- a/tests/Core.Tests/BulkSchedulingServiceTests.cs
+++ b/tests/Core.Tests/BulkSchedulingServiceTests.cs
@@ -272,6 +272,41 @@ public class BulkSchedulingServiceTests
     }
 
     [Fact]
+    public async Task ScheduleAsync_ConflictDetection_DoesNotPersistAnySessions()
+    {
+        // Arrange: 2 weeks, but week 1 has a conflict — no sessions should be persisted at all
+        var plan = CreateActivePlan(weeks: 2, frequency: 1);
+        SetupCommonMocks(plan);
+        SetupTherapist(10, "Dr.", "Smith", feePct: 0.40m);
+        _mockSpecialtyRepo.Setup(r => r.GetTherapistIdsBySpecialtyAsync(5)).ReturnsAsync(new List<int> { 10 });
+
+        // Therapist 10 is booked on week 1 target date
+        _mockSessionRepo.Setup(r => r.GetByTherapistAndDateRangeAsync(10, It.IsAny<DateOnly>(), It.IsAny<DateOnly>()))
+            .ReturnsAsync(new List<TherapySession>
+            {
+                new()
+                {
+                    TherapistId = 10,
+                    SessionDate = new DateOnly(2026, 4, 13), // Week 1 Monday
+                    SessionTime = new TimeOnly(10, 0),
+                    Duration = 60,
+                    AppointmentStatusId = 2
+                }
+            });
+
+        var request = new BulkScheduleRequest { StartDate = new DateOnly(2026, 4, 13), SiteId = 1 };
+
+        // Act
+        var result = await _sut.ScheduleAsync(1, request);
+
+        // Assert: atomic — no sessions created, even though week 2 would be valid
+        Assert.Equal(0, result.SessionsCreated);
+        Assert.Empty(result.Sessions);
+        Assert.NotEmpty(result.Conflicts);
+        _mockSessionRepo.Verify(r => r.AddRangeAsync(It.IsAny<IEnumerable<TherapySession>>()), Times.Never);
+    }
+
+    [Fact]
     public async Task GetProgressAsync_ComputesCorrectSummary()
     {
         var plan = CreateActivePlan(weeks: 4, frequency: 1);

--- a/tests/Core.Tests/TreatmentPlanServiceTests.cs
+++ b/tests/Core.Tests/TreatmentPlanServiceTests.cs
@@ -1,0 +1,122 @@
+using Moq;
+using Microsoft.Extensions.Logging;
+using Neurocorp.Api.Core.Services;
+using Neurocorp.Api.Core.BusinessObjects.TreatmentPlans;
+using Neurocorp.Api.Core.Entities;
+using Neurocorp.Api.Core.Interfaces.Repositories;
+
+namespace Core.Tests;
+
+public class TreatmentPlanServiceTests
+{
+    private readonly Mock<ITreatmentPlanRepository> _mockPlanRepo;
+    private readonly Mock<ITherapySessionRepository> _mockSessionRepo;
+    private readonly Mock<IRepository<SpecialtyType>> _mockSpecialtyRepo;
+    private readonly TreatmentPlanService _sut;
+
+    public TreatmentPlanServiceTests()
+    {
+        var logger = Mock.Of<ILogger<TreatmentPlanService>>();
+        _mockPlanRepo = new Mock<ITreatmentPlanRepository>();
+        _mockSessionRepo = new Mock<ITherapySessionRepository>();
+        _mockSpecialtyRepo = new Mock<IRepository<SpecialtyType>>();
+        _sut = new TreatmentPlanService(logger, _mockPlanRepo.Object, _mockSessionRepo.Object, _mockSpecialtyRepo.Object);
+    }
+
+    private static TreatmentPlan CreatePlan(
+        int id = 1,
+        string firstName = "John",
+        string lastName = "Doe",
+        int weeklyFrequency = 2,
+        DateTime? created = null)
+    {
+        return new TreatmentPlan
+        {
+            Id = id,
+            PatientId = 10,
+            PlanStatus = "Active",
+            WeeklyFrequency = weeklyFrequency,
+            DurationWeeks = 8,
+            DiscoverySessionId = 100,
+            CreatedByTherapistId = 5,
+            CreatedTimestamp = created ?? new DateTime(2026, 4, 7, 14, 30, 0),
+            LastUpdatedTimestamp = created ?? new DateTime(2026, 4, 7, 14, 30, 0),
+            Patient = new Patient
+            {
+                Id = 10,
+                User = new User { FirstName = firstName, LastName = lastName }
+            },
+            DiscoverySession = new TherapySession
+            {
+                SessionDate = new DateOnly(2026, 4, 1),
+                SpecialtyType = new SpecialtyType { Abbreviation = "Eval-SP" }
+            },
+            CreatedByTherapist = new Therapist
+            {
+                Id = 5,
+                User = new User { FirstName = "Dr.", LastName = "Smith" }
+            },
+            Lines = []
+        };
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ReturnsDisplayTitle_WithCorrectFormat()
+    {
+        var plan = CreatePlan(id: 4, firstName: "John", lastName: "Doe", weeklyFrequency: 2,
+            created: new DateTime(2026, 4, 7));
+        _mockPlanRepo.Setup(r => r.GetByIdWithLinesAsync(4)).ReturnsAsync(plan);
+
+        var result = await _sut.GetByIdAsync(4);
+
+        Assert.NotNull(result);
+        Assert.Equal("TP | Doe, J. | 2026-04-07 | 2x/week", result!.DisplayTitle);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_DisplayTitle_SingleFrequency()
+    {
+        var plan = CreatePlan(weeklyFrequency: 1);
+        _mockPlanRepo.Setup(r => r.GetByIdWithLinesAsync(1)).ReturnsAsync(plan);
+
+        var result = await _sut.GetByIdAsync(1);
+
+        Assert.Contains("1x/week", result!.DisplayTitle);
+    }
+
+    [Fact]
+    public async Task GetByPatientIdAsync_DisplayTitle_IncludesLastNameAndInitial()
+    {
+        var plan = CreatePlan(firstName: "Maria", lastName: "Garcia");
+        _mockPlanRepo.Setup(r => r.GetByPatientIdAsync(10))
+            .ReturnsAsync(new List<TreatmentPlan> { plan });
+
+        var results = await _sut.GetByPatientIdAsync(10);
+
+        Assert.Single(results);
+        Assert.Contains("Garcia, M.", results[0].DisplayTitle);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_DisplayTitle_NullPatient_ShowsQuestionMark()
+    {
+        var plan = CreatePlan();
+        plan.Patient = null;
+        _mockPlanRepo.Setup(r => r.GetByIdWithLinesAsync(1)).ReturnsAsync(plan);
+
+        var result = await _sut.GetByIdAsync(1);
+
+        Assert.Contains("?, ?", result!.DisplayTitle);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_DisplayTitle_EmptyFirstName_ShowsQuestionMark()
+    {
+        var plan = CreatePlan(firstName: "");
+        _mockPlanRepo.Setup(r => r.GetByIdWithLinesAsync(1)).ReturnsAsync(plan);
+
+        var result = await _sut.GetByIdAsync(1);
+
+        Assert.Contains("Doe, ?", result!.DisplayTitle);
+    }
+}

--- a/tests/Web.Tests/TimeOnlyJsonConverterTests.cs
+++ b/tests/Web.Tests/TimeOnlyJsonConverterTests.cs
@@ -1,0 +1,105 @@
+using System.Text;
+using System.Text.Json;
+using Neurocorp.Api.Web.Middleware;
+
+namespace Web.Tests;
+
+public class TimeOnlyJsonConverterTests
+{
+    private readonly JsonSerializerOptions _options;
+
+    public TimeOnlyJsonConverterTests()
+    {
+        _options = new JsonSerializerOptions();
+        _options.Converters.Add(new TimeOnlyJsonConverterFactory());
+    }
+
+    [Theory]
+    [InlineData("\"10:00\"", 10, 0)]
+    [InlineData("\"08:30\"", 8, 30)]
+    [InlineData("\"18:00\"", 18, 0)]
+    [InlineData("\"00:00\"", 0, 0)]
+    [InlineData("\"23:45\"", 23, 45)]
+    public void Read_HHmm_ParsesCorrectly(string json, int expectedHour, int expectedMinute)
+    {
+        var result = JsonSerializer.Deserialize<TimeOnly>(json, _options);
+        Assert.Equal(new TimeOnly(expectedHour, expectedMinute), result);
+    }
+
+    [Theory]
+    [InlineData("\"10:00:00\"", 10, 0, 0)]
+    [InlineData("\"08:30:15\"", 8, 30, 15)]
+    [InlineData("\"23:59:59\"", 23, 59, 59)]
+    public void Read_HHmmss_ParsesCorrectly(string json, int expectedHour, int expectedMinute, int expectedSecond)
+    {
+        var result = JsonSerializer.Deserialize<TimeOnly>(json, _options);
+        Assert.Equal(new TimeOnly(expectedHour, expectedMinute, expectedSecond), result);
+    }
+
+    [Theory]
+    [InlineData("\"25:00\"")]
+    [InlineData("\"10\"")]
+    [InlineData("\"abc\"")]
+    [InlineData("\"10:00:00:00\"")]
+    public void Read_InvalidFormat_ThrowsJsonException(string json)
+    {
+        Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<TimeOnly>(json, _options));
+    }
+
+    [Fact]
+    public void Read_NullValue_ThrowsJsonException()
+    {
+        Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<TimeOnly>("null", _options));
+    }
+
+    [Fact]
+    public void Write_SerializesAsHHmmss()
+    {
+        var time = new TimeOnly(14, 30, 0);
+        var json = JsonSerializer.Serialize(time, _options);
+        Assert.Equal("\"14:30:00\"", json);
+    }
+
+    [Fact]
+    public void Write_PreservesSeconds()
+    {
+        var time = new TimeOnly(9, 5, 45);
+        var json = JsonSerializer.Serialize(time, _options);
+        Assert.Equal("\"09:05:45\"", json);
+    }
+
+    [Fact]
+    public void RoundTrip_NullableTimeOnly_WithHHmm()
+    {
+        // Simulates the actual BulkScheduleRequest.LineOverride.Time scenario
+        var json = """{"Time":"10:00"}""";
+        var opts = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+        opts.Converters.Add(new TimeOnlyJsonConverterFactory());
+        var result = JsonSerializer.Deserialize<NullableTimeHolder>(json, opts);
+        Assert.NotNull(result);
+        Assert.Equal(new TimeOnly(10, 0), result!.Time);
+    }
+
+    [Fact]
+    public void RoundTrip_NullableTimeOnly_WithNull()
+    {
+        var json = """{"Time":null}""";
+        var opts = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+        opts.Converters.Add(new TimeOnlyJsonConverterFactory());
+        var result = JsonSerializer.Deserialize<NullableTimeHolder>(json, opts);
+        Assert.NotNull(result);
+        Assert.Null(result!.Time);
+    }
+
+    [Fact]
+    public void Deserialize_NullableTimeOnly_Directly()
+    {
+        var result = JsonSerializer.Deserialize<TimeOnly?>("\"10:00\"", _options);
+        Assert.Equal(new TimeOnly(10, 0), result);
+    }
+
+    private class NullableTimeHolder
+    {
+        public TimeOnly? Time { get; set; }
+    }
+}


### PR DESCRIPTION
Bug fixes:
- Atomic bulk scheduling: no sessions created when any conflict exists
- TimeOnly JSON converter: accept HH:mm format from UI time inputs
- Treatment plan title: "TP | LastName, F. | Date | Frequency"
- Allow therapist reassignment on existing sessions (TherapistId in update)

New tests:
- TimeOnlyJsonConverterTests (11 tests): parsing, serialization, nullable
- TreatmentPlanServiceTests (5 tests): DisplayTitle format + null safety
- BulkSchedulingService atomicity: verify AddRangeAsync never called on conflict