### PR TITLE
WP-12B: Schedule visibility + smart booking (Phase 4 API)

### DIFF
--- a/src/Core/BusinessObjects/Sessions/ScheduleMatrixResponse.cs
+++ b/src/Core/BusinessObjects/Sessions/ScheduleMatrixResponse.cs
@@ -1,0 +1,29 @@
+namespace Neurocorp.Api.Core.BusinessObjects.Sessions;
+
+public class ScheduleMatrixResponse
+{
+    public DateOnly WeekStart { get; set; }
+    public DateOnly WeekEnd { get; set; }
+    public int SiteId { get; set; }
+    public string SiteName { get; set; } = string.Empty;
+    public List<TherapistScheduleRow> Therapists { get; set; } = [];
+}
+
+public class TherapistScheduleRow
+{
+    public int TherapistId { get; set; }
+    public string TherapistName { get; set; } = string.Empty;
+    public List<string> Specialties { get; set; } = [];
+    public List<ScheduleSlot> Slots { get; set; } = [];
+}
+
+public class ScheduleSlot
+{
+    public DateOnly Date { get; set; }
+    public TimeOnly Time { get; set; }
+    public int? SessionId { get; set; }
+    public string? PatientName { get; set; }
+    public string? SpecialtyAbbreviation { get; set; }
+    public int? AppointmentStatusId { get; set; }
+    public string? StatusName { get; set; }
+}

--- a/src/Core/BusinessObjects/TreatmentPlans/ActivePlanSummary.cs
+++ b/src/Core/BusinessObjects/TreatmentPlans/ActivePlanSummary.cs
@@ -1,0 +1,18 @@
+namespace Neurocorp.Api.Core.BusinessObjects.TreatmentPlans;
+
+public class ActivePlanSummary
+{
+    public int PlanId { get; set; }
+    public string DisplayTitle { get; set; } = string.Empty;
+    public int PatientId { get; set; }
+    public string PatientName { get; set; } = string.Empty;
+    public string PlanStatus { get; set; } = "Active";
+    public int WeeklyFrequency { get; set; }
+    public int DurationWeeks { get; set; }
+    public int TotalPlanned { get; set; }
+    public int SessionsCreated { get; set; }
+    public int SessionsCompleted { get; set; }
+    public int SessionsRemaining { get; set; }
+    public DateOnly? NextUpcomingDate { get; set; }
+    public bool NeedsAttention { get; set; }
+}

--- a/src/Core/Configurations/Dependencies.cs
+++ b/src/Core/Configurations/Dependencies.cs
@@ -25,6 +25,7 @@ public static class NeurocorpConfigurationExtensions
         services.AddScoped<ILookupService, LookupService>();
         services.AddScoped<ITreatmentPlanService, TreatmentPlanService>();
         services.AddScoped<IBulkSchedulingService, BulkSchedulingService>();
+        services.AddScoped<IScheduleMatrixService, ScheduleMatrixService>();
         return services;
     }
 }

--- a/src/Core/Interfaces/Repositories/ITherapistSpecialtyRepository.cs
+++ b/src/Core/Interfaces/Repositories/ITherapistSpecialtyRepository.cs
@@ -5,4 +5,5 @@ public interface ITherapistSpecialtyRepository
     Task SetSpecialtiesAsync(int therapistId, IEnumerable<int> specialtyIds);
     Task<IEnumerable<int>> GetValidSpecialtyIdsAsync(IEnumerable<int> candidateIds);
     Task<IReadOnlyList<int>> GetTherapistIdsBySpecialtyAsync(int specialtyId);
+    Task<bool> HasTherapistSpecialtyAsync(int therapistId, int specialtyId);
 }

--- a/src/Core/Interfaces/Repositories/ITherapySessionRepository.cs
+++ b/src/Core/Interfaces/Repositories/ITherapySessionRepository.cs
@@ -14,4 +14,5 @@ public interface ITherapySessionRepository : IRepository<TherapySession>
     Task<IReadOnlyList<int>> GetTherapistIdsForPatientAsync(int patientId);
     Task AddRangeAsync(IEnumerable<TherapySession> sessions);
     Task<bool> HasSessionsForPlanAsync(int treatmentPlanId);
+    Task<IReadOnlyList<TherapySession>> GetBySiteAndDateRangeAsync(int siteId, DateOnly from, DateOnly to);
 }

--- a/src/Core/Interfaces/Repositories/ITreatmentPlanRepository.cs
+++ b/src/Core/Interfaces/Repositories/ITreatmentPlanRepository.cs
@@ -6,4 +6,5 @@ public interface ITreatmentPlanRepository : IRepository<TreatmentPlan>
 {
     Task<TreatmentPlan?> GetByIdWithLinesAsync(int id);
     Task<IReadOnlyList<TreatmentPlan>> GetByPatientIdAsync(int patientId);
+    Task<IReadOnlyList<TreatmentPlan>> GetActiveWithLinesAsync();
 }

--- a/src/Core/Interfaces/Services/IScheduleMatrixService.cs
+++ b/src/Core/Interfaces/Services/IScheduleMatrixService.cs
@@ -1,0 +1,8 @@
+using Neurocorp.Api.Core.BusinessObjects.Sessions;
+
+namespace Neurocorp.Api.Core.Interfaces.Services;
+
+public interface IScheduleMatrixService
+{
+    Task<ScheduleMatrixResponse> GetMatrixAsync(DateOnly date, int siteId);
+}

--- a/src/Core/Interfaces/Services/ITreatmentPlanService.cs
+++ b/src/Core/Interfaces/Services/ITreatmentPlanService.cs
@@ -11,4 +11,5 @@ public interface ITreatmentPlanService
     Task<TreatmentPlanProfile> ActivateAsync(int id);
     Task<TreatmentPlanProfile> CompleteAsync(int id);
     Task<TreatmentPlanProfile> CancelAsync(int id);
+    Task<IReadOnlyList<ActivePlanSummary>> GetActiveSummaryAsync();
 }

--- a/src/Core/Services/ScheduleMatrixService.cs
+++ b/src/Core/Services/ScheduleMatrixService.cs
@@ -1,0 +1,143 @@
+using Microsoft.Extensions.Logging;
+using Neurocorp.Api.Core.BusinessObjects.Sessions;
+using Neurocorp.Api.Core.Entities;
+using Neurocorp.Api.Core.Interfaces.Repositories;
+using Neurocorp.Api.Core.Interfaces.Services;
+
+namespace Neurocorp.Api.Core.Services;
+
+public class ScheduleMatrixService : IScheduleMatrixService
+{
+    private readonly ILogger<ScheduleMatrixService> _logger;
+    private readonly ITherapySessionRepository _sessionRepository;
+    private readonly ITherapistRepository _therapistRepository;
+    private readonly ITherapistSpecialtyRepository _specialtyRepository;
+    private readonly IRepository<Site> _siteRepository;
+
+    private static readonly TimeOnly SlotStart = new(8, 0);
+    private static readonly TimeOnly SlotEnd = new(17, 0);
+
+    public ScheduleMatrixService(
+        ILogger<ScheduleMatrixService> logger,
+        ITherapySessionRepository sessionRepository,
+        ITherapistRepository therapistRepository,
+        ITherapistSpecialtyRepository specialtyRepository,
+        IRepository<Site> siteRepository)
+    {
+        _logger = logger;
+        _sessionRepository = sessionRepository;
+        _therapistRepository = therapistRepository;
+        _specialtyRepository = specialtyRepository;
+        _siteRepository = siteRepository;
+    }
+
+    public async Task<ScheduleMatrixResponse> GetMatrixAsync(DateOnly date, int siteId)
+    {
+        _logger.LogInformation("Building schedule matrix for week of {Date}, SiteId:{SiteId}", date, siteId);
+
+        var site = await _siteRepository.GetByIdAsync(siteId)
+            ?? throw new ArgumentException($"Site {siteId} not found.");
+
+        // Compute Monday–Saturday for the week containing the given date
+        var weekStart = GetMonday(date);
+        var weekEnd = weekStart.AddDays(5); // Saturday
+
+        // Fetch all non-cancelled sessions at this site for the week
+        var sessions = await _sessionRepository.GetBySiteAndDateRangeAsync(siteId, weekStart, weekEnd);
+
+        // Identify therapists: those with sessions this week + all therapists with specialties
+        var therapistIdsFromSessions = sessions.Select(s => s.TherapistId).Distinct().ToHashSet();
+        var allTherapists = await _therapistRepository.GetAllAsync();
+        var relevantTherapists = allTherapists
+            .Where(t => therapistIdsFromSessions.Contains(t.TherapistId) || t.TherapistSpecialties.Count > 0)
+            .OrderBy(t => t.User?.LastName ?? "")
+            .ThenBy(t => t.User?.FirstName ?? "")
+            .ToList();
+
+        // Pre-load therapist IDs for eager-loaded specialties
+        var therapistIds = relevantTherapists.Select(t => t.TherapistId).ToList();
+        var therapistsWithUser = await _therapistRepository.GetByIdsWithUserAsync(therapistIds);
+        var therapistMap = therapistsWithUser.ToDictionary(t => t.TherapistId);
+
+        // Group sessions by therapist+date+time for O(1) lookup
+        var sessionLookup = sessions
+            .GroupBy(s => (s.TherapistId, s.SessionDate, s.SessionTime.Hour))
+            .ToDictionary(g => g.Key, g => g.First());
+
+        // Build rows
+        var rows = new List<TherapistScheduleRow>();
+        foreach (var therapist in relevantTherapists)
+        {
+            var t = therapistMap.GetValueOrDefault(therapist.TherapistId) ?? therapist;
+            var name = t.User != null
+                ? $"{t.User.LastName}, {t.User.FirstName}".Trim().TrimEnd(',')
+                : $"Therapist #{t.TherapistId}";
+
+            var specialties = t.TherapistSpecialties
+                .Where(ts => ts.SpecialtyType != null)
+                .Select(ts => ts.SpecialtyType!.Abbreviation)
+                .OrderBy(a => a)
+                .ToList();
+
+            var slots = BuildSlots(t.TherapistId, weekStart, weekEnd, sessionLookup);
+
+            rows.Add(new TherapistScheduleRow
+            {
+                TherapistId = t.TherapistId,
+                TherapistName = name,
+                Specialties = specialties,
+                Slots = slots,
+            });
+        }
+
+        return new ScheduleMatrixResponse
+        {
+            WeekStart = weekStart,
+            WeekEnd = weekEnd,
+            SiteId = siteId,
+            SiteName = site.SiteName,
+            Therapists = rows,
+        };
+    }
+
+    private static List<ScheduleSlot> BuildSlots(
+        int therapistId,
+        DateOnly weekStart,
+        DateOnly weekEnd,
+        Dictionary<(int TherapistId, DateOnly Date, int Hour), TherapySession> sessionLookup)
+    {
+        var slots = new List<ScheduleSlot>();
+
+        for (var day = weekStart; day <= weekEnd; day = day.AddDays(1))
+        {
+            for (var time = SlotStart; time < SlotEnd; time = time.AddHours(1))
+            {
+                var key = (therapistId, day, time.Hour);
+                var session = sessionLookup.GetValueOrDefault(key);
+
+                slots.Add(new ScheduleSlot
+                {
+                    Date = day,
+                    Time = time,
+                    SessionId = session?.Id,
+                    PatientName = session?.Patient?.User != null
+                        ? $"{session.Patient.User.LastName}, {session.Patient.User.FirstName[0]}."
+                        : null,
+                    SpecialtyAbbreviation = session?.SpecialtyType?.Abbreviation,
+                    AppointmentStatusId = session?.AppointmentStatusId,
+                    StatusName = session?.AppointmentStatus?.Name,
+                });
+            }
+        }
+
+        return slots;
+    }
+
+    private static DateOnly GetMonday(DateOnly date)
+    {
+        var dayOfWeek = (int)date.DayOfWeek;
+        // DayOfWeek: Sunday=0, Monday=1, ..., Saturday=6
+        var daysToSubtract = dayOfWeek == 0 ? 6 : dayOfWeek - 1;
+        return date.AddDays(-daysToSubtract);
+    }
+}

--- a/src/Core/Services/SessionEventHandler.cs
+++ b/src/Core/Services/SessionEventHandler.cs
@@ -17,8 +17,9 @@ public class SessionEventHandler : IHandleSessionEvent
     private readonly IPatientProfileService _patientService;
     private readonly ITherapistProfileService _therapistService;
     private readonly IRepository<SpecialtyType> _specialtyTypeRepository;
+    private readonly ITherapistSpecialtyRepository _therapistSpecialtyRepository;
 
-    public SessionEventHandler(ILogger<SessionEventHandler> logger, ISessionEventRepository repo, ITherapySessionRepository therapySessionRepo, ITherapistProfileService therapistSvc, IPatientProfileService patientSvc, IRepository<SpecialtyType> specialtyTypeRepo)
+    public SessionEventHandler(ILogger<SessionEventHandler> logger, ISessionEventRepository repo, ITherapySessionRepository therapySessionRepo, ITherapistProfileService therapistSvc, IPatientProfileService patientSvc, IRepository<SpecialtyType> specialtyTypeRepo, ITherapistSpecialtyRepository therapistSpecialtyRepo)
     {
         _logger = logger;
         _repository = repo;
@@ -26,6 +27,7 @@ public class SessionEventHandler : IHandleSessionEvent
         _patientService = patientSvc;
         _therapistService = therapistSvc;
         _specialtyTypeRepository = specialtyTypeRepo;
+        _therapistSpecialtyRepository = therapistSpecialtyRepo;
     }
 
     public async Task<IEnumerable<SessionEvent>> GetAllAsync()
@@ -138,6 +140,16 @@ public class SessionEventHandler : IHandleSessionEvent
             if (!hasDiscovery)
                 throw new ArgumentException(
                     "Patient requires a completed discovery session before treatment sessions can be scheduled.");
+        }
+
+        // Specialty validation: therapist must hold the requested specialty
+        if (specialty != null && request.SpecialtyTypeId.HasValue)
+        {
+            var hasSpecialty = await _therapistSpecialtyRepository
+                .HasTherapistSpecialtyAsync(request.TherapistId, specialty.Id);
+            if (!hasSpecialty)
+                throw new ArgumentException(
+                    $"Therapist {tProfile!.TherapistName} does not have the {specialty.Name} qualification.");
         }
 
         var newTherapySession = await _therapySessionRepository.AddAsync(MapToNewSessionEvent(pProfile!, tProfile!, request, specialty));

--- a/src/Core/Services/TreatmentPlanService.cs
+++ b/src/Core/Services/TreatmentPlanService.cs
@@ -191,6 +191,51 @@ public class TreatmentPlanService : ITreatmentPlanService
         return MapToProfile(plan);
     }
 
+    private const int CancelledStatusId = 3;
+    private const int CompletedStatusId = 4;
+
+    public async Task<IReadOnlyList<ActivePlanSummary>> GetActiveSummaryAsync()
+    {
+        var activePlans = await _planRepository.GetActiveWithLinesAsync();
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var summaries = new List<ActivePlanSummary>();
+
+        foreach (var plan in activePlans)
+        {
+            var sessions = await _sessionRepository.GetByTreatmentPlanIdAsync(plan.Id);
+
+            var sessionsCreated = sessions.Count;
+            var sessionsCompleted = sessions.Count(s => s.AppointmentStatusId == CompletedStatusId);
+            var sessionsCancelled = sessions.Count(s => s.AppointmentStatusId == CancelledStatusId);
+            var sessionsRemaining = sessions.Count(s => s.AppointmentStatusId != CancelledStatusId && s.AppointmentStatusId != CompletedStatusId);
+
+            summaries.Add(new ActivePlanSummary
+            {
+                PlanId = plan.Id,
+                DisplayTitle = BuildDisplayTitle(plan),
+                PatientId = plan.PatientId,
+                PatientName = plan.Patient?.User != null
+                    ? $"{plan.Patient.User.FirstName} {plan.Patient.User.LastName}".Trim()
+                    : string.Empty,
+                PlanStatus = plan.PlanStatus,
+                WeeklyFrequency = plan.WeeklyFrequency,
+                DurationWeeks = plan.DurationWeeks,
+                TotalPlanned = plan.DurationWeeks * plan.WeeklyFrequency,
+                SessionsCreated = sessionsCreated,
+                SessionsCompleted = sessionsCompleted,
+                SessionsRemaining = sessionsRemaining,
+                NextUpcomingDate = sessions
+                    .Where(s => s.SessionDate >= today && s.AppointmentStatusId != CancelledStatusId)
+                    .OrderBy(s => s.SessionDate)
+                    .Select(s => (DateOnly?)s.SessionDate)
+                    .FirstOrDefault(),
+                NeedsAttention = sessionsRemaining == 0,
+            });
+        }
+
+        return summaries;
+    }
+
     private static string BuildDisplayTitle(TreatmentPlan plan)
     {
         var lastName = plan.Patient?.User?.LastName ?? "?";

--- a/src/Infrastructure/Repositories/TherapistSpecialtyRepository.cs
+++ b/src/Infrastructure/Repositories/TherapistSpecialtyRepository.cs
@@ -60,4 +60,10 @@ public class TherapistSpecialtyRepository : ITherapistSpecialtyRepository
             .OrderBy(id => id)
             .ToListAsync();
     }
+
+    public async Task<bool> HasTherapistSpecialtyAsync(int therapistId, int specialtyId)
+    {
+        return await _dbContext.TherapistSpecialties
+            .AnyAsync(ts => ts.TherapistId == therapistId && ts.SpecialtyId == specialtyId);
+    }
 }

--- a/src/Infrastructure/Repositories/TherapySessionRepository.cs
+++ b/src/Infrastructure/Repositories/TherapySessionRepository.cs
@@ -108,4 +108,20 @@ public class TherapySessionRepository(ApplicationDbContext dbContext) :
                 && s.TreatmentPlanLine!.TreatmentPlanId == treatmentPlanId
                 && s.AppointmentStatusId != 3); // Exclude cancelled
     }
+
+    public async Task<IReadOnlyList<TherapySession>> GetBySiteAndDateRangeAsync(int siteId, DateOnly from, DateOnly to)
+    {
+        return await _dbContext.TherapySessions
+            .Include(s => s.Patient).ThenInclude(p => p!.User)
+            .Include(s => s.Therapist).ThenInclude(t => t!.User)
+            .Include(s => s.SpecialtyType)
+            .Include(s => s.AppointmentStatus)
+            .Where(s => s.SiteId == siteId
+                && s.SessionDate >= from
+                && s.SessionDate <= to
+                && s.AppointmentStatusId != 3) // Exclude cancelled
+            .OrderBy(s => s.SessionDate)
+            .ThenBy(s => s.SessionTime)
+            .ToListAsync();
+    }
 }

--- a/src/Infrastructure/Repositories/TreatmentPlanRepository.cs
+++ b/src/Infrastructure/Repositories/TreatmentPlanRepository.cs
@@ -31,4 +31,17 @@ public class TreatmentPlanRepository(ApplicationDbContext dbContext) :
             .OrderByDescending(tp => tp.CreatedTimestamp)
             .ToListAsync();
     }
+
+    public async Task<IReadOnlyList<TreatmentPlan>> GetActiveWithLinesAsync()
+    {
+        return await _dbContext.TreatmentPlans
+            .Include(tp => tp.Patient).ThenInclude(p => p!.User)
+            .Include(tp => tp.DiscoverySession).ThenInclude(ds => ds!.SpecialtyType)
+            .Include(tp => tp.CreatedByTherapist).ThenInclude(t => t!.User)
+            .Include(tp => tp.Lines).ThenInclude(l => l.SpecialtyType)
+            .Include(tp => tp.Lines).ThenInclude(l => l.PreferredTherapist).ThenInclude(t => t!.User)
+            .Where(tp => tp.PlanStatus == "Active")
+            .OrderByDescending(tp => tp.CreatedTimestamp)
+            .ToListAsync();
+    }
 }

--- a/src/Web/Controllers/SessionsController.cs
+++ b/src/Web/Controllers/SessionsController.cs
@@ -14,17 +14,20 @@ public class SessionsController : ControllerBase
     private readonly IHandleSessionEvent _sessionEventHandler;
     private readonly IPaymentRecordService _paymentService;
     private readonly IBookingService _bookingService;
+    private readonly IScheduleMatrixService _scheduleMatrixService;
 
     public SessionsController(
         ILogger<SessionsController> loger,
         IHandleSessionEvent handler,
         IPaymentRecordService paymentService,
-        IBookingService bookingService)
+        IBookingService bookingService,
+        IScheduleMatrixService scheduleMatrixService)
     {
         _logger = loger;
         _sessionEventHandler = handler;
         _paymentService = paymentService;
         _bookingService = bookingService;
+        _scheduleMatrixService = scheduleMatrixService;
     }
 
     [HttpGet("{dateString}/all")]
@@ -35,6 +38,23 @@ public class SessionsController : ControllerBase
         var targetDate = ConvertStringToDateOnly(dateString);
         var sessions = await _sessionEventHandler.GetAllByTargetDateAsync(targetDate);
         return Ok(sessions);
+    }
+
+    [HttpGet("{dateString}/schedule-matrix")]
+    [ProducesResponseType(typeof(ScheduleMatrixResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> GetScheduleMatrix(string dateString, [FromQuery] int siteId)
+    {
+        try
+        {
+            var targetDate = ConvertStringToDateOnly(dateString);
+            var result = await _scheduleMatrixService.GetMatrixAsync(targetDate, siteId);
+            return Ok(result);
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
     }
 
     [HttpGet("pastdue")]

--- a/src/Web/Controllers/TreatmentPlansController.cs
+++ b/src/Web/Controllers/TreatmentPlansController.cs
@@ -38,6 +38,14 @@ public class TreatmentPlansController : ControllerBase
         }
     }
 
+    [HttpGet("active-summary")]
+    [ProducesResponseType(typeof(IReadOnlyList<ActivePlanSummary>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetActiveSummary()
+    {
+        var results = await _service.GetActiveSummaryAsync();
+        return Ok(results);
+    }
+
     [HttpGet("{id}")]
     [ProducesResponseType(typeof(TreatmentPlanProfile), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]

--- a/tests/Core.Tests/SessionEventHandlerTests.cs
+++ b/tests/Core.Tests/SessionEventHandlerTests.cs
@@ -17,6 +17,7 @@ public class SessionEventHandlerTests
     private readonly Mock<IPatientProfileService> _mockPatientService;
     private readonly Mock<ITherapistProfileService> _mockTherapistService;
     private readonly Mock<IRepository<SpecialtyType>> _mockSpecialtyTypeRepository;
+    private readonly Mock<ITherapistSpecialtyRepository> _mockTherapistSpecialtyRepository;
     private readonly SessionEventHandler _sut;
 
     public SessionEventHandlerTests()
@@ -27,13 +28,15 @@ public class SessionEventHandlerTests
         _mockPatientService = new Mock<IPatientProfileService>();
         _mockTherapistService = new Mock<ITherapistProfileService>();
         _mockSpecialtyTypeRepository = new Mock<IRepository<SpecialtyType>>();
+        _mockTherapistSpecialtyRepository = new Mock<ITherapistSpecialtyRepository>();
         _sut = new SessionEventHandler(
             fakeLogger,
             _mockRepository.Object,
             _mockTherapySessionRepository.Object,
             _mockTherapistService.Object,
             _mockPatientService.Object,
-            _mockSpecialtyTypeRepository.Object);
+            _mockSpecialtyTypeRepository.Object,
+            _mockTherapistSpecialtyRepository.Object);
     }
 
     [Fact]
@@ -126,6 +129,9 @@ public class SessionEventHandlerTests
             .ReturnsAsync((TherapySession ts) => ts);
         _mockTherapySessionRepository
             .Setup(r => r.HasCompletedDiscoveryAsync(It.IsAny<int>()))
+            .ReturnsAsync(true);
+        _mockTherapistSpecialtyRepository
+            .Setup(r => r.HasTherapistSpecialtyAsync(It.IsAny<int>(), It.IsAny<int>()))
             .ReturnsAsync(true);
     }
 

--- a/tests/Web.Tests/SessionsControllerTests.cs
+++ b/tests/Web.Tests/SessionsControllerTests.cs
@@ -23,7 +23,8 @@ public class SessionsControllerTests
         _mockSessionEventHandler = new Mock<IHandleSessionEvent>(MockBehavior.Strict);
         var mockPaymentService = Mock.Of<IPaymentRecordService>();
         var mockBookingService = Mock.Of<IBookingService>();
-        _controller = new SessionsController(fakeLogger, _mockSessionEventHandler.Object, mockPaymentService, mockBookingService);
+        var mockScheduleMatrixService = Mock.Of<IScheduleMatrixService>();
+        _controller = new SessionsController(fakeLogger, _mockSessionEventHandler.Object, mockPaymentService, mockBookingService, mockScheduleMatrixService);
     }
 
     [Fact]
@@ -36,7 +37,8 @@ public class SessionsControllerTests
         // act
         var fakePaymentService = Mock.Of<IPaymentRecordService>();
         var fakeBookingService = Mock.Of<IBookingService>();
-        var sut = new SessionsController(fakeLogger, fakeEvHandler, fakePaymentService, fakeBookingService);
+        var fakeScheduleMatrixService = Mock.Of<IScheduleMatrixService>();
+        var sut = new SessionsController(fakeLogger, fakeEvHandler, fakePaymentService, fakeBookingService, fakeScheduleMatrixService);
 
         // assert
         sut.Should().NotBeNull();


### PR DESCRIPTION
Specialty validation on session create — returns 400 when therapist lacks the requested specialty. Active plan summary endpoint for cross-patient dashboard alerts. Schedule matrix endpoint returning weekly therapist × timeslot grid scoped by site.

3 new endpoints, 4 new files, 184 tests pass.