### PR TITLE
Fix payment type contract drift between API and UI

### DIFF
--- a/src/Core/BusinessObjects/Payments/PaymentRecord.cs
+++ b/src/Core/BusinessObjects/Payments/PaymentRecord.cs
@@ -1,5 +1,3 @@
-using Neurocorp.Api.Core.BusinessObjects.Lookups;
-
 namespace Neurocorp.Api.Core.BusinessObjects.Payments;
 
 public class PaymentRecord
@@ -7,7 +5,7 @@ public class PaymentRecord
     public PaymentRecord()
     {
         CaretakerName = string.Empty;
-        PaymentType = new LookupItem();
+        PaymentType = new PaymentTypeInfo();
         Allocations = new List<AllocationDetail>();
     }
 
@@ -16,7 +14,7 @@ public class PaymentRecord
     public DateTime PaymentDate { get; set; }
     public int CaretakerId { get; set; }
     public string CaretakerName { get; set; }
-    public LookupItem PaymentType { get; set; }
+    public PaymentTypeInfo PaymentType { get; set; }
     public string? CheckNumber { get; set; }
     public List<AllocationDetail> Allocations { get; set; }
     public decimal TotalAllocated { get; set; }

--- a/src/Core/BusinessObjects/Payments/PaymentTypeInfo.cs
+++ b/src/Core/BusinessObjects/Payments/PaymentTypeInfo.cs
@@ -1,0 +1,8 @@
+namespace Neurocorp.Api.Core.BusinessObjects.Payments;
+
+public class PaymentTypeInfo
+{
+    public int PaymentTypeId { get; set; }
+    public string Abbreviation { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+}

--- a/src/Core/BusinessObjects/Payments/SessionPaymentDetail.cs
+++ b/src/Core/BusinessObjects/Payments/SessionPaymentDetail.cs
@@ -1,5 +1,3 @@
-using Neurocorp.Api.Core.BusinessObjects.Lookups;
-
 namespace Neurocorp.Api.Core.BusinessObjects.Payments;
 
 public class SessionPaymentDetail
@@ -7,7 +5,7 @@ public class SessionPaymentDetail
     public SessionPaymentDetail()
     {
         CaretakerName = string.Empty;
-        PaymentType = new LookupItem();
+        PaymentType = new PaymentTypeInfo();
     }
 
     public int SessionPaymentId { get; set; }
@@ -17,6 +15,6 @@ public class SessionPaymentDetail
     public decimal PaymentTotalAmount { get; set; }
     public int CaretakerId { get; set; }
     public string CaretakerName { get; set; }
-    public LookupItem PaymentType { get; set; }
+    public PaymentTypeInfo PaymentType { get; set; }
     public string? CheckNumber { get; set; }
 }

--- a/src/Core/Interfaces/Services/IPaymentRecordService.cs
+++ b/src/Core/Interfaces/Services/IPaymentRecordService.cs
@@ -1,11 +1,10 @@
-using Neurocorp.Api.Core.BusinessObjects.Lookups;
 using Neurocorp.Api.Core.BusinessObjects.Payments;
 
 namespace Neurocorp.Api.Core.Interfaces.Services;
 
 public interface IPaymentRecordService
 {
-    Task<IEnumerable<LookupItem>> GetPaymentTypesAsync();
+    Task<IEnumerable<PaymentTypeInfo>> GetPaymentTypesAsync();
     Task<IEnumerable<PaymentRecord>> GetByCaretakerAsync(int caretakerId);
     Task<IEnumerable<PaymentRecord>> GetAllAsync();
     Task<PaymentRecord?> GetByIdAsync(int paymentId);

--- a/src/Core/Services/PaymentRecordService.cs
+++ b/src/Core/Services/PaymentRecordService.cs
@@ -1,5 +1,4 @@
 using Microsoft.Extensions.Logging;
-using Neurocorp.Api.Core.BusinessObjects.Lookups;
 using Neurocorp.Api.Core.BusinessObjects.Payments;
 using Neurocorp.Api.Core.Entities;
 using Neurocorp.Api.Core.Interfaces.Repositories;
@@ -32,19 +31,15 @@ public class PaymentRecordService : IPaymentRecordService
         _paymentTypeRepo = paymentTypeRepo;
     }
 
-    public async Task<IEnumerable<LookupItem>> GetPaymentTypesAsync()
+    public async Task<IEnumerable<PaymentTypeInfo>> GetPaymentTypesAsync()
     {
         _logger.LogInformation("Getting all payment types");
         var types = await _paymentTypeRepo.GetAllAsync();
-        return types.Select(pt => new LookupItem
+        return types.Select(pt => new PaymentTypeInfo
         {
-            Id = pt.Id,
+            PaymentTypeId = pt.Id,
             Abbreviation = pt.Abbreviation,
             Name = pt.Name,
-            Description = pt.Description,
-            SortOrder = pt.SortOrder,
-            CreatedTimestamp = pt.CreatedTimestamp,
-            LastUpdatedTimestamp = pt.LastUpdatedTimestamp,
         });
     }
 
@@ -206,17 +201,13 @@ public class PaymentRecordService : IPaymentRecordService
                 ? $"{sp.Payment.Caretaker.User.LastName}, {sp.Payment.Caretaker.User.FirstName} {sp.Payment.Caretaker.User.MiddleName}".Trim()
                 : string.Empty,
             PaymentType = sp.Payment.PaymentType != null
-                ? new LookupItem
+                ? new PaymentTypeInfo
                 {
-                    Id = sp.Payment.PaymentType.Id,
+                    PaymentTypeId = sp.Payment.PaymentType.Id,
                     Abbreviation = sp.Payment.PaymentType.Abbreviation,
                     Name = sp.Payment.PaymentType.Name,
-                    Description = sp.Payment.PaymentType.Description,
-                    SortOrder = sp.Payment.PaymentType.SortOrder,
-                    CreatedTimestamp = sp.Payment.PaymentType.CreatedTimestamp,
-                    LastUpdatedTimestamp = sp.Payment.PaymentType.LastUpdatedTimestamp,
                 }
-                : new LookupItem(),
+                : new PaymentTypeInfo(),
             CheckNumber = sp.Payment.CheckNumber
         });
     }
@@ -277,17 +268,13 @@ public class PaymentRecordService : IPaymentRecordService
             CaretakerId = payment.CaretakerId,
             CaretakerName = caretakerName,
             PaymentType = payment.PaymentType != null
-                ? new LookupItem
+                ? new PaymentTypeInfo
                 {
-                    Id = payment.PaymentType.Id,
+                    PaymentTypeId = payment.PaymentType.Id,
                     Abbreviation = payment.PaymentType.Abbreviation,
                     Name = payment.PaymentType.Name,
-                    Description = payment.PaymentType.Description,
-                    SortOrder = payment.PaymentType.SortOrder,
-                    CreatedTimestamp = payment.PaymentType.CreatedTimestamp,
-                    LastUpdatedTimestamp = payment.PaymentType.LastUpdatedTimestamp,
                 }
-                : new LookupItem(),
+                : new PaymentTypeInfo(),
             CheckNumber = payment.CheckNumber,
             Allocations = allocations,
             TotalAllocated = totalAllocated,

--- a/src/Web/Controllers/PaymentsController.cs
+++ b/src/Web/Controllers/PaymentsController.cs
@@ -1,5 +1,4 @@
 using Microsoft.AspNetCore.Mvc;
-using Neurocorp.Api.Core.BusinessObjects.Lookups;
 using Neurocorp.Api.Core.BusinessObjects.Payments;
 using Neurocorp.Api.Core.Interfaces.Services;
 
@@ -19,7 +18,7 @@ public class PaymentsController : ControllerBase
     }
 
     [HttpGet("types")]
-    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<LookupItem>))]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<PaymentTypeInfo>))]
     public async Task<IActionResult> GetPaymentTypes()
     {
         var types = await _paymentService.GetPaymentTypesAsync();


### PR DESCRIPTION
Replace LookupItem with a dedicated PaymentTypeInfo BO for the GET /api/payments/types endpoint and PaymentType properties on PaymentRecord and SessionPaymentDetail, matching payments-api.md ({ paymentTypeId, abbreviation, name }).

Previously the API returned LookupItem-shaped JSON (id, abbreviation, name, description, sortOrder, ...) so the UI bound pt.paymentTypeId to undefined, breaking the Record Payment "Next" validation step.