### PR TITLE
WP-13B: Therapist Statement API (pro-forma)

### DIFF
--- a/src/Core/BusinessObjects/Statements/ServicePaymentAllocation.cs
+++ b/src/Core/BusinessObjects/Statements/ServicePaymentAllocation.cs
@@ -1,0 +1,7 @@
+namespace Neurocorp.Api.Core.BusinessObjects.Statements;
+
+public class ServicePaymentAllocation
+{
+    public int SessionId { get; set; }
+    public decimal AmountApplied { get; set; }
+}

--- a/src/Core/BusinessObjects/Statements/ServicePaymentItem.cs
+++ b/src/Core/BusinessObjects/Statements/ServicePaymentItem.cs
@@ -1,0 +1,18 @@
+namespace Neurocorp.Api.Core.BusinessObjects.Statements;
+
+/// <summary>
+/// Shape reserved for the Therapist Payroll WP. In the WP-13B pro-forma
+/// scope, the <c>TherapistStatement.ServicePayments</c> list is always empty.
+/// Once WP-14 ships, the service will populate this from a new
+/// <c>ServicePayment</c> table that records disbursements to therapists.
+/// </summary>
+public class ServicePaymentItem
+{
+    public int ServicePaymentId { get; set; }
+    public string PaymentDate { get; set; } = string.Empty;
+    public decimal Amount { get; set; }
+    public string PaymentTypeName { get; set; } = string.Empty;
+    public string ReferenceNumber { get; set; } = string.Empty;
+    public string Notes { get; set; } = string.Empty;
+    public List<ServicePaymentAllocation> Allocations { get; set; } = new();
+}

--- a/src/Core/BusinessObjects/Statements/TherapistStatement.cs
+++ b/src/Core/BusinessObjects/Statements/TherapistStatement.cs
@@ -1,0 +1,14 @@
+namespace Neurocorp.Api.Core.BusinessObjects.Statements;
+
+public class TherapistStatement
+{
+    public int TherapistId { get; set; }
+    public string TherapistName { get; set; } = string.Empty;
+    public string StatementDate { get; set; } = string.Empty;
+    public string PeriodStart { get; set; } = string.Empty;
+    public string PeriodEnd { get; set; } = string.Empty;
+    public bool IsProForma { get; set; } = true;
+    public List<TherapistStatementPatient> Patients { get; set; } = new();
+    public List<ServicePaymentItem> ServicePayments { get; set; } = new();
+    public TherapistStatementSummary Summary { get; set; } = new();
+}

--- a/src/Core/BusinessObjects/Statements/TherapistStatementPatient.cs
+++ b/src/Core/BusinessObjects/Statements/TherapistStatementPatient.cs
@@ -1,0 +1,13 @@
+namespace Neurocorp.Api.Core.BusinessObjects.Statements;
+
+public class TherapistStatementPatient
+{
+    public int PatientId { get; set; }
+    public string PatientName { get; set; } = string.Empty;
+    public List<TherapistStatementSession> Sessions { get; set; } = new();
+    public decimal SubtotalFee { get; set; }
+    public decimal SubtotalDiscount { get; set; }
+    public decimal SubtotalProviderAmount { get; set; }
+    public int CompletedCount { get; set; }
+    public int NonBillableCount { get; set; }
+}

--- a/src/Core/BusinessObjects/Statements/TherapistStatementSession.cs
+++ b/src/Core/BusinessObjects/Statements/TherapistStatementSession.cs
@@ -1,0 +1,14 @@
+namespace Neurocorp.Api.Core.BusinessObjects.Statements;
+
+public class TherapistStatementSession
+{
+    public int SessionId { get; set; }
+    public string SessionDate { get; set; } = string.Empty;
+    public string SessionTime { get; set; } = string.Empty;
+    public string TherapyType { get; set; } = string.Empty;
+    public decimal Amount { get; set; }
+    public decimal DiscountAmount { get; set; }
+    public decimal ProviderAmount { get; set; }
+    public string StatusName { get; set; } = string.Empty;
+    public bool IsBillable { get; set; }
+}

--- a/src/Core/BusinessObjects/Statements/TherapistStatementSummary.cs
+++ b/src/Core/BusinessObjects/Statements/TherapistStatementSummary.cs
@@ -1,0 +1,12 @@
+namespace Neurocorp.Api.Core.BusinessObjects.Statements;
+
+public class TherapistStatementSummary
+{
+    public int TotalCompletedSessions { get; set; }
+    public int TotalNonBillableSessions { get; set; }
+    public decimal TotalFee { get; set; }
+    public decimal TotalDiscount { get; set; }
+    public decimal TotalProviderAmount { get; set; }
+    public decimal TotalServicePaymentsApplied { get; set; }
+    public decimal EstimatedAmountDue { get; set; }
+}

--- a/src/Core/Configurations/Dependencies.cs
+++ b/src/Core/Configurations/Dependencies.cs
@@ -20,6 +20,7 @@ public static class NeurocorpConfigurationExtensions
         services.AddScoped<IHandleSessionEvent, SessionEventHandler>();
         services.AddScoped<IPaymentRecordService, PaymentRecordService>();
         services.AddScoped<IAccountStatementService, AccountStatementService>();
+        services.AddScoped<ITherapistStatementService, TherapistStatementService>();
         services.AddScoped<IBookingService, BookingService>();
         services.AddScoped<ISiteProfileService, SiteProfileService>();
         services.AddScoped<ILookupService, LookupService>();

--- a/src/Core/Interfaces/Repositories/ITherapySessionRepository.cs
+++ b/src/Core/Interfaces/Repositories/ITherapySessionRepository.cs
@@ -10,6 +10,7 @@ public interface ITherapySessionRepository : IRepository<TherapySession>
     Task<TherapySession?> GetByIdWithSpecialtyAsync(int id);
     Task<IReadOnlyList<TherapySession>> GetCompletedDiscoverySessionsAsync(int patientId);
     Task<IReadOnlyList<TherapySession>> GetByTherapistAndDateRangeAsync(int therapistId, DateOnly fromDate, DateOnly toDate);
+    Task<IReadOnlyList<TherapySession>> GetByTherapistIdAndDateRangeAsync(int therapistId, DateOnly from, DateOnly to, IEnumerable<int> statusIds);
     Task<IReadOnlyList<TherapySession>> GetByTreatmentPlanIdAsync(int treatmentPlanId);
     Task<IReadOnlyList<int>> GetTherapistIdsForPatientAsync(int patientId);
     Task AddRangeAsync(IEnumerable<TherapySession> sessions);

--- a/src/Core/Interfaces/Services/ITherapistStatementService.cs
+++ b/src/Core/Interfaces/Services/ITherapistStatementService.cs
@@ -1,0 +1,8 @@
+using Neurocorp.Api.Core.BusinessObjects.Statements;
+
+namespace Neurocorp.Api.Core.Interfaces.Services;
+
+public interface ITherapistStatementService
+{
+    Task<TherapistStatement?> GetStatementAsync(int therapistId, DateOnly? from, DateOnly? to);
+}

--- a/src/Core/Services/TherapistStatementService.cs
+++ b/src/Core/Services/TherapistStatementService.cs
@@ -1,0 +1,194 @@
+using Microsoft.Extensions.Logging;
+using Neurocorp.Api.Core.BusinessObjects.Statements;
+using Neurocorp.Api.Core.Entities;
+using Neurocorp.Api.Core.Interfaces.Repositories;
+using Neurocorp.Api.Core.Interfaces.Services;
+
+namespace Neurocorp.Api.Core.Services;
+
+public class TherapistStatementService : ITherapistStatementService
+{
+    private const string StatusCompleted = "Completed";
+    private const string StatusCancelled = "Cancelled";
+    private const string StatusNoShow = "NoShow";
+
+    private readonly ITherapistProfileService _therapistProfileService;
+    private readonly ITherapySessionRepository _sessionRepo;
+    private readonly IRepository<AppointmentStatus> _appointmentStatusRepo;
+    private readonly ILogger<TherapistStatementService> _logger;
+
+    public TherapistStatementService(
+        ILogger<TherapistStatementService> logger,
+        ITherapistProfileService therapistProfileService,
+        ITherapySessionRepository sessionRepo,
+        IRepository<AppointmentStatus> appointmentStatusRepo)
+    {
+        _logger = logger;
+        _therapistProfileService = therapistProfileService;
+        _sessionRepo = sessionRepo;
+        _appointmentStatusRepo = appointmentStatusRepo;
+    }
+
+    public async Task<TherapistStatement?> GetStatementAsync(int therapistId, DateOnly? from, DateOnly? to)
+    {
+        _logger.LogInformation("Generating therapist statement for therapist {TherapistId}", therapistId);
+
+        // 1. Verify therapist exists
+        var therapist = await _therapistProfileService.GetByIdAsync(therapistId);
+        if (therapist == null)
+        {
+            _logger.LogWarning("Therapist {TherapistId} not found", therapistId);
+            return null;
+        }
+
+        // 2. Default date range: last 90 days
+        var periodStart = from ?? DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-90));
+        var periodEnd = to ?? DateOnly.FromDateTime(DateTime.UtcNow);
+
+        if (periodEnd < periodStart)
+        {
+            throw new ArgumentException("Query parameter 'to' must be on or after 'from'.");
+        }
+
+        // 3. Resolve appointment-status IDs by name (configurable lookup, never hardcoded)
+        var allStatuses = await _appointmentStatusRepo.GetAllAsync();
+        var statusByName = allStatuses
+            .GroupBy(s => s.Name, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase);
+
+        var includedStatusIds = new List<int>();
+        int? completedId = null;
+        foreach (var name in new[] { StatusCompleted, StatusCancelled, StatusNoShow })
+        {
+            if (statusByName.TryGetValue(name, out var status))
+            {
+                includedStatusIds.Add(status.Id);
+                if (string.Equals(name, StatusCompleted, StringComparison.OrdinalIgnoreCase))
+                {
+                    completedId = status.Id;
+                }
+            }
+            else
+            {
+                _logger.LogWarning("AppointmentStatus '{Name}' not found in lookup table", name);
+            }
+        }
+
+        // 4. Pull sessions for therapist within range, restricted to the three statuses
+        var sessions = await _sessionRepo.GetByTherapistIdAndDateRangeAsync(
+            therapistId, periodStart, periodEnd, includedStatusIds);
+
+        // 5. Group by patient → emit blocks, sorted by patient name
+        var patientBlocks = sessions
+            .GroupBy(s => s.PatientId)
+            .Select(g =>
+            {
+                var first = g.First();
+                var patientName = ResolvePatientName(first.Patient);
+
+                var sessionRows = g
+                    .OrderBy(s => s.SessionDate)
+                    .ThenBy(s => s.SessionTime)
+                    .Select(s => MapSession(s, completedId))
+                    .ToList();
+
+                var subtotalFee = sessionRows.Sum(r => r.Amount);
+                var subtotalDiscount = sessionRows.Sum(r => r.DiscountAmount);
+                var subtotalProvider = sessionRows.Where(r => r.IsBillable).Sum(r => r.ProviderAmount);
+                var completedCount = sessionRows.Count(r => r.IsBillable);
+                var nonBillableCount = sessionRows.Count - completedCount;
+
+                return new TherapistStatementPatient
+                {
+                    PatientId = g.Key,
+                    PatientName = patientName,
+                    Sessions = sessionRows,
+                    SubtotalFee = subtotalFee,
+                    SubtotalDiscount = subtotalDiscount,
+                    SubtotalProviderAmount = subtotalProvider,
+                    CompletedCount = completedCount,
+                    NonBillableCount = nonBillableCount,
+                };
+            })
+            .OrderBy(b => b.PatientName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        // 6. Compute summary
+        var totalCompleted = patientBlocks.Sum(p => p.CompletedCount);
+        var totalNonBillable = patientBlocks.Sum(p => p.NonBillableCount);
+        var totalFee = patientBlocks.Sum(p => p.SubtotalFee);
+        var totalDiscount = patientBlocks.Sum(p => p.SubtotalDiscount);
+        var totalProvider = patientBlocks.Sum(p => p.SubtotalProviderAmount);
+        var totalServicePaymentsApplied = 0m; // pro-forma: ServicePayments not tracked yet
+        var estimatedAmountDue = totalProvider - totalServicePaymentsApplied;
+
+        var summary = new TherapistStatementSummary
+        {
+            TotalCompletedSessions = totalCompleted,
+            TotalNonBillableSessions = totalNonBillable,
+            TotalFee = totalFee,
+            TotalDiscount = totalDiscount,
+            TotalProviderAmount = totalProvider,
+            TotalServicePaymentsApplied = totalServicePaymentsApplied,
+            EstimatedAmountDue = estimatedAmountDue,
+        };
+
+        return new TherapistStatement
+        {
+            TherapistId = therapist.TherapistId,
+            TherapistName = therapist.TherapistName,
+            StatementDate = DateOnly.FromDateTime(DateTime.UtcNow).ToString("yyyy-MM-dd"),
+            PeriodStart = periodStart.ToString("yyyy-MM-dd"),
+            PeriodEnd = periodEnd.ToString("yyyy-MM-dd"),
+            IsProForma = true,
+            Patients = patientBlocks,
+            ServicePayments = new List<ServicePaymentItem>(),
+            Summary = summary,
+        };
+    }
+
+    private static TherapistStatementSession MapSession(TherapySession s, int? completedStatusId)
+    {
+        var statusName = s.AppointmentStatus?.Name ?? string.Empty;
+        var isBillable = completedStatusId.HasValue && s.AppointmentStatusId == completedStatusId.Value;
+
+        return new TherapistStatementSession
+        {
+            SessionId = s.Id,
+            SessionDate = s.SessionDate.ToString("yyyy-MM-dd"),
+            SessionTime = s.SessionTime.ToString("HH:mm"),
+            TherapyType = ResolveTherapyType(s),
+            Amount = s.Amount,
+            DiscountAmount = s.DiscountAmount,
+            ProviderAmount = isBillable ? s.ProviderAmount : 0m,
+            StatusName = statusName,
+            IsBillable = isBillable,
+        };
+    }
+
+    /// <summary>
+    /// Therapy Type fallback chain (per WP-13B):
+    ///   1. SpecialtyType.Name (FK-resolved)
+    ///   2. TherapySession.TherapyTypes (legacy text column)
+    ///   3. "N/A"
+    /// </summary>
+    private static string ResolveTherapyType(TherapySession s)
+    {
+        if (s.SpecialtyType != null && !string.IsNullOrWhiteSpace(s.SpecialtyType.Name))
+        {
+            return s.SpecialtyType.Name;
+        }
+        if (!string.IsNullOrWhiteSpace(s.TherapyTypes))
+        {
+            return s.TherapyTypes;
+        }
+        return "N/A";
+    }
+
+    private static string ResolvePatientName(Patient? patient)
+    {
+        if (patient?.User == null) return string.Empty;
+        var middle = string.IsNullOrWhiteSpace(patient.User.MiddleName) ? string.Empty : $" {patient.User.MiddleName}";
+        return $"{patient.User.LastName}, {patient.User.FirstName}{middle}".Trim();
+    }
+}

--- a/src/Infrastructure/Repositories/TherapySessionRepository.cs
+++ b/src/Infrastructure/Repositories/TherapySessionRepository.cs
@@ -72,6 +72,23 @@ public class TherapySessionRepository(ApplicationDbContext dbContext) :
             .ToListAsync();
     }
 
+    public async Task<IReadOnlyList<TherapySession>> GetByTherapistIdAndDateRangeAsync(
+        int therapistId, DateOnly from, DateOnly to, IEnumerable<int> statusIds)
+    {
+        var statusIdList = statusIds.ToList();
+        return await _dbContext.TherapySessions
+            .Include(s => s.Patient).ThenInclude(p => p!.User)
+            .Include(s => s.SpecialtyType)
+            .Include(s => s.AppointmentStatus)
+            .Where(s => s.TherapistId == therapistId
+                && s.SessionDate >= from
+                && s.SessionDate <= to
+                && statusIdList.Contains(s.AppointmentStatusId))
+            .OrderBy(s => s.SessionDate)
+            .ThenBy(s => s.SessionTime)
+            .ToListAsync();
+    }
+
     public async Task<IReadOnlyList<TherapySession>> GetByTreatmentPlanIdAsync(int treatmentPlanId)
     {
         return await _dbContext.TherapySessions

--- a/src/Web/Controllers/TherapistsController.cs
+++ b/src/Web/Controllers/TherapistsController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Neurocorp.Api.Core.BusinessObjects.Therapists;
+using Neurocorp.Api.Core.BusinessObjects.Statements;
 using Neurocorp.Api.Core.Interfaces.Services;
 using Neurocorp.Api.Core.Interfaces;
 using Neurocorp.Api.Core.BusinessObjects.Sessions;
@@ -13,12 +14,18 @@ public class TherapistsController : ControllerBase
 {
     private readonly ITherapistProfileService _therapistProfileService;
     private readonly IHandleSessionEvent _sessionEventHandler;
+    private readonly ITherapistStatementService _therapistStatementService;
     private readonly ILogger<TherapistsController> _logger;
 
-    public TherapistsController(ILogger<TherapistsController> logger, ITherapistProfileService therapistProfileService, IHandleSessionEvent sesssionEventHandler)
+    public TherapistsController(
+        ILogger<TherapistsController> logger,
+        ITherapistProfileService therapistProfileService,
+        IHandleSessionEvent sesssionEventHandler,
+        ITherapistStatementService therapistStatementService)
     {
         _therapistProfileService = therapistProfileService;
         _sessionEventHandler = sesssionEventHandler;
+        _therapistStatementService = therapistStatementService;
         _logger = logger;
     }
 
@@ -88,6 +95,30 @@ public class TherapistsController : ControllerBase
                 }
             }
             return BadRequest();
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(ex.Message);
+        }
+    }
+
+    [HttpGet("{id}/statement")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(TherapistStatement))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<IActionResult> GetStatement(int id, [FromQuery] DateOnly? from, [FromQuery] DateOnly? to)
+    {
+        try
+        {
+            if (from.HasValue && to.HasValue && to.Value < from.Value)
+            {
+                return BadRequest("Query parameter 'to' must be on or after 'from'.");
+            }
+
+            var statement = await _therapistStatementService.GetStatementAsync(id, from, to);
+            if (statement == null) return NotFound();
+            return Ok(statement);
         }
         catch (ArgumentException ex)
         {

--- a/test-scripts/wp-13b-therapist-statement.sh
+++ b/test-scripts/wp-13b-therapist-statement.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# WP-13B: Therapist Statement API curl test script
+#
+# Endpoint:
+#   GET /api/therapists/{id}/statement?from=YYYY-MM-DD&to=YYYY-MM-DD
+#
+# Behavior:
+#   - from/to optional; defaults: from = today - 90d, to = today
+#   - 404 if therapist does not exist
+#   - 400 if to < from or dates are malformed
+#   - Status filter: Completed | Cancelled | NoShow only
+#   - Therapy Type fallback: SpecialtyType.Name -> TherapyTypes -> "N/A"
+#   - IsProForma always true; ServicePayments[] always empty (until WP-14)
+#
+# Prereqs:
+#   - API running locally on :5245 (`dotnet run --project src/Web/Web.csproj`)
+#   - jq installed for pretty printing (optional)
+#
+# Usage:
+#   THERAPIST_ID=1 ./test-scripts/wp-13b-therapist-statement.sh
+#   THERAPIST_ID=2 BASE_URL=http://localhost:5245 ./test-scripts/wp-13b-therapist-statement.sh
+
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost:5245}"
+THERAPIST_ID="${THERAPIST_ID:-1}"
+NONEXISTENT_THERAPIST_ID="${NONEXISTENT_THERAPIST_ID:-99999}"
+MIXED_THERAPIST_ID="${MIXED_THERAPIST_ID:-$THERAPIST_ID}"
+FALLBACK_THERAPIST_ID="${FALLBACK_THERAPIST_ID:-$THERAPIST_ID}"
+
+FROM="${FROM:-2026-01-01}"
+TO="${TO:-2026-04-30}"
+
+EMPTY_FROM="2099-01-01"
+EMPTY_TO="2099-01-31"
+
+PRETTY="cat"
+if command -v jq >/dev/null 2>&1; then
+    PRETTY="jq ."
+fi
+
+echo "=================================================================="
+echo "Test 1: Happy path with default date range (no from/to)"
+echo "  GET ${BASE_URL}/api/therapists/${THERAPIST_ID}/statement"
+echo "=================================================================="
+curl -sS -w "\nHTTP %{http_code}\n" \
+    "${BASE_URL}/api/therapists/${THERAPIST_ID}/statement" | $PRETTY
+echo
+
+echo "=================================================================="
+echo "Test 2: Happy path with explicit from/to"
+echo "  GET ${BASE_URL}/api/therapists/${THERAPIST_ID}/statement?from=${FROM}&to=${TO}"
+echo "=================================================================="
+curl -sS -w "\nHTTP %{http_code}\n" \
+    "${BASE_URL}/api/therapists/${THERAPIST_ID}/statement?from=${FROM}&to=${TO}" | $PRETTY
+echo
+
+echo "=================================================================="
+echo "Test 3: Empty range (no sessions in window)"
+echo "  GET ${BASE_URL}/api/therapists/${THERAPIST_ID}/statement?from=${EMPTY_FROM}&to=${EMPTY_TO}"
+echo "  Expect: 200 OK, patients=[], summary all zeros, isProForma=true"
+echo "=================================================================="
+curl -sS -w "\nHTTP %{http_code}\n" \
+    "${BASE_URL}/api/therapists/${THERAPIST_ID}/statement?from=${EMPTY_FROM}&to=${EMPTY_TO}" | $PRETTY
+echo
+
+echo "=================================================================="
+echo "Test 4: Mixed-status therapist"
+echo "  GET ${BASE_URL}/api/therapists/${MIXED_THERAPIST_ID}/statement?from=${FROM}&to=${TO}"
+echo "  Expect: Cancelled/NoShow rows present with providerAmount=0,"
+echo "          isBillable=false; estimatedAmountDue sums Completed only."
+echo "=================================================================="
+curl -sS -w "\nHTTP %{http_code}\n" \
+    "${BASE_URL}/api/therapists/${MIXED_THERAPIST_ID}/statement?from=${FROM}&to=${TO}" | $PRETTY
+echo
+
+echo "=================================================================="
+echo "Test 5: 404 nonexistent therapist"
+echo "  GET ${BASE_URL}/api/therapists/${NONEXISTENT_THERAPIST_ID}/statement"
+echo "  Expect: HTTP 404"
+echo "=================================================================="
+curl -sS -w "\nHTTP %{http_code}\n" \
+    "${BASE_URL}/api/therapists/${NONEXISTENT_THERAPIST_ID}/statement" || true
+echo
+
+echo "=================================================================="
+echo "Test 6: 400 to < from"
+echo "  GET ${BASE_URL}/api/therapists/${THERAPIST_ID}/statement?from=2026-04-30&to=2026-01-01"
+echo "  Expect: HTTP 400"
+echo "=================================================================="
+curl -sS -w "\nHTTP %{http_code}\n" \
+    "${BASE_URL}/api/therapists/${THERAPIST_ID}/statement?from=2026-04-30&to=2026-01-01" || true
+echo
+
+echo "=================================================================="
+echo "Test 7: 400 malformed date"
+echo "  GET ${BASE_URL}/api/therapists/${THERAPIST_ID}/statement?from=not-a-date&to=2026-04-30"
+echo "  Expect: HTTP 400 (model binding rejects)"
+echo "=================================================================="
+curl -sS -w "\nHTTP %{http_code}\n" \
+    "${BASE_URL}/api/therapists/${THERAPIST_ID}/statement?from=not-a-date&to=2026-04-30" || true
+echo
+
+echo "=================================================================="
+echo "Test 8: Therapy Type fallback verification"
+echo "  GET ${BASE_URL}/api/therapists/${FALLBACK_THERAPIST_ID}/statement?from=${FROM}&to=${TO}"
+echo "  Inspect: rows should show therapyType resolved per fallback chain:"
+echo "    1. SpecialtyType.Name (when SpecialtyTypeId is set)"
+echo "    2. TherapyTypes legacy text (when SpecialtyTypeId is null)"
+echo "    3. \"N/A\" (when both are null/empty)"
+echo "=================================================================="
+curl -sS -w "\nHTTP %{http_code}\n" \
+    "${BASE_URL}/api/therapists/${FALLBACK_THERAPIST_ID}/statement?from=${FROM}&to=${TO}" | $PRETTY
+echo
+
+echo "=================================================================="
+echo "All WP-13B tests complete."
+echo "=================================================================="

--- a/tests/Core.Tests/Core.Tests.csproj
+++ b/tests/Core.Tests/Core.Tests.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="xunit" Version="2.5.3" />

--- a/tests/Core.Tests/TherapistStatementServiceTests.cs
+++ b/tests/Core.Tests/TherapistStatementServiceTests.cs
@@ -1,0 +1,283 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Neurocorp.Api.Core.BusinessObjects.Therapists;
+using Neurocorp.Api.Core.Entities;
+using Neurocorp.Api.Core.Interfaces.Repositories;
+using Neurocorp.Api.Core.Interfaces.Services;
+using Neurocorp.Api.Core.Services;
+
+namespace Core.Tests;
+
+public class TherapistStatementServiceTests
+{
+    private const int TherapistId = 42;
+
+    private static readonly AppointmentStatus CompletedStatus = new() { Id = 4, Name = "Completed" };
+    private static readonly AppointmentStatus CancelledStatus = new() { Id = 3, Name = "Cancelled" };
+    private static readonly AppointmentStatus NoShowStatus = new() { Id = 5, Name = "NoShow" };
+    private static readonly AppointmentStatus ScheduledStatus = new() { Id = 1, Name = "Scheduled" };
+
+    private static (
+        TherapistStatementService Service,
+        Mock<ITherapySessionRepository> SessionRepoMock
+    ) BuildService(IReadOnlyList<TherapySession> sessions)
+    {
+        var fakeLogger = Mock.Of<ILogger<TherapistStatementService>>();
+
+        var profileService = new Mock<ITherapistProfileService>();
+        profileService
+            .Setup(s => s.GetByIdAsync(TherapistId))
+            .ReturnsAsync(new TherapistProfile { TherapistId = TherapistId, TherapistName = "Smith, Jane" });
+
+        var statusRepo = new Mock<IRepository<AppointmentStatus>>();
+        statusRepo
+            .Setup(r => r.GetAllAsync())
+            .ReturnsAsync(new List<AppointmentStatus> { CompletedStatus, CancelledStatus, NoShowStatus, ScheduledStatus });
+
+        var sessionRepo = new Mock<ITherapySessionRepository>();
+        sessionRepo
+            .Setup(r => r.GetByTherapistIdAndDateRangeAsync(
+                It.IsAny<int>(), It.IsAny<DateOnly>(), It.IsAny<DateOnly>(), It.IsAny<IEnumerable<int>>()))
+            .ReturnsAsync((int _, DateOnly from, DateOnly to, IEnumerable<int> statusIds) =>
+            {
+                var ids = statusIds.ToHashSet();
+                return sessions
+                    .Where(s => s.SessionDate >= from && s.SessionDate <= to && ids.Contains(s.AppointmentStatusId))
+                    .ToList();
+            });
+
+        var service = new TherapistStatementService(
+            fakeLogger,
+            profileService.Object,
+            sessionRepo.Object,
+            statusRepo.Object);
+
+        return (service, sessionRepo);
+    }
+
+    private static Patient MakePatient(int id, string first, string last)
+    {
+        return new Patient
+        {
+            Id = id,
+            User = new User { Id = id * 100, FirstName = first, LastName = last, MiddleName = string.Empty }
+        };
+    }
+
+    private static TherapySession MakeSession(
+        int id,
+        Patient patient,
+        DateOnly date,
+        TimeOnly time,
+        AppointmentStatus status,
+        decimal amount = 100m,
+        decimal discount = 0m,
+        decimal providerAmount = 60m,
+        SpecialtyType? specialty = null,
+        string? legacyTherapyTypes = null)
+    {
+        return new TherapySession
+        {
+            Id = id,
+            PatientId = patient.Id,
+            Patient = patient,
+            TherapistId = TherapistId,
+            SessionDate = date,
+            SessionTime = time,
+            AppointmentStatusId = status.Id,
+            AppointmentStatus = status,
+            Amount = amount,
+            DiscountAmount = discount,
+            ProviderAmount = providerAmount,
+            SpecialtyType = specialty,
+            SpecialtyTypeId = specialty?.Id,
+            TherapyTypes = legacyTherapyTypes ?? string.Empty,
+        };
+    }
+
+    [Fact]
+    public async Task GetStatementAsync_ReturnsNull_WhenTherapistNotFound()
+    {
+        // Arrange
+        var fakeLogger = Mock.Of<ILogger<TherapistStatementService>>();
+        var profileService = new Mock<ITherapistProfileService>();
+        profileService.Setup(s => s.GetByIdAsync(It.IsAny<int>())).ReturnsAsync((TherapistProfile?)null);
+        var statusRepo = new Mock<IRepository<AppointmentStatus>>();
+        var sessionRepo = new Mock<ITherapySessionRepository>();
+        var service = new TherapistStatementService(fakeLogger, profileService.Object, sessionRepo.Object, statusRepo.Object);
+
+        // Act
+        var result = await service.GetStatementAsync(999, null, null);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetStatementAsync_Throws_WhenToBeforeFrom()
+    {
+        // Arrange
+        var (service, _) = BuildService(new List<TherapySession>());
+        var from = new DateOnly(2026, 4, 10);
+        var to = new DateOnly(2026, 4, 1);
+
+        // Act
+        var act = async () => await service.GetStatementAsync(TherapistId, from, to);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task GetStatementAsync_MixedStatuses_PreservesAllRowsAndZerosOutNonBillableProvider()
+    {
+        // Arrange
+        var patient = MakePatient(1, "Alice", "Anderson");
+        var sessions = new List<TherapySession>
+        {
+            MakeSession(101, patient, new DateOnly(2026, 4, 1), new TimeOnly(9, 0), CompletedStatus,
+                amount: 100m, discount: 10m, providerAmount: 60m),
+            MakeSession(102, patient, new DateOnly(2026, 4, 2), new TimeOnly(10, 0), CancelledStatus,
+                amount: 100m, discount: 0m, providerAmount: 60m),
+            MakeSession(103, patient, new DateOnly(2026, 4, 3), new TimeOnly(11, 0), NoShowStatus,
+                amount: 100m, discount: 0m, providerAmount: 60m),
+            MakeSession(104, patient, new DateOnly(2026, 4, 4), new TimeOnly(12, 0), CompletedStatus,
+                amount: 200m, discount: 20m, providerAmount: 120m),
+        };
+        var (service, _) = BuildService(sessions);
+
+        // Act
+        var result = await service.GetStatementAsync(
+            TherapistId,
+            new DateOnly(2026, 3, 1),
+            new DateOnly(2026, 4, 30));
+
+        // Assert — (a) all rows present
+        result.Should().NotBeNull();
+        result!.Patients.Should().HaveCount(1);
+        var block = result.Patients[0];
+        block.Sessions.Should().HaveCount(4);
+
+        // (b) ProviderAmount = 0 on non-Completed rows
+        var cancelled = block.Sessions.Single(s => s.SessionId == 102);
+        var noShow = block.Sessions.Single(s => s.SessionId == 103);
+        cancelled.ProviderAmount.Should().Be(0m);
+        cancelled.IsBillable.Should().BeFalse();
+        noShow.ProviderAmount.Should().Be(0m);
+        noShow.IsBillable.Should().BeFalse();
+
+        // Completed rows retain provider amount
+        var completed1 = block.Sessions.Single(s => s.SessionId == 101);
+        var completed2 = block.Sessions.Single(s => s.SessionId == 104);
+        completed1.ProviderAmount.Should().Be(60m);
+        completed1.IsBillable.Should().BeTrue();
+        completed2.ProviderAmount.Should().Be(120m);
+        completed2.IsBillable.Should().BeTrue();
+
+        // (c) EstimatedAmountDue equals sum of Completed ProviderAmount
+        result.Summary.TotalProviderAmount.Should().Be(180m);
+        result.Summary.EstimatedAmountDue.Should().Be(180m);
+        result.Summary.TotalCompletedSessions.Should().Be(2);
+        result.Summary.TotalNonBillableSessions.Should().Be(2);
+
+        // Per-patient subtotals: SubtotalProviderAmount only sums Completed
+        block.SubtotalProviderAmount.Should().Be(180m);
+        block.CompletedCount.Should().Be(2);
+        block.NonBillableCount.Should().Be(2);
+        block.SubtotalFee.Should().Be(500m);       // 100+100+100+200
+        block.SubtotalDiscount.Should().Be(30m);   // 10+0+0+20
+
+        // Pro-forma flag + empty ServicePayments
+        result.IsProForma.Should().BeTrue();
+        result.ServicePayments.Should().BeEmpty();
+        result.Summary.TotalServicePaymentsApplied.Should().Be(0m);
+    }
+
+    [Fact]
+    public async Task GetStatementAsync_TherapyTypeFallbackChain_ResolvesAllThreeBranches()
+    {
+        // Arrange — build one session per branch of the fallback chain
+        var specialty = new SpecialtyType { Id = 7, Name = "Speech Therapy" };
+        var patient = MakePatient(1, "Alice", "Anderson");
+
+        var sessions = new List<TherapySession>
+        {
+            // Branch 1: SpecialtyType set → use SpecialtyType.Name
+            MakeSession(201, patient, new DateOnly(2026, 4, 1), new TimeOnly(9, 0), CompletedStatus,
+                specialty: specialty,
+                legacyTherapyTypes: "OldLegacyValue"),
+            // Branch 2: SpecialtyType null, legacy text set → use legacy
+            MakeSession(202, patient, new DateOnly(2026, 4, 2), new TimeOnly(10, 0), CompletedStatus,
+                specialty: null,
+                legacyTherapyTypes: "Legacy ABA"),
+            // Branch 3: both null/empty → "N/A"
+            MakeSession(203, patient, new DateOnly(2026, 4, 3), new TimeOnly(11, 0), CompletedStatus,
+                specialty: null,
+                legacyTherapyTypes: null),
+        };
+        var (service, _) = BuildService(sessions);
+
+        // Act
+        var result = await service.GetStatementAsync(
+            TherapistId,
+            new DateOnly(2026, 3, 1),
+            new DateOnly(2026, 4, 30));
+
+        // Assert
+        result.Should().NotBeNull();
+        var rows = result!.Patients.Single().Sessions;
+
+        rows.Single(r => r.SessionId == 201).TherapyType.Should().Be("Speech Therapy");
+        rows.Single(r => r.SessionId == 202).TherapyType.Should().Be("Legacy ABA");
+        rows.Single(r => r.SessionId == 203).TherapyType.Should().Be("N/A");
+    }
+
+    [Fact]
+    public async Task GetStatementAsync_GroupsByPatient_AndSortsBlocksAlphabetically()
+    {
+        // Arrange — two patients, intentionally inserted out of alphabetical order
+        var patientB = MakePatient(1, "Bob", "Brown");
+        var patientA = MakePatient(2, "Alice", "Anderson");
+        var sessions = new List<TherapySession>
+        {
+            MakeSession(301, patientB, new DateOnly(2026, 4, 1), new TimeOnly(9, 0), CompletedStatus, providerAmount: 50m),
+            MakeSession(302, patientA, new DateOnly(2026, 4, 2), new TimeOnly(9, 0), CompletedStatus, providerAmount: 70m),
+            MakeSession(303, patientA, new DateOnly(2026, 4, 1), new TimeOnly(8, 0), CompletedStatus, providerAmount: 30m),
+        };
+        var (service, _) = BuildService(sessions);
+
+        // Act
+        var result = await service.GetStatementAsync(
+            TherapistId,
+            new DateOnly(2026, 3, 1),
+            new DateOnly(2026, 4, 30));
+
+        // Assert
+        result!.Patients.Should().HaveCount(2);
+        result.Patients[0].PatientName.Should().StartWith("Anderson");
+        result.Patients[1].PatientName.Should().StartWith("Brown");
+
+        // Within Anderson, sessions sorted by date then time
+        var andersonSessions = result.Patients[0].Sessions;
+        andersonSessions[0].SessionId.Should().Be(303); // 4/1 08:00
+        andersonSessions[1].SessionId.Should().Be(302); // 4/2 09:00
+    }
+
+    [Fact]
+    public async Task GetStatementAsync_AlwaysSetsIsProFormaTrue_AndReturnsEmptyServicePayments()
+    {
+        // Arrange — empty session set
+        var (service, _) = BuildService(new List<TherapySession>());
+
+        // Act
+        var result = await service.GetStatementAsync(TherapistId, null, null);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.IsProForma.Should().BeTrue();
+        result.ServicePayments.Should().NotBeNull();
+        result.ServicePayments.Should().BeEmpty();
+        result.Summary.EstimatedAmountDue.Should().Be(0m);
+    }
+}

--- a/tests/Web.Tests/TherapistsControllerTests.cs
+++ b/tests/Web.Tests/TherapistsControllerTests.cs
@@ -17,6 +17,7 @@ public class TherapistsControllerTests
 {
     private readonly Mock<ITherapistProfileService> _mockService;
     private readonly Mock<IHandleSessionEvent> _mockSessionEventHandler;
+    private readonly Mock<ITherapistStatementService> _mockStatementService;
     private readonly TherapistsController _controller;
 
     public TherapistsControllerTests()
@@ -24,7 +25,12 @@ public class TherapistsControllerTests
         var fakeLogger = Mock.Of<ILogger<TherapistsController>>();
         _mockService = new Mock<ITherapistProfileService>();
         _mockSessionEventHandler = new Mock<IHandleSessionEvent>();
-        _controller = new TherapistsController(fakeLogger, _mockService.Object, _mockSessionEventHandler.Object);
+        _mockStatementService = new Mock<ITherapistStatementService>();
+        _controller = new TherapistsController(
+            fakeLogger,
+            _mockService.Object,
+            _mockSessionEventHandler.Object,
+            _mockStatementService.Object);
     }
 
     [Fact]


### PR DESCRIPTION
Adds GET /api/therapists/{id}/statement?from&to returning a per-therapist, date-range report grouped by patient. Estimated amount due is computed as the sum of ProviderAmount across Completed sessions in the period.

Decisions locked in this WP:
- Status filter resolves the ids for "Completed", "Cancelled", "NoShow" by name from the AppointmentStatus lookup at request time (no hardcoded ids). Cancelled/NoShow rows are returned with providerAmount=0 and isBillable=false so the UI can show them grayed-out without dropping context.
- Therapy Type fallback chain: SpecialtyType.Name -> legacy TherapyTypes text column -> "N/A". Differs from AccountStatementService which uses the legacy column unconditionally; the FK-resolved name is preferred for new reports.
- IsProForma is hard-coded true and ServicePayments[] is always empty in this WP. The shape is reserved for the Therapist Payroll WP (WP-14) which will introduce a ServicePayment table and flip the flag.
- Controller wraps the action body in try-catch, returning 400 for ArgumentException; an explicit to<from guard short-circuits before the service call.

Repository: adds GetByTherapistIdAndDateRangeAsync that takes a status-id set and eager-loads Patient.User, SpecialtyType, and AppointmentStatus. Existing GetByTherapistAndDateRangeAsync was left untouched (different shape and call sites).

Tests: 5 new unit tests in TherapistStatementServiceTests covering not-found, to<from, mixed-status math, therapy-type fallback chain, and patient/session sort order. Added FluentAssertions 6.12.0 to Core.Tests.csproj to match the Web.Tests testing idiom.

Test artifact: test-scripts/wp-13b-therapist-statement.sh covers happy path (default + explicit range), empty range, mixed-status, 404, 400 on to<from, 400 on malformed date, and therapy-type fallback inspection.

Build: 0 warnings, 0 errors. Tests: 190 passed, 0 failed.