### PR TITLE
Fix DB-API audit findings: audit cols + nullable hygiene

### DIFF
--- a/src/Core/BusinessObjects/Patients/CaretakerProfile.cs
+++ b/src/Core/BusinessObjects/Patients/CaretakerProfile.cs
@@ -5,16 +5,14 @@ public class CaretakerProfile
     public CaretakerProfile()
     {
         this.CaretakerName = string.Empty;
-        this.Email = string.Empty;
-        this.PhoneNumber = string.Empty;
         this.Notes = string.Empty;
     }
 
     public int CaretakerId { get; set; }
     public int UserId { get; set; }
     public string CaretakerName { get; set; }
-    public string Email { get; set; }
-    public string PhoneNumber { get; set; }
+    public string? Email { get; set; }
+    public string? PhoneNumber { get; set; }
     public string Notes { get; set; }
     public DateTime CreatedTimestamp { get; set; }
     public DateTime LastUpdated { get; set; }

--- a/src/Core/BusinessObjects/Patients/PatientProfile.cs
+++ b/src/Core/BusinessObjects/Patients/PatientProfile.cs
@@ -7,21 +7,17 @@ public class PatientProfile : IProfile
     public PatientProfile()
     {
         this.PatientName = string.Empty;
-        this.MedicalRecordNumber = string.Empty;
-        this.Email = string.Empty;
-        this.PhoneNumber = string.Empty;
-        this.Gender = string.Empty;
     }
 
     public int PatientId { get; set; }
     public int UserId { get; set; }
     public string PatientName { get; set; }
-    public string MedicalRecordNumber { get; set; }
+    public string? MedicalRecordNumber { get; set; }
     public DateTime DateOfBirth { get; set; }
-    public string Email { get; set; }
-    public string PhoneNumber { get; set; }
+    public string? Email { get; set; }
+    public string? PhoneNumber { get; set; }
     public DateTime CreatedTimestamp { get; set; }
-    public string Gender { get; set; }
+    public string? Gender { get; set; }
     public bool IsActive { get; set; }
     public bool? HasCompletedDiscovery { get; set; }
     public List<PatientCaretakerSummary> Caretakers { get; set; } = new();

--- a/src/Core/BusinessObjects/Therapists/TherapistProfile.cs
+++ b/src/Core/BusinessObjects/Therapists/TherapistProfile.cs
@@ -7,8 +7,6 @@ public class TherapistProfile : IProfile
     public TherapistProfile()
     {
         TherapistName = string.Empty;
-        Email = string.Empty;
-        PhoneNumber = string.Empty;
     }
 
     public int TherapistId { get; set; }
@@ -16,8 +14,8 @@ public class TherapistProfile : IProfile
     public decimal FeePerSession { get; set; }
     public decimal FeePctPerSession { get; set; }
     public string TherapistName { get; set; }
-    public string Email { get; set; }
-    public string PhoneNumber { get; set; }
+    public string? Email { get; set; }
+    public string? PhoneNumber { get; set; }
     public DateTime CreatedTimestamp    { get; set; }
     public bool IsActive { get; set; }
     public List<TherapistSpecialtyItem> Specialties { get; set; } = [];

--- a/src/Core/Entities/Patient.cs
+++ b/src/Core/Entities/Patient.cs
@@ -6,13 +6,11 @@ public class Patient : PersonBase
 {
     public Patient()
     {
-        this.Gender = string.Empty;
-        this.MedicalRecordNumber = string.Empty;
     }
 
     public DateTime? DateOfBirth { get; set; }
-    public string Gender { get; set; }
-    public string MedicalRecordNumber { get; set; }
+    public string? Gender { get; set; }
+    public string? MedicalRecordNumber { get; set; }
     public ICollection<PatientCaretaker>? Caretakers { get; set; }
 
     public bool HasTemporaryMrn()

--- a/src/Core/Entities/Payment.cs
+++ b/src/Core/Entities/Payment.cs
@@ -2,14 +2,13 @@ using System.Collections.Generic;
 
 namespace Neurocorp.Api.Core.Entities;
 
-public class Payment
+public class Payment : AuditableEntityBase
 {
     public Payment()
     {
         this.Caretaker = null!;
         this.SessionPayments = [];
     }
-    public int Id { get; set; }
     public int CaretakerId { get; set; }
     public Caretaker Caretaker { get; set; }
     public int PaymentTypeId { get; set; }

--- a/src/Core/Entities/SessionPayment.cs
+++ b/src/Core/Entities/SessionPayment.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace Neurocorp.Api.Core.Entities;
 
-public class SessionPayment
+public class SessionPayment : AuditableEntityBase
 {
     public SessionPayment()
     {
@@ -10,7 +10,6 @@ public class SessionPayment
         this.TherapySession = null!;
     }
 
-    public int Id { get; set; }
     public int PaymentId { get; set; }
     public Payment Payment { get; set; }
     public int TherapySessionId { get; set; }

--- a/src/Core/Entities/User.cs
+++ b/src/Core/Entities/User.cs
@@ -8,27 +8,26 @@ public class User : PersonBase
     {
         this.FirstName = string.Empty;
         this.LastName = string.Empty;
-        this.MiddleName = string.Empty;
-        this.Email = string.Empty;
-        this.PhoneNumber = string.Empty;
         this.ActiveStatus = false;
         this.CreatedTimestamp = DateTime.UtcNow;
     }
 
     public string FirstName { get; set; }
-    public string MiddleName { get; set; }
+    public string? MiddleName { get; set; }
     public string LastName { get; set; }
-    public string Email { get; set; }
-    public string PhoneNumber { get; set; }
+    public string? Email { get; set; }
+    public string? PhoneNumber { get; set; }
     public bool ActiveStatus { get; set; }
 
     public string GetFullName()
     {
-        return $"{LastName.Trim()}, {FirstName.Trim()} {MiddleName.Trim()}".Trim();
+        var middle = MiddleName?.Trim();
+        var head = $"{LastName.Trim()}, {FirstName.Trim()}";
+        return string.IsNullOrEmpty(middle) ? head : $"{head} {middle}";
     }
     
     public override string ToString()
     {
-        return $"ID: {this.Id} FN: {this.FirstName} MN: {this.MiddleName} LN: {this.LastName} e: {this.Email} p: {this.PhoneNumber} cr: {this.CreatedTimestamp.ToShortDateString()} Active: {this.ActiveStatus}";
+        return $"ID: {this.Id} FN: {this.FirstName} MN: {this.MiddleName ?? string.Empty} LN: {this.LastName} e: {this.Email ?? string.Empty} p: {this.PhoneNumber ?? string.Empty} cr: {this.CreatedTimestamp.ToShortDateString()} Active: {this.ActiveStatus}";
     }
 }

--- a/src/Core/Services/PatientProfileService.cs
+++ b/src/Core/Services/PatientProfileService.cs
@@ -104,7 +104,7 @@ public class PatientProfileService : IPatientProfileService
         if (profileOnFile != null)
         {
             if (updateRequest.ActiveStatus
-                && profileOnFile.MedicalRecordNumber.StartsWith("TEMP-", StringComparison.OrdinalIgnoreCase))
+                && (profileOnFile.MedicalRecordNumber?.StartsWith("TEMP-", StringComparison.OrdinalIgnoreCase) ?? false))
             {
                 throw new InvalidOperationException(
                     "Cannot activate a patient with a temporary Medical Record Number. Assign a permanent MRN first.");

--- a/tests/Infrastructure.Tests/PaymentEntityMappingTests.cs
+++ b/tests/Infrastructure.Tests/PaymentEntityMappingTests.cs
@@ -213,6 +213,49 @@ public class PaymentEntityMappingTests
     }
 
     [Fact]
+    public async Task Payment_AuditColumns_AreStamped_OnSave()
+    {
+        var options = CreateInMemoryOptions("Payment_AuditColumns_AreStamped_OnSave");
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            context.Caretakers.Add(new Caretaker
+            {
+                Id = 1,
+                Notes = "Test caretaker",
+                User = new User { Id = 1, FirstName = "Audit", LastName = "Tester" }
+            });
+            context.PaymentTypes.Add(new PaymentType { Id = 1, Abbreviation = "CSH", Name = "Cash" });
+            await context.SaveChangesAsync();
+        }
+
+        DateTime before;
+        using (var context = new ApplicationDbContext(options))
+        {
+            before = DateTime.UtcNow;
+            context.Payments.Add(new Payment
+            {
+                Id = 1,
+                CaretakerId = 1,
+                PaymentTypeId = 1,
+                Amount = 250.00m,
+                PaymentDate = before
+            });
+            await context.SaveChangesAsync();
+        }
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            var payment = await context.Payments.FindAsync(1);
+            Assert.NotNull(payment);
+            Assert.NotEqual(default, payment.CreatedTimestamp);
+            Assert.NotEqual(default, payment.LastUpdatedTimestamp);
+            Assert.True(payment.CreatedTimestamp >= before.AddSeconds(-1));
+            Assert.True(payment.LastUpdatedTimestamp >= before.AddSeconds(-1));
+        }
+    }
+
+    [Fact]
     public async Task Payment_CheckNumber_CanBeNull()
     {
         // Arrange

--- a/tests/Infrastructure.Tests/SessionPaymentEntityMappingTests.cs
+++ b/tests/Infrastructure.Tests/SessionPaymentEntityMappingTests.cs
@@ -166,6 +166,68 @@ public class SessionPaymentEntityMappingTests
     }
 
     [Fact]
+    public async Task SessionPayment_AuditColumns_AreStamped_OnSave()
+    {
+        var options = CreateInMemoryOptions("SessionPayment_AuditColumns_AreStamped_OnSave");
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            context.Caretakers.Add(new Caretaker
+            {
+                Id = 1,
+                Notes = "Test",
+                User = new User { Id = 1, FirstName = "Audit", LastName = "Tester" }
+            });
+            context.PaymentTypes.Add(new PaymentType { Id = 1, Abbreviation = "CSH", Name = "Cash" });
+            context.Patients.Add(new Patient { Id = 1, User = new User { Id = 2, FirstName = "P", LastName = "X" } });
+            context.Therapists.Add(new Therapist { Id = 1, User = new User { Id = 3, FirstName = "T", LastName = "Y" } });
+            context.TherapySessions.Add(new TherapySession
+            {
+                Id = 1,
+                PatientId = 1,
+                TherapistId = 1,
+                SessionDate = DateOnly.FromDateTime(DateTime.UtcNow),
+                SessionTime = TimeOnly.FromDateTime(DateTime.UtcNow),
+                Amount = 100m,
+                Notes = "Test"
+            });
+            context.Payments.Add(new Payment
+            {
+                Id = 1,
+                CaretakerId = 1,
+                PaymentTypeId = 1,
+                Amount = 100m,
+                PaymentDate = DateTime.UtcNow
+            });
+            await context.SaveChangesAsync();
+        }
+
+        DateTime before;
+        using (var context = new ApplicationDbContext(options))
+        {
+            before = DateTime.UtcNow;
+            context.SessionPayments.Add(new SessionPayment
+            {
+                Id = 1,
+                PaymentId = 1,
+                TherapySessionId = 1,
+                AmountAllocated = 100m
+            });
+            await context.SaveChangesAsync();
+        }
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            var sp = await context.SessionPayments.FindAsync(1);
+            Assert.NotNull(sp);
+            Assert.NotEqual(default, sp.CreatedTimestamp);
+            Assert.NotEqual(default, sp.LastUpdatedTimestamp);
+            Assert.True(sp.CreatedTimestamp >= before.AddSeconds(-1));
+            Assert.True(sp.LastUpdatedTimestamp >= before.AddSeconds(-1));
+        }
+    }
+
+    [Fact]
     public async Task SessionPayment_NavigationProperties_LoadCorrectly()
     {
         // Arrange


### PR DESCRIPTION
Source audit: patient-care-super/planning/audits/audit-db-api-2026-05-16.md

- Payment + SessionPayment inherit AuditableEntityBase so SaveChanges() audit-stamp logic actually stamps these tables (previously the columns were populated only by MySQL DEFAULTs and LastUpdatedByUserId stayed 0).
- Nullable hygiene on User (MiddleName, Email, PhoneNumber) and Patient (Gender, MedicalRecordNumber) to match the DB schema. Updated GetFullName() and dependent profile DTOs (PatientProfile, CaretakerProfile, TherapistProfile) so nullable values propagate cleanly. JSON output now emits null instead of "" for these fields.
- Added unit tests verifying audit columns are stamped on Payment and SessionPayment saves.

Tests: 192 passed, 0 failed.