### PR TITLE
Remediation 2026 Chunk 1B: API authentication & claims-aware authoriz…

### DIFF
--- a/docs/auth-1b-verification.md
+++ b/docs/auth-1b-verification.md
@@ -1,0 +1,239 @@
+# Auth Verification — Remediation 2026, Chunk 1B (API Authentication)
+
+This document contains copy-paste `curl` commands to verify the authentication and
+claims-aware authorization foundation delivered in Chunk 1B. Keep it for re-testing after
+future auth changes.
+
+> Commands use `curl.exe` so they work in both PowerShell and bash. `jq` is optional (only
+> used to pretty-print / extract the token). Replace values in `<angle brackets>`.
+
+## Prerequisites
+
+1. **Database** is up and migration **V017** has been applied (auth columns + RoleClaim/UserClaim).
+2. **SA bootstrap** has been run: `patient-care-db/scripts/bootstrap-sa.sql`
+   (see `patient-care-db/docs/runbooks/bootstrap-sa.md`). You know the SA's temporary password.
+3. **API is running**:
+   ```bash
+   dotnet run --project src/Web/Web.csproj    # http://localhost:5245
+   ```
+   For local runs without a configured key, a development-only JWT signing key is used
+   automatically. In any non-development environment set `JWT_SIGNING_KEY` first.
+
+```bash
+# Base URL used throughout
+BASE=http://localhost:5245
+```
+
+---
+
+## 1. Health endpoints are public (no token) → 200
+
+```bash
+curl.exe -i $BASE/api/health/live
+```
+**Expect:** `200 OK`, body `Alive`. (Health is marked `[AllowAnonymous]`.)
+
+## 2. A protected endpoint with NO token → 401 + ProblemDetails
+
+```bash
+curl.exe -i $BASE/api/patients
+```
+**Expect:** `401 Unauthorized`, `Content-Type: application/problem+json`, body like:
+```json
+{"type":"https://httpstatuses.io/401","title":"Unauthorized","status":401,"detail":"Authentication is required to access this resource."}
+```
+
+## 3. SA login → access + refresh tokens
+
+```bash
+curl.exe -i -X POST $BASE/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d "{\"email\":\"anibalvelarde+sa@gmail.com\",\"password\":\"<SA_TEMP_PASSWORD>\"}"
+```
+**Expect:** `200 OK` with:
+```json
+{"accessToken":"eyJ...","refreshToken":"eyJ...","tokenType":"Bearer","expiresIn":3600,"mustChangePassword":true}
+```
+
+Capture the access token into a variable:
+```bash
+SA_TOKEN=$(curl.exe -s -X POST $BASE/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d "{\"email\":\"anibalvelarde+sa@gmail.com\",\"password\":\"<SA_TEMP_PASSWORD>\"}" \
+  | jq -r .accessToken)
+echo "$SA_TOKEN"
+```
+
+## 4. Confirm the token carries ('System','FullAccess')
+
+Decode the JWT payload (middle segment). With `jq`:
+```bash
+echo "$SA_TOKEN" | cut -d. -f2 | tr '_-' '/+' | base64 -d 2>/dev/null | jq .
+```
+**Expect:** a `"System": "FullAccess"` claim (plus `uid`, `name`, `role`, etc.).
+You can also paste the token into https://jwt.io to inspect it.
+
+## 5. SA reaches the convenience identity endpoint
+
+```bash
+curl.exe -s $BASE/api/auth/me -H "Authorization: Bearer $SA_TOKEN" | jq .
+```
+**Expect:** `200 OK`, `"isSystemAdmin": true`, roles include `SystemAdmin`, and the claims
+array contains `{"type":"System","value":"FullAccess"}`.
+
+## 6. SA reaches protected endpoints across multiple controllers → 200
+
+```bash
+curl.exe -i $BASE/api/patients -H "Authorization: Bearer $SA_TOKEN"
+curl.exe -i $BASE/api/sites    -H "Authorization: Bearer $SA_TOKEN"
+curl.exe -i $BASE/api/therapists -H "Authorization: Bearer $SA_TOKEN"
+```
+**Expect:** `200 OK` for each (the wildcard satisfies the authenticated-user fallback policy).
+
+## 7. SA passes the claims-gated endpoint → 200
+
+```bash
+curl.exe -i $BASE/api/auth/admin-check -H "Authorization: Bearer $SA_TOKEN"
+```
+**Expect:** `200 OK`, message confirming System.FullAccess access. This endpoint requires the
+`System.Diagnostics` permission, which no role is granted by default — only the SA wildcard passes.
+
+## 8. A non-SA authenticated user is correctly denied the claims-gated endpoint → 403
+
+> Requires a second, non-SA user with a known password. Create one with the helper hash and a
+> direct insert, or reuse an existing staff account once its password is set. Example setup:
+> ```bash
+> # 1) hash a password
+> dotnet run --project tools/SaPasswordHasher -- "<StaffPassword>"
+> # 2) set it on an existing active SystemUser (no SYSADMIN role), e.g. via mysql:
+> #    UPDATE SystemUser SET PasswordHash='PBKDF2$...', MustChangePassword=0 WHERE Email='<staff email>';
+> ```
+
+```bash
+STAFF_TOKEN=$(curl.exe -s -X POST $BASE/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d "{\"email\":\"<STAFF_EMAIL>\",\"password\":\"<StaffPassword>\"}" | jq -r .accessToken)
+
+# Authenticated, so a normal protected endpoint works:
+curl.exe -i $BASE/api/patients -H "Authorization: Bearer $STAFF_TOKEN"      # → 200
+
+# But the claims-gated endpoint is forbidden:
+curl.exe -i $BASE/api/auth/admin-check -H "Authorization: Bearer $STAFF_TOKEN"   # → 403 problem+json
+```
+**Expect:** `200` for `/api/patients`, `403 Forbidden` (`application/problem+json`) for
+`/api/auth/admin-check`.
+
+## 9. Invalid credentials → 401 (and no user enumeration)
+
+```bash
+curl.exe -i -X POST $BASE/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d "{\"email\":\"anibalvelarde+sa@gmail.com\",\"password\":\"wrong\"}"
+```
+**Expect:** `401`, generic detail `Invalid email or password.` (same message for unknown emails).
+
+## 10. Refresh the access token
+
+```bash
+REFRESH=$(curl.exe -s -X POST $BASE/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d "{\"email\":\"anibalvelarde+sa@gmail.com\",\"password\":\"<SA_TEMP_PASSWORD>\"}" | jq -r .refreshToken)
+
+curl.exe -s -X POST $BASE/api/auth/refresh \
+  -H "Content-Type: application/json" \
+  -d "{\"refreshToken\":\"$REFRESH\"}" | jq .
+```
+**Expect:** `200 OK` with a new `accessToken` / `refreshToken` pair. An access token used here is
+rejected (`401`) because it lacks the `typ=refresh` marker.
+
+## 11. Change password (clears must-change + rotates tokens)
+
+```bash
+curl.exe -i -X POST $BASE/api/auth/change-password \
+  -H "Authorization: Bearer $SA_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{\"currentPassword\":\"<SA_TEMP_PASSWORD>\",\"newPassword\":\"<NewStrongPassword>\"}"
+```
+**Expect:** `200 OK` with a fresh token pair and `mustChangePassword: false`. Subsequent logins
+must use the new password.
+
+## 12. Evidence that `LastUpdatedByUserId` is now the real user
+
+After authenticating as the SA, perform any write (e.g. update a patient) and inspect the row:
+
+```bash
+# Example write as the SA:
+curl.exe -i -X PUT $BASE/api/patients/<id> \
+  -H "Authorization: Bearer $SA_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{ ...patient update body... }"
+```
+Then in the DB:
+```sql
+SELECT PatientID, LastUpdatedByUserId, LastUpdatedTimestamp
+FROM Patient WHERE PatientID = <id>;
+```
+**Expect:** `LastUpdatedByUserId` equals the SA's `UserID` (previously always `0`).
+
+## 13. Must-change-password is enforced server-side (not advisory)
+
+Per the locked design (`remediation-2026-system-admin-bootstrap.md`): *"the first login must force a
+password change before any other actions are allowed (this is an API + UI requirement)."* This
+proves the API — not just the UI — restricts a must-change session to the password-change flow.
+
+Pick a non-SA test user and set the flag directly in the DB:
+```sql
+UPDATE SystemUser SET MustChangePassword = 1 WHERE Email = '<test email>';
+```
+
+Log in and capture the token (note `"mustChangePassword": true` in the response):
+```bash
+MC_TOKEN=$(curl.exe -s -X POST $BASE/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d "{\"email\":\"<test email>\",\"password\":\"<password>\"}" | jq -r .accessToken)
+```
+
+A normal protected endpoint is now BLOCKED:
+```bash
+curl.exe -i $BASE/api/patients -H "Authorization: Bearer $MC_TOKEN"
+```
+**Expect:** `403 Forbidden`, `application/problem+json`, body containing
+`"code":"password_change_required"` and title `Password change required`.
+
+But the allowlisted endpoints still work, so the user can resolve it:
+```bash
+curl.exe -i $BASE/api/auth/me            -H "Authorization: Bearer $MC_TOKEN"   # → 200
+curl.exe -i -X POST $BASE/api/auth/change-password \
+  -H "Authorization: Bearer $MC_TOKEN" -H "Content-Type: application/json" \
+  -d "{\"currentPassword\":\"<password>\",\"newPassword\":\"<NewStrongPassword>\"}"   # → 200, new tokens
+```
+**Expect:** `/api/auth/me` → `200`; `change-password` → `200` with a fresh token pair and
+`mustChangePassword: false`. The new access token has the marker dropped, so a protected call now
+succeeds:
+```bash
+NEW_TOKEN=$(curl.exe -s -X POST $BASE/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d "{\"email\":\"<test email>\",\"password\":\"<NewStrongPassword>\"}" | jq -r .accessToken)
+curl.exe -i $BASE/api/patients -H "Authorization: Bearer $NEW_TOKEN"   # → 200
+```
+**Expect:** `200 OK` — the gate clears automatically once the password is changed.
+
+---
+
+## Summary of expected results
+
+| # | Scenario | Expected |
+|---|----------|----------|
+| 1 | Health, no token | 200 |
+| 2 | Protected endpoint, no token | 401 + problem+json |
+| 3 | SA login | 200 + tokens |
+| 4 | Token claims | contains `System=FullAccess` |
+| 5 | `/api/auth/me` as SA | 200, `isSystemAdmin: true` |
+| 6 | Protected endpoints as SA | 200 |
+| 7 | `/api/auth/admin-check` as SA | 200 |
+| 8 | `/api/auth/admin-check` as non-SA | 403; business endpoint 200 |
+| 9 | Bad password | 401, generic message |
+| 10 | Refresh | 200 + new tokens |
+| 11 | Change password | 200, `mustChangePassword: false` |
+| 12 | Audit stamping | `LastUpdatedByUserId` = real user id |
+| 13 | Must-change-password enforced | protected → 403 `password_change_required`; `me`/`change-password` → 200; cleared after change |

--- a/src/Core/Authorization/SystemClaims.cs
+++ b/src/Core/Authorization/SystemClaims.cs
@@ -1,0 +1,35 @@
+namespace Neurocorp.Api.Core.Authorization;
+
+/// <summary>
+/// Well-known authorization claim constants shared across layers.
+///
+/// The platform is claims-aware: a permission is a (<see cref="PermissionClaimType"/>, value)
+/// pair such as ("Permission", "Patients.FullAccess"). The single god-mode claim
+/// (<see cref="SystemClaimType"/> = <see cref="FullAccessValue"/>) acts as a wildcard that
+/// satisfies every policy. Per the locked design it is granted ONLY to the SystemAdmin role.
+/// See remediation-2026-system-admin-bootstrap.md.
+/// </summary>
+public static class SystemClaims
+{
+    /// <summary>Claim type for the god-mode wildcard.</summary>
+    public const string SystemClaimType = "System";
+
+    /// <summary>Claim value that grants unrestricted access.</summary>
+    public const string FullAccessValue = "FullAccess";
+
+    /// <summary>Conventional claim type for granular permissions.</summary>
+    public const string PermissionClaimType = "Permission";
+
+    /// <summary>Custom JWT claim carrying the authenticated user's SystemUser.UserID.</summary>
+    public const string UserIdClaimType = "uid";
+
+    /// <summary>
+    /// Custom JWT claim present (value "true") when the user still owes a password change.
+    /// While set, <c>PasswordChangeRequiredMiddleware</c> blocks all but the change-password flow.
+    /// The claim disappears automatically once the password is changed (tokens are re-issued).
+    /// </summary>
+    public const string MustChangePasswordClaimType = "mcp";
+
+    /// <summary>Value emitted for <see cref="MustChangePasswordClaimType"/> when a change is owed.</summary>
+    public const string MustChangePasswordValue = "true";
+}

--- a/src/Core/BusinessObjects/Auth/AuthResult.cs
+++ b/src/Core/BusinessObjects/Auth/AuthResult.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+
+namespace Neurocorp.Api.Core.BusinessObjects.Auth;
+
+/// <summary>
+/// Internal result of an authentication operation (login / refresh / change-password).
+/// The controller translates a successful result into an <see cref="AuthTokenResponse"/>.
+/// </summary>
+public class AuthResult
+{
+    public bool Succeeded { get; init; }
+    public string? Error { get; init; }
+    public string? AccessToken { get; init; }
+    public string? RefreshToken { get; init; }
+    public int ExpiresInSeconds { get; init; }
+    public bool MustChangePassword { get; init; }
+
+    public static AuthResult Fail(string error) => new() { Succeeded = false, Error = error };
+
+    public static AuthResult Success(string accessToken, string refreshToken, int expiresInSeconds, bool mustChangePassword) =>
+        new()
+        {
+            Succeeded = true,
+            AccessToken = accessToken,
+            RefreshToken = refreshToken,
+            ExpiresInSeconds = expiresInSeconds,
+            MustChangePassword = mustChangePassword
+        };
+}

--- a/src/Core/BusinessObjects/Auth/AuthTokenResponse.cs
+++ b/src/Core/BusinessObjects/Auth/AuthTokenResponse.cs
@@ -1,0 +1,11 @@
+namespace Neurocorp.Api.Core.BusinessObjects.Auth;
+
+/// <summary>API-facing response returned by login / refresh.</summary>
+public class AuthTokenResponse
+{
+    public string AccessToken { get; set; } = string.Empty;
+    public string RefreshToken { get; set; } = string.Empty;
+    public string TokenType { get; set; } = "Bearer";
+    public int ExpiresIn { get; set; }
+    public bool MustChangePassword { get; set; }
+}

--- a/src/Core/BusinessObjects/Auth/ChangePasswordRequest.cs
+++ b/src/Core/BusinessObjects/Auth/ChangePasswordRequest.cs
@@ -1,0 +1,7 @@
+namespace Neurocorp.Api.Core.BusinessObjects.Auth;
+
+public class ChangePasswordRequest
+{
+    public string CurrentPassword { get; set; } = string.Empty;
+    public string NewPassword { get; set; } = string.Empty;
+}

--- a/src/Core/BusinessObjects/Auth/ClaimDto.cs
+++ b/src/Core/BusinessObjects/Auth/ClaimDto.cs
@@ -1,0 +1,9 @@
+namespace Neurocorp.Api.Core.BusinessObjects.Auth;
+
+/// <summary>
+/// A portable representation of a single authorization claim (type + value).
+/// Used to move effective claims between the data layer, the token layer, and the API
+/// without coupling Core to any specific token library. Record equality makes set
+/// operations (union / except for denials) straightforward.
+/// </summary>
+public sealed record ClaimDto(string Type, string Value);

--- a/src/Core/BusinessObjects/Auth/CurrentUserResponse.cs
+++ b/src/Core/BusinessObjects/Auth/CurrentUserResponse.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+
+namespace Neurocorp.Api.Core.BusinessObjects.Auth;
+
+/// <summary>The authenticated caller's identity, roles, and effective claims.</summary>
+public class CurrentUserResponse
+{
+    public int UserId { get; set; }
+    public string? Email { get; set; }
+    public string FullName { get; set; } = string.Empty;
+    public bool MustChangePassword { get; set; }
+    public IReadOnlyList<string> Roles { get; set; } = new List<string>();
+    public IReadOnlyList<ClaimDto> Claims { get; set; } = new List<ClaimDto>();
+    public bool IsSystemAdmin { get; set; }
+}

--- a/src/Core/BusinessObjects/Auth/LoginRequest.cs
+++ b/src/Core/BusinessObjects/Auth/LoginRequest.cs
@@ -1,0 +1,7 @@
+namespace Neurocorp.Api.Core.BusinessObjects.Auth;
+
+public class LoginRequest
+{
+    public string Email { get; set; } = string.Empty;
+    public string Password { get; set; } = string.Empty;
+}

--- a/src/Core/BusinessObjects/Auth/RefreshTokenRequest.cs
+++ b/src/Core/BusinessObjects/Auth/RefreshTokenRequest.cs
@@ -1,0 +1,6 @@
+namespace Neurocorp.Api.Core.BusinessObjects.Auth;
+
+public class RefreshTokenRequest
+{
+    public string RefreshToken { get; set; } = string.Empty;
+}

--- a/src/Core/Configurations/Dependencies.cs
+++ b/src/Core/Configurations/Dependencies.cs
@@ -27,6 +27,12 @@ public static class NeurocorpConfigurationExtensions
         services.AddScoped<ITreatmentPlanService, TreatmentPlanService>();
         services.AddScoped<IBulkSchedulingService, BulkSchedulingService>();
         services.AddScoped<IScheduleMatrixService, ScheduleMatrixService>();
+
+        // Authentication / authorization (Chunk 1B). Token + current-user
+        // implementations live in the Web layer (composition root) because they
+        // depend on JWT and HttpContext; the orchestration + hashing are here.
+        services.AddScoped<IAuthService, AuthService>();
+        services.AddSingleton<IPasswordHasher, Pbkdf2PasswordHasher>();
         return services;
     }
 }

--- a/src/Core/Entities/RoleClaim.cs
+++ b/src/Core/Entities/RoleClaim.cs
@@ -1,0 +1,13 @@
+namespace Neurocorp.Api.Core.Entities;
+
+/// <summary>
+/// A default claim granted to a role (role-level claim mapping). Maps to the
+/// <c>RoleClaim</c> table created in migration V017. Every user assigned the role
+/// inherits these claims. See <see cref="UserClaim"/> for per-user overrides.
+/// </summary>
+public class RoleClaim : AuditableEntityBase
+{
+    public int RoleId { get; set; }
+    public string ClaimType { get; set; } = string.Empty;
+    public string ClaimValue { get; set; } = string.Empty;
+}

--- a/src/Core/Entities/User.cs
+++ b/src/Core/Entities/User.cs
@@ -19,6 +19,19 @@ public class User : PersonBase
     public string? PhoneNumber { get; set; }
     public bool ActiveStatus { get; set; }
 
+    // --- Authentication columns (added in DB migration V017 / Chunk 1A) ---
+    // Local password authentication. Null for users that authenticate only via an external IdP.
+    public string? PasswordHash { get; set; }
+    public string? PasswordSalt { get; set; }
+    public DateTime? PasswordChangedAt { get; set; }
+    public bool MustChangePassword { get; set; }
+    public DateTime? LastLoginAt { get; set; }
+    public int FailedLoginAttempts { get; set; }
+    public DateTime? LockoutUntil { get; set; }
+    // External IdP identity (forward-looking; unused until a future IdP migration).
+    public string? ExternalSubject { get; set; }
+    public string? ExternalIssuer { get; set; }
+
     public string GetFullName()
     {
         var middle = MiddleName?.Trim();

--- a/src/Core/Entities/UserClaim.cs
+++ b/src/Core/Entities/UserClaim.cs
@@ -1,0 +1,14 @@
+namespace Neurocorp.Api.Core.Entities;
+
+/// <summary>
+/// A per-user claim grant or explicit denial. Maps to the <c>UserClaim</c> table
+/// created in migration V017. When <see cref="IsDenied"/> is true the row removes a
+/// claim the user would otherwise inherit from a role; otherwise it grants an extra claim.
+/// </summary>
+public class UserClaim : AuditableEntityBase
+{
+    public int UserId { get; set; }
+    public string ClaimType { get; set; } = string.Empty;
+    public string ClaimValue { get; set; } = string.Empty;
+    public bool IsDenied { get; set; }
+}

--- a/src/Core/Interfaces/Repositories/IAuthRepository.cs
+++ b/src/Core/Interfaces/Repositories/IAuthRepository.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Neurocorp.Api.Core.BusinessObjects.Auth;
+using Neurocorp.Api.Core.Entities;
+
+namespace Neurocorp.Api.Core.Interfaces.Repositories;
+
+/// <summary>
+/// Data access for authentication and the claims-aware authorization model.
+/// Computes a user's effective claims from RoleClaim + UserClaim (with denials applied).
+/// </summary>
+public interface IAuthRepository
+{
+    Task<User?> GetByEmailAsync(string email);
+
+    Task<User?> GetByIdAsync(int id);
+
+    /// <summary>
+    /// Returns the user's effective claims:
+    /// (claims from every role in UserRole) UNION (UserClaim where IsDenied=0)
+    /// MINUS (UserClaim where IsDenied=1).
+    /// </summary>
+    Task<IReadOnlyList<ClaimDto>> GetEffectiveClaimsAsync(int userId);
+
+    Task<IReadOnlyList<string>> GetRoleNamesAsync(int userId);
+
+    /// <summary>Persists changes to a tracked user (login bookkeeping, password change).</summary>
+    Task SaveUserAsync(User user);
+}

--- a/src/Core/Interfaces/Services/IAuthService.cs
+++ b/src/Core/Interfaces/Services/IAuthService.cs
@@ -1,0 +1,17 @@
+using System.Threading.Tasks;
+using Neurocorp.Api.Core.BusinessObjects.Auth;
+
+namespace Neurocorp.Api.Core.Interfaces.Services;
+
+/// <summary>Orchestrates authentication: credential checks, token issuance, password changes.</summary>
+public interface IAuthService
+{
+    Task<AuthResult> LoginAsync(LoginRequest request);
+
+    Task<AuthResult> RefreshAsync(string refreshToken);
+
+    /// <summary>Changes the caller's password and clears the must-change / lockout flags.</summary>
+    Task<AuthResult> ChangePasswordAsync(int userId, ChangePasswordRequest request);
+
+    Task<CurrentUserResponse?> GetCurrentUserAsync(int userId);
+}

--- a/src/Core/Interfaces/Services/ICurrentUserService.cs
+++ b/src/Core/Interfaces/Services/ICurrentUserService.cs
@@ -1,0 +1,14 @@
+namespace Neurocorp.Api.Core.Interfaces.Services;
+
+/// <summary>
+/// Exposes the identity of the user making the current request. Implemented in the Web
+/// layer over <c>IHttpContextAccessor</c> and consumed by <c>ApplicationDbContext</c> so
+/// audit columns (<c>LastUpdatedByUserId</c>) are stamped with the real authenticated user.
+/// </summary>
+public interface ICurrentUserService
+{
+    /// <summary>The authenticated user's SystemUser.UserID, or null when unauthenticated.</summary>
+    int? UserId { get; }
+
+    bool IsAuthenticated { get; }
+}

--- a/src/Core/Interfaces/Services/IPasswordHasher.cs
+++ b/src/Core/Interfaces/Services/IPasswordHasher.cs
@@ -1,0 +1,11 @@
+namespace Neurocorp.Api.Core.Interfaces.Services;
+
+/// <summary>Hashes and verifies local passwords. Implementation must be salted and slow.</summary>
+public interface IPasswordHasher
+{
+    /// <summary>Produces a self-describing hash string (algorithm + parameters + salt + hash).</summary>
+    string Hash(string password);
+
+    /// <summary>Constant-time verification of a password against a stored hash.</summary>
+    bool Verify(string password, string storedHash);
+}

--- a/src/Core/Interfaces/Services/ITokenService.cs
+++ b/src/Core/Interfaces/Services/ITokenService.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using Neurocorp.Api.Core.BusinessObjects.Auth;
+
+namespace Neurocorp.Api.Core.Interfaces.Services;
+
+/// <summary>Issues and validates the application's access and refresh tokens.</summary>
+public interface ITokenService
+{
+    /// <summary>Creates a signed access token embedding the user's identity, roles, and effective claims.</summary>
+    /// <param name="mustChangePassword">
+    /// When true, the token carries the must-change-password marker so the API can restrict the
+    /// session to the password-change flow until the user updates their credentials.
+    /// </param>
+    TokenResult CreateAccessToken(
+        int userId,
+        string? email,
+        string fullName,
+        IReadOnlyCollection<ClaimDto> claims,
+        IReadOnlyCollection<string> roles,
+        bool mustChangePassword);
+
+    /// <summary>Creates a longer-lived refresh token bound to the user.</summary>
+    string CreateRefreshToken(int userId);
+
+    /// <summary>Validates a refresh token and returns the user id it was issued for, or null if invalid.</summary>
+    int? ValidateRefreshToken(string refreshToken);
+}
+
+/// <summary>A freshly minted token and how long (in seconds) it is valid.</summary>
+public sealed record TokenResult(string Token, int ExpiresInSeconds);

--- a/src/Core/Services/AuthService.cs
+++ b/src/Core/Services/AuthService.cs
@@ -1,0 +1,176 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Neurocorp.Api.Core.Authorization;
+using Neurocorp.Api.Core.BusinessObjects.Auth;
+using Neurocorp.Api.Core.Interfaces.Repositories;
+using Neurocorp.Api.Core.Interfaces.Services;
+
+namespace Neurocorp.Api.Core.Services;
+
+/// <summary>
+/// Authentication orchestration: validates credentials, applies lockout policy, issues
+/// access + refresh tokens, and handles password changes. Knows nothing about JWTs or
+/// HTTP — it depends only on Core interfaces, so the token strategy and storage are
+/// swappable (e.g. a future external IdP).
+/// </summary>
+public class AuthService : IAuthService
+{
+    private const int MaxFailedAttempts = 5;
+    private static readonly TimeSpan LockoutDuration = TimeSpan.FromMinutes(15);
+    private const int MinPasswordLength = 8;
+    private const string InvalidCredentialsMessage = "Invalid email or password.";
+
+    private readonly IAuthRepository _authRepository;
+    private readonly IPasswordHasher _passwordHasher;
+    private readonly ITokenService _tokenService;
+
+    public AuthService(IAuthRepository authRepository, IPasswordHasher passwordHasher, ITokenService tokenService)
+    {
+        _authRepository = authRepository;
+        _passwordHasher = passwordHasher;
+        _tokenService = tokenService;
+    }
+
+    public async Task<AuthResult> LoginAsync(LoginRequest request)
+    {
+        if (request is null || string.IsNullOrWhiteSpace(request.Email) || string.IsNullOrEmpty(request.Password))
+        {
+            return AuthResult.Fail(InvalidCredentialsMessage);
+        }
+
+        var user = await _authRepository.GetByEmailAsync(request.Email.Trim());
+
+        // Generic message either way so we don't reveal which emails exist.
+        if (user is null)
+        {
+            return AuthResult.Fail(InvalidCredentialsMessage);
+        }
+
+        if (!user.ActiveStatus)
+        {
+            return AuthResult.Fail("This account is inactive. Contact an administrator.");
+        }
+
+        if (user.LockoutUntil is { } lockout && lockout > DateTime.UtcNow)
+        {
+            return AuthResult.Fail("This account is temporarily locked due to failed login attempts. Try again later.");
+        }
+
+        if (string.IsNullOrEmpty(user.PasswordHash) || !_passwordHasher.Verify(request.Password, user.PasswordHash))
+        {
+            user.FailedLoginAttempts += 1;
+            if (user.FailedLoginAttempts >= MaxFailedAttempts)
+            {
+                user.LockoutUntil = DateTime.UtcNow.Add(LockoutDuration);
+                user.FailedLoginAttempts = 0;
+            }
+            await _authRepository.SaveUserAsync(user);
+            return AuthResult.Fail(InvalidCredentialsMessage);
+        }
+
+        // Successful authentication — reset lockout bookkeeping.
+        user.FailedLoginAttempts = 0;
+        user.LockoutUntil = null;
+        user.LastLoginAt = DateTime.UtcNow;
+        await _authRepository.SaveUserAsync(user);
+
+        return await IssueTokensAsync(user.Id, user.Email, user.GetFullName(), user.MustChangePassword);
+    }
+
+    public async Task<AuthResult> RefreshAsync(string refreshToken)
+    {
+        if (string.IsNullOrWhiteSpace(refreshToken))
+        {
+            return AuthResult.Fail("A refresh token is required.");
+        }
+
+        var userId = _tokenService.ValidateRefreshToken(refreshToken);
+        if (userId is null)
+        {
+            return AuthResult.Fail("The refresh token is invalid or has expired.");
+        }
+
+        var user = await _authRepository.GetByIdAsync(userId.Value);
+        if (user is null || !user.ActiveStatus)
+        {
+            return AuthResult.Fail("The refresh token is invalid or has expired.");
+        }
+
+        return await IssueTokensAsync(user.Id, user.Email, user.GetFullName(), user.MustChangePassword);
+    }
+
+    public async Task<AuthResult> ChangePasswordAsync(int userId, ChangePasswordRequest request)
+    {
+        if (request is null || string.IsNullOrEmpty(request.NewPassword))
+        {
+            return AuthResult.Fail("A new password is required.");
+        }
+
+        if (request.NewPassword.Length < MinPasswordLength)
+        {
+            return AuthResult.Fail($"The new password must be at least {MinPasswordLength} characters long.");
+        }
+
+        var user = await _authRepository.GetByIdAsync(userId);
+        if (user is null)
+        {
+            return AuthResult.Fail("User not found.");
+        }
+
+        // Require the current password to be correct (the temporary password counts).
+        if (string.IsNullOrEmpty(user.PasswordHash) || !_passwordHasher.Verify(request.CurrentPassword ?? string.Empty, user.PasswordHash))
+        {
+            return AuthResult.Fail("The current password is incorrect.");
+        }
+
+        if (_passwordHasher.Verify(request.NewPassword, user.PasswordHash))
+        {
+            return AuthResult.Fail("The new password must be different from the current password.");
+        }
+
+        user.PasswordHash = _passwordHasher.Hash(request.NewPassword);
+        user.PasswordChangedAt = DateTime.UtcNow;
+        user.MustChangePassword = false;
+        user.FailedLoginAttempts = 0;
+        user.LockoutUntil = null;
+        await _authRepository.SaveUserAsync(user);
+
+        return await IssueTokensAsync(user.Id, user.Email, user.GetFullName(), mustChangePassword: false);
+    }
+
+    public async Task<CurrentUserResponse?> GetCurrentUserAsync(int userId)
+    {
+        var user = await _authRepository.GetByIdAsync(userId);
+        if (user is null)
+        {
+            return null;
+        }
+
+        var claims = await _authRepository.GetEffectiveClaimsAsync(userId);
+        var roles = await _authRepository.GetRoleNamesAsync(userId);
+
+        return new CurrentUserResponse
+        {
+            UserId = user.Id,
+            Email = user.Email,
+            FullName = user.GetFullName(),
+            MustChangePassword = user.MustChangePassword,
+            Roles = roles,
+            Claims = claims,
+            IsSystemAdmin = claims.Any(c =>
+                c.Type == SystemClaims.SystemClaimType && c.Value == SystemClaims.FullAccessValue)
+        };
+    }
+
+    private async Task<AuthResult> IssueTokensAsync(int userId, string? email, string fullName, bool mustChangePassword)
+    {
+        var claims = await _authRepository.GetEffectiveClaimsAsync(userId);
+        var roles = await _authRepository.GetRoleNamesAsync(userId);
+
+        var access = _tokenService.CreateAccessToken(userId, email, fullName, claims, roles, mustChangePassword);
+        var refresh = _tokenService.CreateRefreshToken(userId);
+
+        return AuthResult.Success(access.Token, refresh, access.ExpiresInSeconds, mustChangePassword);
+    }
+}

--- a/src/Core/Services/Pbkdf2PasswordHasher.cs
+++ b/src/Core/Services/Pbkdf2PasswordHasher.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Security.Cryptography;
+using Neurocorp.Api.Core.Interfaces.Services;
+
+namespace Neurocorp.Api.Core.Services;
+
+/// <summary>
+/// PBKDF2 (RFC 2898) password hasher using only the .NET BCL — no external dependency,
+/// which keeps the Core project dependency-free and avoids supply-chain surface for a
+/// security-critical primitive.
+///
+/// Stored format (self-describing, so parameters can evolve without a data migration):
+///   PBKDF2$&lt;iterations&gt;$&lt;saltBase64&gt;$&lt;hashBase64&gt;
+///
+/// The explicit <c>PasswordSalt</c> column is intentionally left unused — the salt is
+/// embedded in the hash string, matching the comment on the DB column.
+/// </summary>
+public class Pbkdf2PasswordHasher : IPasswordHasher
+{
+    private const int SaltSize = 16;          // 128-bit salt
+    private const int KeySize = 32;           // 256-bit derived key
+    private const int Iterations = 100_000;   // OWASP-aligned cost for PBKDF2-SHA256
+    private static readonly HashAlgorithmName Algorithm = HashAlgorithmName.SHA256;
+    private const string Prefix = "PBKDF2";
+
+    public string Hash(string password)
+    {
+        ArgumentNullException.ThrowIfNull(password);
+
+        byte[] salt = RandomNumberGenerator.GetBytes(SaltSize);
+        byte[] key = Rfc2898DeriveBytes.Pbkdf2(password, salt, Iterations, Algorithm, KeySize);
+
+        return string.Join('$', Prefix, Iterations, Convert.ToBase64String(salt), Convert.ToBase64String(key));
+    }
+
+    public bool Verify(string password, string storedHash)
+    {
+        if (string.IsNullOrEmpty(password) || string.IsNullOrEmpty(storedHash))
+        {
+            return false;
+        }
+
+        var parts = storedHash.Split('$');
+        if (parts.Length != 4 || parts[0] != Prefix)
+        {
+            return false;
+        }
+
+        if (!int.TryParse(parts[1], out var iterations))
+        {
+            return false;
+        }
+
+        byte[] salt;
+        byte[] expectedKey;
+        try
+        {
+            salt = Convert.FromBase64String(parts[2]);
+            expectedKey = Convert.FromBase64String(parts[3]);
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+
+        byte[] actualKey = Rfc2898DeriveBytes.Pbkdf2(password, salt, iterations, Algorithm, expectedKey.Length);
+        return CryptographicOperations.FixedTimeEquals(actualKey, expectedKey);
+    }
+}

--- a/src/Infrastructure/Configurations/Dependencies.cs
+++ b/src/Infrastructure/Configurations/Dependencies.cs
@@ -28,10 +28,16 @@ public static class NeurocorpConfigurationExtensions
             .Replace("{{DB_USER}}", dbUser)
             .Replace("{{MYSQL_PASSWORD}}", dbPassword);
 
-        // Register ApplicationDbContext with MySQL|
-        services.AddDbContextPool<ApplicationDbContext>(options =>
+        // Register ApplicationDbContext with MySQL.
+        // NOTE: switched from AddDbContextPool to AddDbContext in Chunk 1B. Pooling
+        // requires a single (DbContextOptions) constructor and cannot inject the
+        // request-scoped ICurrentUserService needed to stamp LastUpdatedByUserId with
+        // the real authenticated user. A scoped context is the standard pattern for
+        // auditing; pooling can be re-introduced later with a pool-safe accessor if
+        // profiling shows it is needed.
+        services.AddDbContext<ApplicationDbContext>(options =>
             options.UseMySql(
-                cn!.ToString(), 
+                cn!.ToString(),
                 ServerVersion.AutoDetect(cn),
                 options => options.EnableRetryOnFailure(
                     maxRetryCount: 5,
@@ -60,6 +66,7 @@ public static class NeurocorpConfigurationExtensions
         services.AddScoped<ISiteRepository, SiteRepository>();
         services.AddScoped<ITherapistSpecialtyRepository, TherapistSpecialtyRepository>();
         services.AddScoped<ITreatmentPlanRepository, TreatmentPlanRepository>();
+        services.AddScoped<IAuthRepository, AuthRepository>();
         return services;
     }
 }

--- a/src/Infrastructure/Data/ApplicationDbContext.cs
+++ b/src/Infrastructure/Data/ApplicationDbContext.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Neurocorp.Api.Core.Entities;
+using Neurocorp.Api.Core.Interfaces.Services;
 
 namespace Neurocorp.Api.Infrastructure.Data;
 
@@ -7,9 +8,22 @@ public class ApplicationDbContext : DbContext
 {
     private static readonly int DEFAULT_SYSTEM_USER_ID = 0;
 
-    public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : base(options) { }
+    private readonly ICurrentUserService? _currentUserService;
+
+    // The optional ICurrentUserService keeps existing `new ApplicationDbContext(options)`
+    // call sites (notably the test suite, which uses the in-memory provider) working
+    // unchanged. At runtime the DI container supplies the HttpContext-backed implementation
+    // so audit columns are stamped with the real authenticated user instead of 0.
+    public ApplicationDbContext(
+        DbContextOptions<ApplicationDbContext> options,
+        ICurrentUserService? currentUserService = null) : base(options)
+    {
+        _currentUserService = currentUserService;
+    }
 
     public DbSet<User> Users { get; set; }
+    public DbSet<RoleClaim> RoleClaims { get; set; }
+    public DbSet<UserClaim> UserClaims { get; set; }
     public DbSet<Patient> Patients { get; set; }
     public DbSet<Caretaker> Caretakers { get; set; }
     public DbSet<Therapist> Therapists { get; set; }
@@ -135,6 +149,18 @@ public class ApplicationDbContext : DbContext
             ur.HasKey(e => e.Id);
             ur.Property(e => e.Id).HasColumnName("UserRoleID");
             ur.Ignore(e => e.RoleCreatedOn);
+        });
+        modelBuilder.Entity<RoleClaim>(rc => {
+            rc.ToTable("RoleClaim");
+            rc.HasKey(e => e.Id);
+            rc.Property(e => e.Id).HasColumnName("RoleClaimID");
+            rc.Property(e => e.RoleId).HasColumnName("RoleID");
+        });
+        modelBuilder.Entity<UserClaim>(uc => {
+            uc.ToTable("UserClaim");
+            uc.HasKey(e => e.Id);
+            uc.Property(e => e.Id).HasColumnName("UserClaimID");
+            uc.Property(e => e.UserId).HasColumnName("UserID");
         });
         modelBuilder.Entity<Payment>(p => {
             p.ToTable("Payment");
@@ -265,7 +291,9 @@ public class ApplicationDbContext : DbContext
 
     private int GetCurrentUserId()
     {
-        // Your logic to get the current user ID
-        return DEFAULT_SYSTEM_USER_ID; // Placeholder implementation
-    }    
+        // Resolved from the authenticated principal at request time. Falls back to the
+        // system id (0) for unauthenticated contexts: background/hosted services, the
+        // bootstrap path, and tests that construct the context without DI.
+        return _currentUserService?.UserId ?? DEFAULT_SYSTEM_USER_ID;
+    }
 }

--- a/src/Infrastructure/Repositories/AuthRepository.cs
+++ b/src/Infrastructure/Repositories/AuthRepository.cs
@@ -1,0 +1,93 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Neurocorp.Api.Core.BusinessObjects.Auth;
+using Neurocorp.Api.Core.Entities;
+using Neurocorp.Api.Core.Interfaces.Repositories;
+using Neurocorp.Api.Infrastructure.Data;
+
+namespace Neurocorp.Api.Infrastructure.Repositories;
+
+/// <summary>
+/// EF Core data access for authentication and the claims-aware authorization model.
+/// </summary>
+public class AuthRepository : IAuthRepository
+{
+    private readonly ApplicationDbContext _dbContext;
+
+    public AuthRepository(ApplicationDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<User?> GetByEmailAsync(string email)
+    {
+        // Email has a UNIQUE constraint; tracked so login bookkeeping can be saved.
+        return await _dbContext.Users
+            .FirstOrDefaultAsync(u => u.Email == email);
+    }
+
+    public async Task<User?> GetByIdAsync(int id)
+    {
+        return await _dbContext.Users.FindAsync(id);
+    }
+
+    public async Task<IReadOnlyList<ClaimDto>> GetEffectiveClaimsAsync(int userId)
+    {
+        var roleIds = await _dbContext.Set<UserRole>()
+            .Where(ur => ur.UserId == userId)
+            .Select(ur => ur.RoleId)
+            .ToListAsync();
+
+        var roleClaims = await _dbContext.RoleClaims
+            .Where(rc => roleIds.Contains(rc.RoleId))
+            .Select(rc => new ClaimDto(rc.ClaimType, rc.ClaimValue))
+            .ToListAsync();
+
+        var userClaims = await _dbContext.UserClaims
+            .Where(uc => uc.UserId == userId)
+            .Select(uc => new { uc.ClaimType, uc.ClaimValue, uc.IsDenied })
+            .ToListAsync();
+
+        var denied = userClaims
+            .Where(uc => uc.IsDenied)
+            .Select(uc => new ClaimDto(uc.ClaimType, uc.ClaimValue))
+            .ToHashSet();
+
+        var granted = userClaims
+            .Where(uc => !uc.IsDenied)
+            .Select(uc => new ClaimDto(uc.ClaimType, uc.ClaimValue));
+
+        // (role claims UNION user grants) MINUS user denials, de-duplicated.
+        return roleClaims
+            .Concat(granted)
+            .Distinct()
+            .Where(c => !denied.Contains(c))
+            .ToList();
+    }
+
+    public async Task<IReadOnlyList<string>> GetRoleNamesAsync(int userId)
+    {
+        var roleIds = await _dbContext.Set<UserRole>()
+            .Where(ur => ur.UserId == userId)
+            .Select(ur => ur.RoleId)
+            .ToListAsync();
+
+        return await _dbContext.RoleTypes
+            .Where(r => roleIds.Contains(r.Id))
+            .Select(r => r.Name)
+            .ToListAsync();
+    }
+
+    public async Task SaveUserAsync(User user)
+    {
+        // user is typically already tracked (from GetByEmail/GetById); ensure it is attached.
+        if (_dbContext.Entry(user).State == EntityState.Detached)
+        {
+            _dbContext.Users.Attach(user);
+            _dbContext.Entry(user).State = EntityState.Modified;
+        }
+        await _dbContext.SaveChangesAsync();
+    }
+}

--- a/src/Web/Authentication/AuthProblemDetails.cs
+++ b/src/Web/Authentication/AuthProblemDetails.cs
@@ -1,0 +1,55 @@
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Neurocorp.Api.Web.Authentication;
+
+/// <summary>
+/// Renders authentication (401) and authorization (403) failures as RFC 7807
+/// <c>application/problem+json</c> instead of the bearer middleware's default empty body.
+/// </summary>
+public static class AuthProblemDetails
+{
+    public static Task OnChallenge(JwtBearerChallengeContext context)
+    {
+        // Suppress the default empty 401 response and emit ProblemDetails instead.
+        context.HandleResponse();
+        return WriteProblem(
+            context.Response,
+            StatusCodes.Status401Unauthorized,
+            "Unauthorized",
+            "Authentication is required to access this resource.");
+    }
+
+    public static Task OnForbidden(ForbiddenContext context)
+    {
+        return WriteProblem(
+            context.Response,
+            StatusCodes.Status403Forbidden,
+            "Forbidden",
+            "You do not have permission to perform this action.");
+    }
+
+    private static async Task WriteProblem(HttpResponse response, int status, string title, string detail)
+    {
+        if (response.HasStarted)
+        {
+            return;
+        }
+
+        response.StatusCode = status;
+        response.ContentType = "application/problem+json";
+
+        var problem = new ProblemDetails
+        {
+            Status = status,
+            Title = title,
+            Detail = detail,
+            Type = $"https://httpstatuses.io/{status}"
+        };
+
+        await response.WriteAsync(JsonSerializer.Serialize(problem));
+    }
+}

--- a/src/Web/Authentication/CurrentUserService.cs
+++ b/src/Web/Authentication/CurrentUserService.cs
@@ -1,0 +1,40 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Neurocorp.Api.Core.Authorization;
+using Neurocorp.Api.Core.Interfaces.Services;
+
+namespace Neurocorp.Api.Web.Authentication;
+
+/// <summary>
+/// Reads the authenticated user's id from the current request principal. Backs both
+/// audit stamping (via <c>ApplicationDbContext</c>) and the AuthController convenience endpoints.
+/// </summary>
+public class CurrentUserService : ICurrentUserService
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public CurrentUserService(IHttpContextAccessor httpContextAccessor)
+    {
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public bool IsAuthenticated =>
+        _httpContextAccessor.HttpContext?.User?.Identity?.IsAuthenticated ?? false;
+
+    public int? UserId
+    {
+        get
+        {
+            var user = _httpContextAccessor.HttpContext?.User;
+            if (user is null)
+            {
+                return null;
+            }
+
+            var raw = user.FindFirst(SystemClaims.UserIdClaimType)?.Value
+                      ?? user.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+
+            return int.TryParse(raw, out var id) ? id : null;
+        }
+    }
+}

--- a/src/Web/Authentication/JwtConfig.cs
+++ b/src/Web/Authentication/JwtConfig.cs
@@ -1,0 +1,47 @@
+using System;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+
+namespace Neurocorp.Api.Web.Authentication;
+
+/// <summary>
+/// Single source of truth for JWT settings so the token issuer (<see cref="JwtTokenService"/>)
+/// and the bearer validation in <c>Startup</c> can never drift apart. The signing key is read
+/// from the <c>JWT_SIGNING_KEY</c> environment variable (preferred) or <c>Jwt:SigningKey</c>
+/// configuration. It is never committed; in non-development environments a missing key fails fast.
+/// </summary>
+public static class JwtConfig
+{
+    // Used ONLY when running in the Development environment without a configured key,
+    // so local dev works out of the box. Long enough for HMAC-SHA256 (>= 256 bits).
+    public const string DevelopmentFallbackKey =
+        "DEV-ONLY-INSECURE-JWT-SIGNING-KEY-DO-NOT-USE-IN-PRODUCTION-0123456789";
+
+    public static string Issuer(IConfiguration config) => config["Jwt:Issuer"] ?? "neurocorp-api";
+
+    public static string Audience(IConfiguration config) => config["Jwt:Audience"] ?? "neurocorp-clients";
+
+    public static int AccessTokenMinutes(IConfiguration config) =>
+        int.TryParse(config["Jwt:AccessTokenMinutes"], out var m) ? m : 60;
+
+    public static int RefreshTokenDays(IConfiguration config) =>
+        int.TryParse(config["Jwt:RefreshTokenDays"], out var d) ? d : 14;
+
+    public static string ResolveSigningKey(IConfiguration config, IHostEnvironment env)
+    {
+        var key = Environment.GetEnvironmentVariable("JWT_SIGNING_KEY") ?? config["Jwt:SigningKey"];
+        if (!string.IsNullOrWhiteSpace(key))
+        {
+            return key;
+        }
+
+        if (!env.IsDevelopment())
+        {
+            throw new InvalidOperationException(
+                "JWT signing key is not configured. Set the JWT_SIGNING_KEY environment variable " +
+                "(or Jwt:SigningKey) before starting the API in a non-development environment.");
+        }
+
+        return DevelopmentFallbackKey;
+    }
+}

--- a/src/Web/Authentication/JwtTokenService.cs
+++ b/src/Web/Authentication/JwtTokenService.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.IdentityModel.Tokens;
+using Neurocorp.Api.Core.Authorization;
+using Neurocorp.Api.Core.BusinessObjects.Auth;
+using Neurocorp.Api.Core.Interfaces.Services;
+
+namespace Neurocorp.Api.Web.Authentication;
+
+/// <summary>
+/// Issues and validates HMAC-SHA256 signed JWTs.
+///
+/// Access tokens are stateless and carry the user's identity, roles, and effective claims
+/// (including the ('System','FullAccess') wildcard for SystemAdmins) so the API can do
+/// policy evaluation and the SPA can drive claims-aware rendering without an extra round-trip.
+///
+/// Refresh tokens are longer-lived signed JWTs marked with typ=refresh. NOTE: with no
+/// server-side revocation store (deliberately deferred in Chunk 1A) a refresh token cannot be
+/// individually revoked before expiry — see the 1B sub-plan trade-offs. Keep refresh lifetime
+/// modest and add a RefreshToken table when revocation becomes a requirement.
+/// </summary>
+public class JwtTokenService : ITokenService
+{
+    private const string RefreshTokenTypeClaim = "typ";
+    private const string RefreshTokenTypeValue = "refresh";
+
+    private readonly string _issuer;
+    private readonly string _audience;
+    private readonly int _accessMinutes;
+    private readonly int _refreshDays;
+    private readonly SymmetricSecurityKey _signingKey;
+
+    public JwtTokenService(IConfiguration config, IHostEnvironment env)
+    {
+        _issuer = JwtConfig.Issuer(config);
+        _audience = JwtConfig.Audience(config);
+        _accessMinutes = JwtConfig.AccessTokenMinutes(config);
+        _refreshDays = JwtConfig.RefreshTokenDays(config);
+        _signingKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(JwtConfig.ResolveSigningKey(config, env)));
+    }
+
+    public TokenResult CreateAccessToken(
+        int userId,
+        string? email,
+        string fullName,
+        IReadOnlyCollection<ClaimDto> claims,
+        IReadOnlyCollection<string> roles,
+        bool mustChangePassword)
+    {
+        var now = DateTime.UtcNow;
+        var expires = now.AddMinutes(_accessMinutes);
+
+        var jwtClaims = new List<Claim>
+        {
+            new(SystemClaims.UserIdClaimType, userId.ToString()),
+            new(JwtRegisteredClaimNames.Sub, userId.ToString()),
+            new(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
+            new("name", fullName)
+        };
+
+        if (mustChangePassword)
+        {
+            // Marks the session as restricted to the password-change flow (enforced by
+            // PasswordChangeRequiredMiddleware). Dropped once the password is changed.
+            jwtClaims.Add(new Claim(SystemClaims.MustChangePasswordClaimType, SystemClaims.MustChangePasswordValue));
+        }
+
+        if (!string.IsNullOrEmpty(email))
+        {
+            jwtClaims.Add(new Claim(JwtRegisteredClaimNames.Email, email));
+        }
+
+        foreach (var role in roles)
+        {
+            jwtClaims.Add(new Claim("role", role));
+        }
+
+        foreach (var claim in claims)
+        {
+            jwtClaims.Add(new Claim(claim.Type, claim.Value));
+        }
+
+        var token = new JwtSecurityToken(
+            issuer: _issuer,
+            audience: _audience,
+            claims: jwtClaims,
+            notBefore: now,
+            expires: expires,
+            signingCredentials: new SigningCredentials(_signingKey, SecurityAlgorithms.HmacSha256));
+
+        var encoded = new JwtSecurityTokenHandler().WriteToken(token);
+        return new TokenResult(encoded, (int)(expires - now).TotalSeconds);
+    }
+
+    public string CreateRefreshToken(int userId)
+    {
+        var now = DateTime.UtcNow;
+        var claims = new List<Claim>
+        {
+            new(SystemClaims.UserIdClaimType, userId.ToString()),
+            new(JwtRegisteredClaimNames.Sub, userId.ToString()),
+            new(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
+            new(RefreshTokenTypeClaim, RefreshTokenTypeValue)
+        };
+
+        var token = new JwtSecurityToken(
+            issuer: _issuer,
+            audience: _audience,
+            claims: claims,
+            notBefore: now,
+            expires: now.AddDays(_refreshDays),
+            signingCredentials: new SigningCredentials(_signingKey, SecurityAlgorithms.HmacSha256));
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+
+    public int? ValidateRefreshToken(string refreshToken)
+    {
+        var parameters = new TokenValidationParameters
+        {
+            ValidateIssuer = true,
+            ValidIssuer = _issuer,
+            ValidateAudience = true,
+            ValidAudience = _audience,
+            ValidateLifetime = true,
+            ValidateIssuerSigningKey = true,
+            IssuerSigningKey = _signingKey,
+            ClockSkew = TimeSpan.FromSeconds(30)
+        };
+
+        try
+        {
+            var handler = new JwtSecurityTokenHandler { MapInboundClaims = false };
+            var principal = handler.ValidateToken(refreshToken, parameters, out _);
+
+            if (principal.FindFirst(RefreshTokenTypeClaim)?.Value != RefreshTokenTypeValue)
+            {
+                return null; // an access token cannot be used as a refresh token
+            }
+
+            var uid = principal.FindFirst(SystemClaims.UserIdClaimType)?.Value;
+            return int.TryParse(uid, out var id) ? id : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/src/Web/Authorization/AuthPolicy.cs
+++ b/src/Web/Authorization/AuthPolicy.cs
@@ -1,0 +1,16 @@
+using Neurocorp.Api.Core.Authorization;
+
+namespace Neurocorp.Api.Web.Authorization;
+
+/// <summary>
+/// Builds policy names understood by <see cref="PermissionPolicyProvider"/>.
+/// Usage: <c>[Authorize(Policy = AuthPolicy.Permission("Patients.FullAccess"))]</c>.
+/// </summary>
+public static class AuthPolicy
+{
+    public static string Permission(string value) =>
+        $"{PermissionPolicyProvider.PolicyPrefix}{SystemClaims.PermissionClaimType}:{value}";
+
+    public static string Claim(string type, string value) =>
+        $"{PermissionPolicyProvider.PolicyPrefix}{type}:{value}";
+}

--- a/src/Web/Authorization/PermissionAuthorizationHandler.cs
+++ b/src/Web/Authorization/PermissionAuthorizationHandler.cs
@@ -1,0 +1,31 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Neurocorp.Api.Core.Authorization;
+
+namespace Neurocorp.Api.Web.Authorization;
+
+/// <summary>
+/// Grants a <see cref="PermissionRequirement"/> when the principal either holds the exact
+/// permission claim or holds the god-mode wildcard ('System','FullAccess'). The wildcard
+/// short-circuit is the ONLY super-power mechanism in the system (granted solely to the
+/// SystemAdmin role per the locked bootstrap design).
+/// </summary>
+public class PermissionAuthorizationHandler : AuthorizationHandler<PermissionRequirement>
+{
+    protected override Task HandleRequirementAsync(
+        AuthorizationHandlerContext context,
+        PermissionRequirement requirement)
+    {
+        var user = context.User;
+
+        var hasWildcard = user.HasClaim(SystemClaims.SystemClaimType, SystemClaims.FullAccessValue);
+        var hasExplicit = user.HasClaim(requirement.ClaimType, requirement.ClaimValue);
+
+        if (hasWildcard || hasExplicit)
+        {
+            context.Succeed(requirement);
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Web/Authorization/PermissionPolicyProvider.cs
+++ b/src/Web/Authorization/PermissionPolicyProvider.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Options;
+using Neurocorp.Api.Core.Authorization;
+
+namespace Neurocorp.Api.Web.Authorization;
+
+/// <summary>
+/// Dynamic policy provider so controllers can require any claim with
+/// <c>[Authorize(Policy = "claim:{type}:{value}")]</c> without registering each policy by hand.
+/// This keeps the claims catalogue open-ended (a key 1B requirement) — new permissions need no
+/// Startup change. Use <see cref="AuthPolicy"/> to build the policy names.
+///
+/// Policy name grammar:  claim:&lt;ClaimType&gt;:&lt;ClaimValue&gt;
+/// A value with no explicit type (claim:&lt;value&gt;) defaults the type to "Permission".
+/// Any other policy name falls through to the default provider.
+/// </summary>
+public class PermissionPolicyProvider : IAuthorizationPolicyProvider
+{
+    public const string PolicyPrefix = "claim:";
+
+    private readonly DefaultAuthorizationPolicyProvider _fallbackProvider;
+
+    public PermissionPolicyProvider(IOptions<AuthorizationOptions> options)
+    {
+        _fallbackProvider = new DefaultAuthorizationPolicyProvider(options);
+    }
+
+    public Task<AuthorizationPolicy> GetDefaultPolicyAsync() => _fallbackProvider.GetDefaultPolicyAsync();
+
+    public Task<AuthorizationPolicy?> GetFallbackPolicyAsync() => _fallbackProvider.GetFallbackPolicyAsync();
+
+    public Task<AuthorizationPolicy?> GetPolicyAsync(string policyName)
+    {
+        if (policyName.StartsWith(PolicyPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            var spec = policyName.Substring(PolicyPrefix.Length);
+            var separator = spec.IndexOf(':');
+
+            string claimType;
+            string claimValue;
+            if (separator < 0)
+            {
+                claimType = SystemClaims.PermissionClaimType;
+                claimValue = spec;
+            }
+            else
+            {
+                claimType = spec.Substring(0, separator);
+                claimValue = spec.Substring(separator + 1);
+            }
+
+            var policy = new AuthorizationPolicyBuilder()
+                .RequireAuthenticatedUser()
+                .AddRequirements(new PermissionRequirement(claimType, claimValue))
+                .Build();
+
+            return Task.FromResult<AuthorizationPolicy?>(policy);
+        }
+
+        return _fallbackProvider.GetPolicyAsync(policyName);
+    }
+}

--- a/src/Web/Authorization/PermissionRequirement.cs
+++ b/src/Web/Authorization/PermissionRequirement.cs
@@ -1,0 +1,19 @@
+using Microsoft.AspNetCore.Authorization;
+
+namespace Neurocorp.Api.Web.Authorization;
+
+/// <summary>
+/// An authorization requirement satisfied by a single (ClaimType, ClaimValue) pair —
+/// or by the ('System','FullAccess') wildcard. See <see cref="PermissionAuthorizationHandler"/>.
+/// </summary>
+public class PermissionRequirement : IAuthorizationRequirement
+{
+    public string ClaimType { get; }
+    public string ClaimValue { get; }
+
+    public PermissionRequirement(string claimType, string claimValue)
+    {
+        ClaimType = claimType;
+        ClaimValue = claimValue;
+    }
+}

--- a/src/Web/Controllers/AuthController.cs
+++ b/src/Web/Controllers/AuthController.cs
@@ -1,0 +1,120 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Neurocorp.Api.Core.BusinessObjects.Auth;
+using Neurocorp.Api.Core.Interfaces.Services;
+using Neurocorp.Api.Web.Authorization;
+
+namespace Neurocorp.Api.Web.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class AuthController : ControllerBase
+{
+    private readonly IAuthService _authService;
+    private readonly ICurrentUserService _currentUser;
+
+    public AuthController(IAuthService authService, ICurrentUserService currentUser)
+    {
+        _authService = authService;
+        _currentUser = currentUser;
+    }
+
+    /// <summary>Exchange email + password for an access token and refresh token.</summary>
+    [AllowAnonymous]
+    [HttpPost("login")]
+    [ProducesResponseType(typeof(AuthTokenResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> Login([FromBody] LoginRequest request)
+    {
+        var result = await _authService.LoginAsync(request);
+        if (!result.Succeeded)
+        {
+            return Problem(statusCode: StatusCodes.Status401Unauthorized,
+                title: "Authentication failed", detail: result.Error);
+        }
+        return Ok(ToResponse(result));
+    }
+
+    /// <summary>Exchange a valid refresh token for a fresh access + refresh token pair.</summary>
+    [AllowAnonymous]
+    [HttpPost("refresh")]
+    [ProducesResponseType(typeof(AuthTokenResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> Refresh([FromBody] RefreshTokenRequest request)
+    {
+        var result = await _authService.RefreshAsync(request?.RefreshToken ?? string.Empty);
+        if (!result.Succeeded)
+        {
+            return Problem(statusCode: StatusCodes.Status401Unauthorized,
+                title: "Token refresh failed", detail: result.Error);
+        }
+        return Ok(ToResponse(result));
+    }
+
+    /// <summary>Return the authenticated caller's identity, roles, and effective claims.</summary>
+    [HttpGet("me")]
+    [ProducesResponseType(typeof(CurrentUserResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> Me()
+    {
+        var userId = _currentUser.UserId;
+        if (userId is null)
+        {
+            return Unauthorized();
+        }
+
+        var me = await _authService.GetCurrentUserAsync(userId.Value);
+        return me is null ? NotFound() : Ok(me);
+    }
+
+    /// <summary>Change the caller's password (also clears the must-change-password flag).</summary>
+    [HttpPost("change-password")]
+    [ProducesResponseType(typeof(AuthTokenResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> ChangePassword([FromBody] ChangePasswordRequest request)
+    {
+        var userId = _currentUser.UserId;
+        if (userId is null)
+        {
+            return Unauthorized();
+        }
+
+        var result = await _authService.ChangePasswordAsync(userId.Value, request);
+        if (!result.Succeeded)
+        {
+            return Problem(statusCode: StatusCodes.Status400BadRequest,
+                title: "Password change failed", detail: result.Error);
+        }
+        return Ok(ToResponse(result));
+    }
+
+    /// <summary>
+    /// Demonstrates claims-based authorization. Requires the "System.Diagnostics" permission,
+    /// which is granted to no role by default — so only a SystemAdmin (via the
+    /// ('System','FullAccess') wildcard) succeeds here. Used by the 1B verification doc to prove
+    /// the wildcard works and that an authenticated non-SA user is correctly denied (403).
+    /// </summary>
+    [HttpGet("admin-check")]
+    [Authorize(Policy = "claim:Permission:System.Diagnostics")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public IActionResult AdminCheck()
+    {
+        return Ok(new
+        {
+            message = "Access granted: you hold the System.FullAccess wildcard (SystemAdmin).",
+            userId = _currentUser.UserId
+        });
+    }
+
+    private static AuthTokenResponse ToResponse(AuthResult result) => new()
+    {
+        AccessToken = result.AccessToken!,
+        RefreshToken = result.RefreshToken!,
+        ExpiresIn = result.ExpiresInSeconds,
+        MustChangePassword = result.MustChangePassword
+    };
+}

--- a/src/Web/Controllers/HealthController.cs
+++ b/src/Web/Controllers/HealthController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using System.Reflection;
@@ -5,6 +6,7 @@ using Neurocorp.Api.Web.Middleware.HealthChecks;
 
 namespace Neurocorp.Api.Web.Controllers;
 
+[AllowAnonymous]
 [ApiController]
 [Route("api/[controller]")]
 public class HealthController : ControllerBase

--- a/src/Web/Middleware/PasswordChangeRequiredMiddleware.cs
+++ b/src/Web/Middleware/PasswordChangeRequiredMiddleware.cs
@@ -1,0 +1,93 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Neurocorp.Api.Core.Authorization;
+
+namespace Neurocorp.Api.Web.Middleware;
+
+/// <summary>
+/// Enforces the locked design requirement that "the first login must force a password change
+/// before any other actions are allowed" (remediation-2026-system-admin-bootstrap.md).
+///
+/// When the authenticated principal carries the must-change-password marker
+/// (<see cref="SystemClaims.MustChangePasswordClaimType"/>), every request is rejected with a
+/// 403 <c>application/problem+json</c> carrying <c>code = "password_change_required"</c>, except a
+/// short allowlist needed to actually resolve the situation (change-password, identity lookup) plus
+/// the anonymous auth/health endpoints. The marker is set at token issuance and disappears as soon
+/// as the password is changed (tokens are re-issued without it), so no per-request database lookup
+/// is required.
+/// </summary>
+public class PasswordChangeRequiredMiddleware
+{
+    /// <summary>Stable code the SPA can switch on to route the user to the change-password screen.</summary>
+    public const string ProblemCode = "password_change_required";
+
+    // Paths a must-change-password session is still allowed to reach. Matched as path segments
+    // (case-insensitive) so trailing content / query strings do not bypass the check.
+    private static readonly string[] AllowedPaths =
+    {
+        "/api/auth/change-password",
+        "/api/auth/me",
+        "/api/auth/login",
+        "/api/auth/refresh",
+        "/api/health"
+    };
+
+    private readonly RequestDelegate _next;
+
+    public PasswordChangeRequiredMiddleware(RequestDelegate next)
+    {
+        _next = next;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        var user = context.User;
+        var mustChange = user?.Identity?.IsAuthenticated == true
+            && user.FindFirst(SystemClaims.MustChangePasswordClaimType)?.Value == SystemClaims.MustChangePasswordValue;
+
+        if (mustChange && !IsAllowed(context.Request.Path))
+        {
+            await WriteProblem(context.Response);
+            return;
+        }
+
+        await _next(context);
+    }
+
+    private static bool IsAllowed(PathString path)
+    {
+        foreach (var allowed in AllowedPaths)
+        {
+            if (path.StartsWithSegments(allowed, System.StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static async Task WriteProblem(HttpResponse response)
+    {
+        if (response.HasStarted)
+        {
+            return;
+        }
+
+        response.StatusCode = StatusCodes.Status403Forbidden;
+        response.ContentType = "application/problem+json";
+
+        var problem = new ProblemDetails
+        {
+            Status = StatusCodes.Status403Forbidden,
+            Title = "Password change required",
+            Detail = "You must change your password before performing any other action.",
+            Type = "https://httpstatuses.io/403",
+            Extensions = { ["code"] = ProblemCode }
+        };
+
+        await response.WriteAsync(JsonSerializer.Serialize(problem));
+    }
+}

--- a/src/Web/Startup.cs
+++ b/src/Web/Startup.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Text;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
@@ -11,13 +13,20 @@ using Neurocorp.Api.Web.Middleware.HealthChecks;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Neurocorp.Api.Infrastructure.Data;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.IdentityModel.Tokens;
+using Neurocorp.Api.Core.Interfaces.Services;
+using Neurocorp.Api.Web.Authentication;
+using Neurocorp.Api.Web.Authorization;
 using Neurocorp.Api.Web.Middleware;
 
 namespace Neurocorp.Api.Web;
 
-public class Startup(IConfiguration configuration)
+public class Startup(IConfiguration configuration, IWebHostEnvironment environment)
 {
     public IConfiguration Configuration { get; } = configuration;
+    public IWebHostEnvironment Environment { get; } = environment;
 
     // This method gets called by the runtime. Use this method to add services to the container.
     public void ConfigureServices(IServiceCollection services)
@@ -60,6 +69,53 @@ public class Startup(IConfiguration configuration)
         // Register the hosted service
         services.AddHostedService<DbContextWarmupService>();
 
+        // --- Authentication & Authorization (Chunk 1B) ---
+        services.AddHttpContextAccessor();
+        services.AddScoped<ICurrentUserService, CurrentUserService>();
+        services.AddSingleton<ITokenService, JwtTokenService>();
+        services.AddSingleton<IAuthorizationHandler, PermissionAuthorizationHandler>();
+        // Dynamic policy provider so [Authorize(Policy = "claim:Type:Value")] works without
+        // registering each permission policy explicitly.
+        services.AddSingleton<IAuthorizationPolicyProvider, PermissionPolicyProvider>();
+
+        var signingKey = new SymmetricSecurityKey(
+            Encoding.UTF8.GetBytes(JwtConfig.ResolveSigningKey(Configuration, Environment)));
+
+        services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+            .AddJwtBearer(options =>
+            {
+                // Keep custom claim types (e.g. "System", "uid") verbatim instead of the
+                // default SOAP-style remapping, so policy handlers match what we issued.
+                options.MapInboundClaims = false;
+                options.TokenValidationParameters = new TokenValidationParameters
+                {
+                    ValidateIssuer = true,
+                    ValidIssuer = JwtConfig.Issuer(Configuration),
+                    ValidateAudience = true,
+                    ValidAudience = JwtConfig.Audience(Configuration),
+                    ValidateLifetime = true,
+                    ValidateIssuerSigningKey = true,
+                    IssuerSigningKey = signingKey,
+                    ClockSkew = TimeSpan.FromSeconds(30),
+                    NameClaimType = "name",
+                    RoleClaimType = "role"
+                };
+                options.Events = new JwtBearerEvents
+                {
+                    OnChallenge = AuthProblemDetails.OnChallenge,
+                    OnForbidden = AuthProblemDetails.OnForbidden
+                };
+            });
+
+        // Secure by default: every endpoint requires an authenticated user unless it opts
+        // out with [AllowAnonymous] (login, refresh, health checks).
+        services.AddAuthorization(options =>
+        {
+            options.FallbackPolicy = new AuthorizationPolicyBuilder()
+                .RequireAuthenticatedUser()
+                .Build();
+        });
+
         // Register dependencies with DI framework
         services.AddCoreDependencies(Configuration);
         services.AddInfrastructureServices(Configuration);
@@ -79,7 +135,11 @@ public class Startup(IConfiguration configuration)
         app.UseRouting();
         app.UseCors("AllowedOrigins");
 
+        app.UseAuthentication();
         app.UseAuthorization();
+
+        // Restricts a must-change-password session to the password-change flow until resolved.
+        app.UseMiddleware<PasswordChangeRequiredMiddleware>();
 
         app.UseEndpoints(endpoints =>
         {

--- a/src/Web/Web.csproj
+++ b/src/Web/Web.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.11" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 

--- a/src/Web/appsettings.json
+++ b/src/Web/appsettings.json
@@ -8,5 +8,12 @@
   "ConnectionStrings": {
     "DefaultConnection": "Server={{HOST}};Port={{DB_PORT}};Database={{DB_NAME}};Uid={{DB_USER}};Pwd={{MYSQL_PASSWORD}};"
   },
+  "Jwt": {
+    "Issuer": "neurocorp-api",
+    "Audience": "neurocorp-clients",
+    "AccessTokenMinutes": 60,
+    "RefreshTokenDays": 14,
+    "SigningKey": ""
+  },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
…ation

Implements the authentication/authorization foundation per the locked 1B design and SA bootstrap doc:

- JWT access + refresh tokens (HMAC-SHA256), stateless access tokens carrying uid, roles, and effective claims (incl. the ('System','FullAccess') wildcard).
- AuthController: login, refresh, me, change-password, admin-check.
- Policy-based authorization with a dynamic permission policy provider; the System.FullAccess wildcard satisfies every policy. Secure-by-default via a RequireAuthenticatedUser fallback policy ([AllowAnonymous] on auth/health).
- Real GetCurrentUserId(): ApplicationDbContext now stamps LastUpdatedByUserId from the authenticated principal (switched AddDbContextPool -> AddDbContext so the request-scoped ICurrentUserService can be injected).
- 401/403 rendered as application/problem+json.

Adds server-side enforcement of the must-change-password requirement (bootstrap doc: "first login must force a password change before any other actions are allowed"):

- Access tokens carry an 'mcp' marker claim while a change is owed; it is dropped automatically when the password is changed (tokens re-issued).
- PasswordChangeRequiredMiddleware blocks all requests from such a session except change-password / me / login / refresh / health, returning 403 with code "password_change_required".

Verification: docs/auth-1b-verification.md (scenarios 1-13). Full suite green (192 tests). Manually verified end-to-end against localhost incl. SA wildcard, non-SA 403 denial, token tamper rejection, full unauth sweep, and must-change enforcement.