### PR TITLE
Helm: plumb JWT_SIGNING_KEY through the chart (required for auth)

### DIFF
--- a/deploy/helm/patient-care-api/.env.example
+++ b/deploy/helm/patient-care-api/.env.example
@@ -5,3 +5,9 @@ DATABASE_PORT=3306
 DATABASE_NAME=neurocorp_db
 DATABASE_USER=api_user
 DATABASE_PASSWORD=changeme
+
+# HMAC-SHA256 signing key for JWT auth tokens. REQUIRED — the API fails fast without it outside
+# Development, and the deploy scripts refuse to run if it is empty. Generate a strong key with:
+#   openssl rand -base64 48
+# Keep it stable across deploys (changing it invalidates all issued tokens / logs everyone out).
+JWT_SIGNING_KEY=

--- a/deploy/helm/patient-care-api/deploy-remote.sh
+++ b/deploy/helm/patient-care-api/deploy-remote.sh
@@ -54,6 +54,13 @@ fi
 echo "  K3s cluster reachable."
 echo ""
 
+# Fail early if the JWT signing key is missing — the API crash-loops without it outside Development.
+if [ -z "${JWT_SIGNING_KEY:-}" ]; then
+  echo "Error: JWT_SIGNING_KEY is not set. Generate one with 'openssl rand -base64 48' and add"
+  echo "  'JWT_SIGNING_KEY=<value>' to your .env."
+  exit 1
+fi
+
 # ── Build helm command ───────────────────────────────────────────
 HELM_CMD="helm upgrade --install patient-care-api $CHART_DIR"
 HELM_CMD="$HELM_CMD --set database.host=$DATABASE_HOST"
@@ -61,6 +68,7 @@ HELM_CMD="$HELM_CMD --set database.port=$DATABASE_PORT"
 HELM_CMD="$HELM_CMD --set database.name=$DATABASE_NAME"
 HELM_CMD="$HELM_CMD --set database.user=$DATABASE_USER"
 HELM_CMD="$HELM_CMD --set database.password=$DATABASE_PASSWORD"
+HELM_CMD="$HELM_CMD --set jwt.signingKey=$JWT_SIGNING_KEY"
 
 if [ -n "$IMAGE_TAG" ]; then
   HELM_CMD="$HELM_CMD --set image.tag=$IMAGE_TAG"

--- a/deploy/helm/patient-care-api/deploy.sh
+++ b/deploy/helm/patient-care-api/deploy.sh
@@ -26,6 +26,15 @@ set -a
 source "$ENV_FILE"
 set +a
 
+# Fail early if the JWT signing key is missing — the API crash-loops without it outside Development.
+if [ -z "${JWT_SIGNING_KEY:-}" ]; then
+  echo "Error: JWT_SIGNING_KEY is not set in $ENV_FILE."
+  echo "The API requires it (it fails fast outside Development). Generate one with:"
+  echo "  openssl rand -base64 48"
+  echo "then add 'JWT_SIGNING_KEY=<value>' to your .env."
+  exit 1
+fi
+
 # Build the helm command
 HELM_CMD="helm upgrade --install patient-care-api $CHART_DIR"
 HELM_CMD="$HELM_CMD --set database.host=$DATABASE_HOST"
@@ -33,6 +42,7 @@ HELM_CMD="$HELM_CMD --set database.port=$DATABASE_PORT"
 HELM_CMD="$HELM_CMD --set database.name=$DATABASE_NAME"
 HELM_CMD="$HELM_CMD --set database.user=$DATABASE_USER"
 HELM_CMD="$HELM_CMD --set database.password=$DATABASE_PASSWORD"
+HELM_CMD="$HELM_CMD --set jwt.signingKey=$JWT_SIGNING_KEY"
 
 if [ -n "$IMAGE_TAG" ]; then
   HELM_CMD="$HELM_CMD --set image.tag=$IMAGE_TAG"

--- a/deploy/helm/patient-care-api/templates/secret.yaml
+++ b/deploy/helm/patient-care-api/templates/secret.yaml
@@ -12,3 +12,6 @@ stringData:
   DATABASE_NAME: {{ .Values.database.name | quote }}
   DATABASE_USER: {{ .Values.database.user | quote }}
   DATABASE_PASSWORD: {{ .Values.database.password | quote }}
+  # Required by the API outside Development (JwtConfig fails fast if unset). `required` here
+  # blocks a render that would otherwise deploy a pod that crash-loops on a missing signing key.
+  JWT_SIGNING_KEY: {{ required "jwt.signingKey is required — set JWT_SIGNING_KEY in your .env (or --set jwt.signingKey=...). Generate one with: openssl rand -base64 48" .Values.jwt.signingKey | quote }}

--- a/deploy/helm/patient-care-api/values.yaml
+++ b/deploy/helm/patient-care-api/values.yaml
@@ -20,6 +20,12 @@ database:
   user: ""
   password: ""
 
+# HMAC-SHA256 signing key for JWT access/refresh tokens. Required (no default) — the API fails
+# fast outside Development if it is unset. Provide via --set jwt.signingKey=... or the deploy
+# scripts (which read JWT_SIGNING_KEY from .env). Never commit a real key. Generate: openssl rand -base64 48
+jwt:
+  signingKey: ""
+
 healthCheck:
   liveness:
     path: /api/health/live


### PR DESCRIPTION
The 1B auth work made JWT_SIGNING_KEY mandatory outside Development (JwtConfig fails fast if unset), but the chart only injected DATABASE_*. A Production deploy would therefore crash-loop on a missing signing key.

- secret.yaml: add JWT_SIGNING_KEY, guarded by Helm `required` so a render without a key fails fast instead of deploying a broken pod.
- values.yaml: add jwt.signingKey ("", no default).
- deploy.sh / deploy-remote.sh: pass --set jwt.signingKey=$JWT_SIGNING_KEY and refuse to run if JWT_SIGNING_KEY is empty.
- .env.example: document JWT_SIGNING_KEY + how to generate one (openssl rand -base64 48).

Verified with `helm template`: renders the key when set; fails with the required message when absent. The real key lives only in the git-ignored .env / cluster secret.