### PR TITLE
Remediation 2026 Chunk 4: decompose the god SessionsController

### DIFF
--- a/docs/sessions-split-4-verification.md
+++ b/docs/sessions-split-4-verification.md
@@ -1,0 +1,60 @@
+# SessionsController Split Verification — Remediation 2026, Chunk 4
+
+The god `SessionsController` was decomposed into four focused controllers. **Every route, method,
+request/response shape, and status code is unchanged** — all still under the `api/sessions` prefix.
+This doc maps each endpoint to its new home and gives a curl matrix to prove no regression.
+
+```bash
+BASE=http://localhost:5245          # or http://neurocorp.k3s:30000
+TOKEN=...                           # access token (all endpoints require auth — see 1B)
+```
+
+## Endpoint → controller map (routes identical to before)
+
+| Method & Route | Now served by |
+|---|---|
+| `GET  /api/sessions/{date}/all` | `SessionsController` |
+| `GET  /api/sessions/pastdue` | `SessionsController` |
+| `POST /api/sessions` | `SessionsController` |
+| `PUT  /api/sessions/{id}` | `SessionsController` |
+| `GET  /api/sessions/patient/{patientId}/discovery` | `SessionsController` |
+| `GET  /api/sessions/{date}/schedule-matrix?siteId=` | `ScheduleController` |
+| `GET  /api/sessions/{id}/payments` | `SessionPaymentsController` |
+| `GET  /api/sessions/statuses` | `BookingController` |
+| `PUT  /api/sessions/{id}/confirm` | `BookingController` |
+| `PUT  /api/sessions/{id}/cancel` | `BookingController` |
+| `PUT  /api/sessions/{id}/complete` | `BookingController` |
+| `PUT  /api/sessions/{id}/noshow` | `BookingController` |
+| `PUT  /api/sessions/{id}/checkin` | `BookingController` |
+| `PUT  /api/sessions/{id}/start-therapy` | `BookingController` |
+| `GET  /api/sessions/unconfirmed` | `BookingController` |
+| `GET  /api/sessions/upcoming` | `BookingController` |
+| `GET  /api/sessions/{id}/confirmations` | `BookingController` |
+
+All four controllers declare `[Route("api/sessions")]` explicitly (no `[controller]` token), so the
+URLs are byte-identical. No action-template collisions across them.
+
+## Curl matrix (spot-check before/after the split — expect identical results)
+```bash
+H="-H \"Authorization: Bearer $TOKEN\""
+curl.exe -s -o /dev/null -w "all          -> %{http_code}\n" $BASE/api/sessions/2026-06-06/all          -H "Authorization: Bearer $TOKEN"
+curl.exe -s -o /dev/null -w "pastdue      -> %{http_code}\n" $BASE/api/sessions/pastdue                 -H "Authorization: Bearer $TOKEN"
+curl.exe -s -o /dev/null -w "discovery    -> %{http_code}\n" $BASE/api/sessions/patient/1/discovery     -H "Authorization: Bearer $TOKEN"
+curl.exe -s -o /dev/null -w "schedule-mtx -> %{http_code}\n" "$BASE/api/sessions/2026-06-06/schedule-matrix?siteId=1" -H "Authorization: Bearer $TOKEN"
+curl.exe -s -o /dev/null -w "payments     -> %{http_code}\n" $BASE/api/sessions/1/payments              -H "Authorization: Bearer $TOKEN"
+curl.exe -s -o /dev/null -w "statuses     -> %{http_code}\n" $BASE/api/sessions/statuses                -H "Authorization: Bearer $TOKEN"
+curl.exe -s -o /dev/null -w "unconfirmed  -> %{http_code}\n" $BASE/api/sessions/unconfirmed             -H "Authorization: Bearer $TOKEN"
+curl.exe -s -o /dev/null -w "upcoming     -> %{http_code}\n" $BASE/api/sessions/upcoming                -H "Authorization: Bearer $TOKEN"
+curl.exe -s -o /dev/null -w "confirmations-> %{http_code}\n" $BASE/api/sessions/1/confirmations         -H "Authorization: Bearer $TOKEN"
+# Booking actions (PUT): confirm/cancel/complete/noshow/checkin/start-therapy on a known session id
+curl.exe -s -o /dev/null -w "complete     -> %{http_code}\n" -X PUT $BASE/api/sessions/1/complete       -H "Authorization: Bearer $TOKEN"
+```
+**Expect:** the same status codes you got before the split (200/204/400/404 per input), and error
+bodies as RFC 7807 `application/problem+json` (from Chunk 3A). Swagger should list every route exactly
+as before, just grouped under the new controllers.
+
+## Automated coverage
+- Existing `SessionsControllerTests` (session-event endpoints) — unchanged behavior, pass with the
+  slimmed constructor.
+- `SplitSessionControllersTests` — init/DI smoke tests for the three new controllers.
+- Full suite green (199 tests); build clean.

--- a/src/Web/Common/RouteDates.cs
+++ b/src/Web/Common/RouteDates.cs
@@ -1,0 +1,15 @@
+namespace Neurocorp.Api.Web.Common;
+
+/// <summary>
+/// Helpers for parsing date values that arrive as route segments. Shared by the controllers that
+/// were split out of the former god SessionsController (Sessions + Schedule).
+/// </summary>
+public static class RouteDates
+{
+    /// <summary>
+    /// Parse a route date string, falling back to today (UTC) when it cannot be parsed.
+    /// Preserves the lenient behavior of the original SessionsController.ConvertStringToDateOnly.
+    /// </summary>
+    public static DateOnly ParseOrToday(string dateString)
+        => DateOnly.TryParse(dateString, out var date) ? date : DateOnly.FromDateTime(DateTime.UtcNow);
+}

--- a/src/Web/Controllers/BookingController.cs
+++ b/src/Web/Controllers/BookingController.cs
@@ -1,0 +1,131 @@
+using Microsoft.AspNetCore.Mvc;
+using Neurocorp.Api.Core.BusinessObjects.Lookups;
+using Neurocorp.Api.Core.BusinessObjects.Sessions;
+using Neurocorp.Api.Core.Interfaces.Services;
+
+namespace Neurocorp.Api.Web.Controllers;
+
+// Appointment booking lifecycle, split out of SessionsController (Chunk 4). Keeps the api/sessions
+// route prefix so all URLs are unchanged. Errors bubble to the global ProblemDetails handler (3A).
+[ApiController]
+[Route("api/sessions")]
+public class BookingController : ControllerBase
+{
+    private readonly IBookingService _bookingService;
+
+    public BookingController(IBookingService bookingService)
+    {
+        _bookingService = bookingService;
+    }
+
+    [HttpGet("statuses")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<LookupItem>))]
+    public async Task<IActionResult> GetStatuses()
+    {
+        var statuses = await _bookingService.GetStatusesAsync();
+        return Ok(statuses);
+    }
+
+    [HttpPut("{id}/confirm")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(SessionEvent))]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> ConfirmAppointment(int id, [FromBody] ConfirmationRequest request)
+    {
+        var result = await _bookingService.ConfirmAppointmentAsync(id, request);
+        return Ok(result);
+    }
+
+    [HttpPut("{id}/cancel")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(SessionEvent))]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> CancelAppointment(int id, [FromBody] CancelRequest request)
+    {
+        var result = await _bookingService.CancelAppointmentAsync(id, request.Reason);
+        return Ok(result);
+    }
+
+    [HttpPut("{id}/complete")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(SessionEvent))]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> CompleteAppointment(int id)
+    {
+        var result = await _bookingService.UpdateStatusAsync(id, 4); // Completed
+        return Ok(result);
+    }
+
+    [HttpPut("{id}/noshow")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(SessionEvent))]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> NoShowAppointment(int id)
+    {
+        var result = await _bookingService.UpdateStatusAsync(id, 5); // NoShow
+        return Ok(result);
+    }
+
+    [HttpPut("{id}/checkin")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(SessionEvent))]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> CheckInAppointment(int id)
+    {
+        var result = await _bookingService.UpdateStatusAsync(id, 6); // CheckedIn
+        return Ok(result);
+    }
+
+    [HttpPut("{id}/start-therapy")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(SessionEvent))]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> StartTherapy(int id)
+    {
+        var result = await _bookingService.UpdateStatusAsync(id, 7); // InTherapy
+        return Ok(result);
+    }
+
+    [HttpGet("unconfirmed")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<SessionEvent>))]
+    public async Task<IActionResult> GetUnconfirmed([FromQuery] string? from = null, [FromQuery] string? to = null, [FromQuery] int days = 7)
+    {
+        DateOnly fromDate, toDate;
+        if (from != null || to != null)
+        {
+            fromDate = from != null ? DateOnly.Parse(from) : DateOnly.FromDateTime(DateTime.UtcNow);
+            toDate = to != null ? DateOnly.Parse(to) : fromDate.AddDays(7);
+        }
+        else
+        {
+            if (days > 30) days = 30;
+            fromDate = DateOnly.FromDateTime(DateTime.UtcNow);
+            toDate = fromDate.AddDays(days);
+        }
+        var sessions = await _bookingService.GetUnconfirmedAsync(fromDate, toDate);
+        return Ok(sessions);
+    }
+
+    [HttpGet("upcoming")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<SessionEvent>))]
+    public async Task<IActionResult> GetUpcoming([FromQuery] string? from = null, [FromQuery] string? to = null, [FromQuery] int days = 7)
+    {
+        DateOnly fromDate, toDate;
+        if (from != null || to != null)
+        {
+            fromDate = from != null ? DateOnly.Parse(from) : DateOnly.FromDateTime(DateTime.UtcNow);
+            toDate = to != null ? DateOnly.Parse(to) : fromDate.AddDays(7);
+        }
+        else
+        {
+            if (days > 30) days = 30;
+            fromDate = DateOnly.FromDateTime(DateTime.UtcNow);
+            toDate = fromDate.AddDays(days);
+        }
+        var sessions = await _bookingService.GetUpcomingAsync(fromDate, toDate);
+        return Ok(sessions);
+    }
+
+    [HttpGet("{id}/confirmations")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<ConfirmationRecord>))]
+    public async Task<IActionResult> GetConfirmations(int id)
+    {
+        var confirmations = await _bookingService.GetConfirmationsAsync(id);
+        return Ok(confirmations);
+    }
+}

--- a/src/Web/Controllers/ScheduleController.cs
+++ b/src/Web/Controllers/ScheduleController.cs
@@ -1,0 +1,30 @@
+using Microsoft.AspNetCore.Mvc;
+using Neurocorp.Api.Core.BusinessObjects.Sessions;
+using Neurocorp.Api.Core.Interfaces.Services;
+using Neurocorp.Api.Web.Common;
+
+namespace Neurocorp.Api.Web.Controllers;
+
+// Schedule-matrix endpoint, split out of SessionsController (Chunk 4). Keeps the api/sessions route
+// prefix so the URL is unchanged.
+[ApiController]
+[Route("api/sessions")]
+public class ScheduleController : ControllerBase
+{
+    private readonly IScheduleMatrixService _scheduleMatrixService;
+
+    public ScheduleController(IScheduleMatrixService scheduleMatrixService)
+    {
+        _scheduleMatrixService = scheduleMatrixService;
+    }
+
+    [HttpGet("{dateString}/schedule-matrix")]
+    [ProducesResponseType(typeof(ScheduleMatrixResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> GetScheduleMatrix(string dateString, [FromQuery] int siteId)
+    {
+        var targetDate = RouteDates.ParseOrToday(dateString);
+        var result = await _scheduleMatrixService.GetMatrixAsync(targetDate, siteId);
+        return Ok(result);
+    }
+}

--- a/src/Web/Controllers/SessionPaymentsController.cs
+++ b/src/Web/Controllers/SessionPaymentsController.cs
@@ -1,0 +1,27 @@
+using Microsoft.AspNetCore.Mvc;
+using Neurocorp.Api.Core.BusinessObjects.Payments;
+using Neurocorp.Api.Core.Interfaces.Services;
+
+namespace Neurocorp.Api.Web.Controllers;
+
+// Session-payment query, split out of SessionsController (Chunk 4). Keeps the api/sessions route
+// prefix so the URL is unchanged.
+[ApiController]
+[Route("api/sessions")]
+public class SessionPaymentsController : ControllerBase
+{
+    private readonly IPaymentRecordService _paymentService;
+
+    public SessionPaymentsController(IPaymentRecordService paymentService)
+    {
+        _paymentService = paymentService;
+    }
+
+    [HttpGet("{id}/payments")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<SessionPaymentDetail>))]
+    public async Task<IActionResult> GetSessionPayments(int id)
+    {
+        var payments = await _paymentService.GetPaymentsForSessionAsync(id);
+        return Ok(payments);
+    }
+}

--- a/src/Web/Controllers/SessionsController.cs
+++ b/src/Web/Controllers/SessionsController.cs
@@ -1,33 +1,23 @@
 using Microsoft.AspNetCore.Mvc;
-using Neurocorp.Api.Core.BusinessObjects.Lookups;
-using Neurocorp.Api.Core.BusinessObjects.Payments;
 using Neurocorp.Api.Core.BusinessObjects.Sessions;
 using Neurocorp.Api.Core.Interfaces.Services;
+using Neurocorp.Api.Web.Common;
 
 namespace Neurocorp.Api.Web.Controllers;
 
+// Core session-event endpoints. Booking lifecycle, schedule matrix, and session-payment queries
+// were split out of this former god controller (Chunk 4) into BookingController,
+// ScheduleController, and SessionPaymentsController — all sharing the api/sessions route prefix so
+// existing URLs are unchanged.
 [ApiController]
-[Route("api/[controller]")]
+[Route("api/sessions")]
 public class SessionsController : ControllerBase
 {
-    private readonly ILogger<SessionsController> _logger;
     private readonly IHandleSessionEvent _sessionEventHandler;
-    private readonly IPaymentRecordService _paymentService;
-    private readonly IBookingService _bookingService;
-    private readonly IScheduleMatrixService _scheduleMatrixService;
 
-    public SessionsController(
-        ILogger<SessionsController> loger,
-        IHandleSessionEvent handler,
-        IPaymentRecordService paymentService,
-        IBookingService bookingService,
-        IScheduleMatrixService scheduleMatrixService)
+    public SessionsController(IHandleSessionEvent handler)
     {
-        _logger = loger;
         _sessionEventHandler = handler;
-        _paymentService = paymentService;
-        _bookingService = bookingService;
-        _scheduleMatrixService = scheduleMatrixService;
     }
 
     [HttpGet("{dateString}/all")]
@@ -35,19 +25,9 @@ public class SessionsController : ControllerBase
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetAllEventsForADate(string dateString)
     {
-        var targetDate = ConvertStringToDateOnly(dateString);
+        var targetDate = RouteDates.ParseOrToday(dateString);
         var sessions = await _sessionEventHandler.GetAllByTargetDateAsync(targetDate);
         return Ok(sessions);
-    }
-
-    [HttpGet("{dateString}/schedule-matrix")]
-    [ProducesResponseType(typeof(ScheduleMatrixResponse), StatusCodes.Status200OK)]
-    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
-    public async Task<IActionResult> GetScheduleMatrix(string dateString, [FromQuery] int siteId)
-    {
-        var targetDate = ConvertStringToDateOnly(dateString);
-        var result = await _scheduleMatrixService.GetMatrixAsync(targetDate, siteId);
-        return Ok(result);
     }
 
     [HttpGet("pastdue")]
@@ -91,138 +71,4 @@ public class SessionsController : ControllerBase
         var sessions = await _sessionEventHandler.GetCompletedDiscoverySessionsAsync(patientId);
         return Ok(sessions);
     }
-
-    [HttpGet("{id}/payments")]
-    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<SessionPaymentDetail>))]
-    public async Task<IActionResult> GetSessionPayments(int id)
-    {
-        var payments = await _paymentService.GetPaymentsForSessionAsync(id);
-        return Ok(payments);
-    }
-
-    // --- Appointment Booking Endpoints ---
-
-    [HttpGet("statuses")]
-    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<LookupItem>))]
-    public async Task<IActionResult> GetStatuses()
-    {
-        var statuses = await _bookingService.GetStatusesAsync();
-        return Ok(statuses);
-    }
-
-    [HttpPut("{id}/confirm")]
-    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(SessionEvent))]
-    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
-    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
-    public async Task<IActionResult> ConfirmAppointment(int id, [FromBody] ConfirmationRequest request)
-    {
-        var result = await _bookingService.ConfirmAppointmentAsync(id, request);
-        return Ok(result);
-    }
-
-    [HttpPut("{id}/cancel")]
-    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(SessionEvent))]
-    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
-    public async Task<IActionResult> CancelAppointment(int id, [FromBody] CancelRequest request)
-    {
-        var result = await _bookingService.CancelAppointmentAsync(id, request.Reason);
-        return Ok(result);
-    }
-
-    [HttpPut("{id}/complete")]
-    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(SessionEvent))]
-    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
-    public async Task<IActionResult> CompleteAppointment(int id)
-    {
-        var result = await _bookingService.UpdateStatusAsync(id, 4); // Completed
-        return Ok(result);
-    }
-
-    [HttpPut("{id}/noshow")]
-    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(SessionEvent))]
-    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
-    public async Task<IActionResult> NoShowAppointment(int id)
-    {
-        var result = await _bookingService.UpdateStatusAsync(id, 5); // NoShow
-        return Ok(result);
-    }
-
-    [HttpPut("{id}/checkin")]
-    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(SessionEvent))]
-    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
-    public async Task<IActionResult> CheckInAppointment(int id)
-    {
-        var result = await _bookingService.UpdateStatusAsync(id, 6); // CheckedIn
-        return Ok(result);
-    }
-
-    [HttpPut("{id}/start-therapy")]
-    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(SessionEvent))]
-    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
-    public async Task<IActionResult> StartTherapy(int id)
-    {
-        var result = await _bookingService.UpdateStatusAsync(id, 7); // InTherapy
-        return Ok(result);
-    }
-
-    [HttpGet("unconfirmed")]
-    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<SessionEvent>))]
-    public async Task<IActionResult> GetUnconfirmed([FromQuery] string? from = null, [FromQuery] string? to = null, [FromQuery] int days = 7)
-    {
-        DateOnly fromDate, toDate;
-        if (from != null || to != null)
-        {
-            fromDate = from != null ? DateOnly.Parse(from) : DateOnly.FromDateTime(DateTime.UtcNow);
-            toDate = to != null ? DateOnly.Parse(to) : fromDate.AddDays(7);
-        }
-        else
-        {
-            if (days > 30) days = 30;
-            fromDate = DateOnly.FromDateTime(DateTime.UtcNow);
-            toDate = fromDate.AddDays(days);
-        }
-        var sessions = await _bookingService.GetUnconfirmedAsync(fromDate, toDate);
-        return Ok(sessions);
-    }
-
-    [HttpGet("upcoming")]
-    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<SessionEvent>))]
-    public async Task<IActionResult> GetUpcoming([FromQuery] string? from = null, [FromQuery] string? to = null, [FromQuery] int days = 7)
-    {
-        DateOnly fromDate, toDate;
-        if (from != null || to != null)
-        {
-            fromDate = from != null ? DateOnly.Parse(from) : DateOnly.FromDateTime(DateTime.UtcNow);
-            toDate = to != null ? DateOnly.Parse(to) : fromDate.AddDays(7);
-        }
-        else
-        {
-            if (days > 30) days = 30;
-            fromDate = DateOnly.FromDateTime(DateTime.UtcNow);
-            toDate = fromDate.AddDays(days);
-        }
-        var sessions = await _bookingService.GetUpcomingAsync(fromDate, toDate);
-        return Ok(sessions);
-    }
-
-    [HttpGet("{id}/confirmations")]
-    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<ConfirmationRecord>))]
-    public async Task<IActionResult> GetConfirmations(int id)
-    {
-        var confirmations = await _bookingService.GetConfirmationsAsync(id);
-        return Ok(confirmations);
-    }
-
-    public static DateOnly ConvertStringToDateOnly(string dateString)
-    {
-        if (DateOnly.TryParse(dateString, out DateOnly date))
-        {
-            return date;
-        }
-        else
-        {
-            return DateOnly.FromDateTime(DateTime.UtcNow);
-        }
-    }
-
 }

--- a/tests/Web.Tests/SessionsControllerTests.cs
+++ b/tests/Web.Tests/SessionsControllerTests.cs
@@ -19,26 +19,21 @@ public class SessionsControllerTests
 
     public SessionsControllerTests()
     {
-        var fakeLogger = Mock.Of<ILogger<SessionsController>>();
+        // After the Chunk 4 split, SessionsController only handles core session events
+        // (booking/schedule/payments moved to their own controllers), so it depends on
+        // IHandleSessionEvent alone.
         _mockSessionEventHandler = new Mock<IHandleSessionEvent>(MockBehavior.Strict);
-        var mockPaymentService = Mock.Of<IPaymentRecordService>();
-        var mockBookingService = Mock.Of<IBookingService>();
-        var mockScheduleMatrixService = Mock.Of<IScheduleMatrixService>();
-        _controller = new SessionsController(fakeLogger, _mockSessionEventHandler.Object, mockPaymentService, mockBookingService, mockScheduleMatrixService);
+        _controller = new SessionsController(_mockSessionEventHandler.Object);
     }
 
     [Fact]
     public void Should_Initialize()
     {
         // arrange
-        var fakeLogger = Mock.Of<ILogger<SessionsController>>();
         var fakeEvHandler = Mock.Of<IHandleSessionEvent>();
 
         // act
-        var fakePaymentService = Mock.Of<IPaymentRecordService>();
-        var fakeBookingService = Mock.Of<IBookingService>();
-        var fakeScheduleMatrixService = Mock.Of<IScheduleMatrixService>();
-        var sut = new SessionsController(fakeLogger, fakeEvHandler, fakePaymentService, fakeBookingService, fakeScheduleMatrixService);
+        var sut = new SessionsController(fakeEvHandler);
 
         // assert
         sut.Should().NotBeNull();

--- a/tests/Web.Tests/SplitSessionControllersTests.cs
+++ b/tests/Web.Tests/SplitSessionControllersTests.cs
@@ -1,0 +1,32 @@
+using FluentAssertions;
+using Moq;
+using Neurocorp.Api.Core.Interfaces.Services;
+using Neurocorp.Api.Web.Controllers;
+
+namespace Web.Tests.Controllers;
+
+// Smoke tests for the controllers split out of the former god SessionsController in Chunk 4.
+// Each now depends only on the single service it needs (the basis for cleaner future claims policies).
+public class SplitSessionControllersTests
+{
+    [Fact]
+    public void BookingController_initializes_with_only_booking_service()
+    {
+        var sut = new BookingController(Mock.Of<IBookingService>());
+        sut.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void ScheduleController_initializes_with_only_schedule_service()
+    {
+        var sut = new ScheduleController(Mock.Of<IScheduleMatrixService>());
+        sut.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void SessionPaymentsController_initializes_with_only_payment_service()
+    {
+        var sut = new SessionPaymentsController(Mock.Of<IPaymentRecordService>());
+        sut.Should().NotBeNull();
+    }
+}


### PR DESCRIPTION
Split SessionsController's 17 endpoints along service boundaries into four focused controllers, all sharing the api/sessions route prefix so every URL, method, request/response shape, and status code is unchanged (zero breaking changes).

- SessionsController (slimmed): core session events via IHandleSessionEvent ({date}/all, pastdue, POST, PUT {id}, patient/{id}/discovery). Dropped the unused logger and the 3 services it no longer needs.
- BookingController (new): full booking lifecycle via IBookingService (statuses, confirm/cancel/complete/noshow/checkin/start-therapy, unconfirmed, upcoming, {id}/confirmations).
- ScheduleController (new): {date}/schedule-matrix via IScheduleMatrixService.
- SessionPaymentsController (new): {id}/payments via IPaymentRecordService.
- Each controller uses explicit [Route("api/sessions")] (no [controller] token); verified no action-template collisions. Each injects only the one service it needs — the basis for cleaner per-boundary claims policies later.
- Extracted the shared date helper to Web/Common/RouteDates.ParseOrToday.
- Error handling unchanged: exceptions bubble to the 3A GlobalExceptionHandler.

Tests: slimmed SessionsControllerTests constructor (session-event tests unchanged); added init/DI smoke tests for the three new controllers. Full suite green (199). Route-preservation curl matrix: docs/sessions-split-4-verification.md.