### PR TITLE
Remediation 2026 Chunk 2: modularize EF Core mapping (config classes)

### DIFF
--- a/src/Infrastructure/Data/ApplicationDbContext.cs
+++ b/src/Infrastructure/Data/ApplicationDbContext.cs
@@ -44,7 +44,7 @@ public class ApplicationDbContext : DbContext
     {
         var entries = ChangeTracker
             .Entries()
-            .Where(e => e.Entity is AuditableEntityBase && 
+            .Where(e => e.Entity is AuditableEntityBase &&
                         (e.State == EntityState.Added || e.State == EntityState.Modified));
 
         foreach (var entityEntry in entries)
@@ -66,7 +66,7 @@ public class ApplicationDbContext : DbContext
     {
         var entries = ChangeTracker
             .Entries()
-            .Where(e => e.Entity is AuditableEntityBase && 
+            .Where(e => e.Entity is AuditableEntityBase &&
                         (e.State == EntityState.Added || e.State == EntityState.Modified));
 
         foreach (var entityEntry in entries)
@@ -84,209 +84,13 @@ public class ApplicationDbContext : DbContext
         return await base.SaveChangesAsync(cancellationToken);
     }
 
-    // Override OnModelCreating if needed
+    // EF Core mappings live in IEntityTypeConfiguration<T> classes under Data/Configurations,
+    // applied here by assembly scan (Chunk 2 — modularized from a ~180-line inline block).
+    // DB column names (PatientID, SessionID, …) are preserved; the C# PK rename is a deferred follow-up.
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
-
-        // Entity name mappings...
-        modelBuilder.Entity<Patient>(p =>{
-            p.ToTable("Patient");
-            p.HasKey(e => e.Id);
-            p.Property(e => e.Id).HasColumnName("PatientID");
-        });
-        modelBuilder.Entity<User>(u => {
-            u.ToTable("SystemUser");
-            u.HasKey(e => e.Id);
-            u.Property(e => e.Id).HasColumnName("UserID");
-        });
-        modelBuilder.Entity<Caretaker>(ct => {
-            ct.ToTable("Caretaker");
-            ct.HasKey(e => e.Id);
-            ct.Property(e => e.Id).HasColumnName("CaretakerID");
-            ct.Property(e => e.Notes).IsRequired(false);
-        });
-        modelBuilder.Entity<Therapist>(t => {
-            t.ToTable("Therapist");
-            t.HasKey(e => e.Id);
-            t.Property(e => e.Id).HasColumnName("TherapistID");
-        });
-        modelBuilder.Entity<TherapySession>(ts =>{
-            ts.ToTable("TherapySession");
-            ts.HasKey(e => e.Id);
-            ts.Property(e => e.Id).HasColumnName("SessionID");
-            ts.Property(e => e.TherapyTypes).IsRequired(false);
-            ts.HasOne(e => e.AppointmentStatus)
-                .WithMany()
-                .HasForeignKey(e => e.AppointmentStatusId);
-            ts.HasMany(e => e.Confirmations)
-                .WithOne(c => c.TherapySession)
-                .HasForeignKey(c => c.SessionId);
-            ts.HasOne(e => e.Site)
-                .WithMany(s => s.TherapySessions)
-                .HasForeignKey(e => e.SiteId);
-            ts.HasOne(e => e.SpecialtyType)
-                .WithMany()
-                .HasForeignKey(e => e.SpecialtyTypeId);
-            ts.HasOne(e => e.TreatmentPlanLine)
-                .WithMany(tpl => tpl.TherapySessions)
-                .HasForeignKey(e => e.TreatmentPlanLineId)
-                .HasConstraintName("TherapySession_ibfk_planline");
-            ts.Property(e => e.TreatmentPlanLineId).HasColumnName("TreatmentPlanLineID");
-        });
-        modelBuilder.Entity<Site>(s => {
-            s.ToTable("Site");
-            s.HasKey(e => e.Id);
-            s.Property(e => e.Id).HasColumnName("SiteID");
-            s.Property(e => e.SiteName).IsRequired();
-            s.Property(e => e.RUC).IsRequired(false);
-            s.Property(e => e.Address).IsRequired(false);
-            s.Property(e => e.Latitude).IsRequired(false);
-            s.Property(e => e.Longitude).IsRequired(false);
-        });
-        modelBuilder.Entity<UserRole>(ur => {
-            ur.ToTable("UserRole");
-            ur.HasKey(e => e.Id);
-            ur.Property(e => e.Id).HasColumnName("UserRoleID");
-            ur.Ignore(e => e.RoleCreatedOn);
-        });
-        modelBuilder.Entity<RoleClaim>(rc => {
-            rc.ToTable("RoleClaim");
-            rc.HasKey(e => e.Id);
-            rc.Property(e => e.Id).HasColumnName("RoleClaimID");
-            rc.Property(e => e.RoleId).HasColumnName("RoleID");
-        });
-        modelBuilder.Entity<UserClaim>(uc => {
-            uc.ToTable("UserClaim");
-            uc.HasKey(e => e.Id);
-            uc.Property(e => e.Id).HasColumnName("UserClaimID");
-            uc.Property(e => e.UserId).HasColumnName("UserID");
-        });
-        modelBuilder.Entity<Payment>(p => {
-            p.ToTable("Payment");
-            p.HasKey(e => e.Id);
-            p.Property(e => e.Id).HasColumnName("PaymentID");
-            p.Property(e => e.CaretakerId).HasColumnName("PaidBy");
-        });
-        modelBuilder.Entity<SessionPayment>(sp => {
-            sp.ToTable("SessionPayment");
-            sp.HasKey(e => e.Id);
-            sp.Property(e => e.Id).HasColumnName("SessionPaymentID");
-            sp.Property(e => e.TherapySessionId).HasColumnName("SessionID");
-            sp.Property(e => e.PaymentId).HasColumnName("PaymentID");
-        });
-        modelBuilder.Entity<PaymentType>(pt => {
-            pt.ToTable("PaymentType");
-            pt.HasKey(e => e.Id);
-            pt.Property(e => e.Id).HasColumnName("PaymentTypeID");
-            pt.Property(e => e.Abbreviation).HasColumnName("PmtTypeAbbreviation");
-            pt.Property(e => e.Name).HasColumnName("PmtTypeName");
-            pt.Property(e => e.Description).HasColumnName("PmtTypeDescription");
-        });
-        modelBuilder.Entity<AppointmentStatus>(ast => {
-            ast.ToTable("AppointmentStatus");
-            ast.HasKey(e => e.Id);
-            ast.Property(e => e.Id).HasColumnName("AppointmentStatusID");
-            ast.Property(e => e.Abbreviation).HasColumnName("StatusAbbreviation");
-            ast.Property(e => e.Name).HasColumnName("StatusName");
-            ast.Property(e => e.Description).HasColumnName("StatusDescription");
-        });
-        modelBuilder.Entity<AppointmentConfirmation>(ac => {
-            ac.ToTable("AppointmentConfirmation");
-            ac.HasKey(e => e.Id);
-            ac.Property(e => e.Id).HasColumnName("ConfirmationID");
-            ac.Property(e => e.SessionId).HasColumnName("SessionID");
-        });
-        modelBuilder.Entity<RoleType>(rt => {
-            rt.ToTable("RoleType");
-            rt.HasKey(e => e.Id);
-            rt.Property(e => e.Id).HasColumnName("RoleID");
-            rt.Property(e => e.Abbreviation).HasColumnName("RoleAbbreviation");
-            rt.Property(e => e.Name).HasColumnName("RoleName");
-            rt.Property(e => e.Description).HasColumnName("RoleDescription");
-        });
-        modelBuilder.Entity<SpecialtyType>(st => {
-            st.ToTable("SpecialtyType");
-            st.HasKey(e => e.Id);
-            st.Property(e => e.Id).HasColumnName("SpecialtyID");
-            st.Property(e => e.Abbreviation).HasColumnName("SpecialtyAbbreviation");
-            st.Property(e => e.Name).HasColumnName("SpecialtyName");
-            st.Property(e => e.Description).HasColumnName("SpecialtyDescription");
-        });
-        modelBuilder.Entity<TherapistSpecialty>(ts => {
-            ts.ToTable("TherapistSpecialty");
-            ts.HasKey(e => e.Id);
-            ts.Property(e => e.Id).HasColumnName("TherapistSpecialtyID");
-            ts.Property(e => e.TherapistId).HasColumnName("TherapistID");
-            ts.Property(e => e.SpecialtyId).HasColumnName("SpecialtyID");
-            ts.HasOne(e => e.Therapist)
-                .WithMany(t => t.TherapistSpecialties)
-                .HasForeignKey(e => e.TherapistId);
-            ts.HasOne(e => e.SpecialtyType)
-                .WithMany()
-                .HasForeignKey(e => e.SpecialtyId);
-            ts.HasIndex(e => new { e.TherapistId, e.SpecialtyId })
-                .IsUnique();
-        });
-        modelBuilder.Entity<PatientCaretaker>(entity =>
-        {
-            entity.ToTable("PatientCaretaker");
-            entity.HasKey(pc => pc.Id);
-            entity.Property(pc => pc.Id).HasColumnName("PatientCaretakerID");
-
-            entity.HasOne(pc => pc.Patient)
-                .WithMany(p => p.Caretakers)
-                .HasForeignKey(pc => pc.PatientId);
-
-            entity.HasOne(pc => pc.Caretaker)
-                .WithMany(c => c.Patients)
-                .HasForeignKey(pc => pc.CaretakerId);
-
-            entity.Property(pc => pc.PrimaryCaretaker)
-                .IsRequired();
-
-            entity.Property(pc => pc.RelationshipToPatient)
-                .IsRequired(false);
-
-            // Unique constraint to prevent duplicate caretaker assignments per patient
-            entity.HasIndex(pc => new { pc.PatientId, pc.CaretakerId })
-                .IsUnique();
-        });
-        modelBuilder.Entity<TreatmentPlan>(tp => {
-            tp.ToTable("TreatmentPlan");
-            tp.HasKey(e => e.Id);
-            tp.Property(e => e.Id).HasColumnName("TreatmentPlanID");
-            tp.Property(e => e.PatientId).HasColumnName("PatientID");
-            tp.Property(e => e.DiscoverySessionId).HasColumnName("DiscoverySessionID");
-            tp.Property(e => e.CreatedByTherapistId).HasColumnName("CreatedByTherapistID");
-            tp.Property(e => e.ResultsDocumentUrl).IsRequired(false);
-            tp.Property(e => e.Notes).IsRequired(false);
-            tp.HasOne(e => e.Patient)
-                .WithMany()
-                .HasForeignKey(e => e.PatientId);
-            tp.HasOne(e => e.DiscoverySession)
-                .WithMany()
-                .HasForeignKey(e => e.DiscoverySessionId);
-            tp.HasOne(e => e.CreatedByTherapist)
-                .WithMany()
-                .HasForeignKey(e => e.CreatedByTherapistId);
-            tp.HasMany(e => e.Lines)
-                .WithOne(l => l.TreatmentPlan)
-                .HasForeignKey(l => l.TreatmentPlanId);
-        });
-        modelBuilder.Entity<TreatmentPlanLine>(tpl => {
-            tpl.ToTable("TreatmentPlanLine");
-            tpl.HasKey(e => e.Id);
-            tpl.Property(e => e.Id).HasColumnName("TreatmentPlanLineID");
-            tpl.Property(e => e.TreatmentPlanId).HasColumnName("TreatmentPlanID");
-            tpl.Property(e => e.PreferredTherapistId).HasColumnName("PreferredTherapistID");
-            tpl.HasOne(e => e.SpecialtyType)
-                .WithMany()
-                .HasForeignKey(e => e.SpecialtyTypeId);
-            tpl.HasOne(e => e.PreferredTherapist)
-                .WithMany()
-                .HasForeignKey(e => e.PreferredTherapistId);
-        });
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(ApplicationDbContext).Assembly);
     }
 
     private int GetCurrentUserId()

--- a/src/Infrastructure/Data/Configurations/AuthConfigurations.cs
+++ b/src/Infrastructure/Data/Configurations/AuthConfigurations.cs
@@ -1,0 +1,54 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Neurocorp.Api.Core.Entities;
+
+namespace Neurocorp.Api.Infrastructure.Data.Configurations;
+
+// EF Core mapping for roles, role/user claims, and user-role membership.
+// Extracted verbatim from ApplicationDbContext.OnModelCreating (Chunk 2).
+
+public class UserRoleConfiguration : IEntityTypeConfiguration<UserRole>
+{
+    public void Configure(EntityTypeBuilder<UserRole> builder)
+    {
+        builder.ToTable("UserRole");
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.Id).HasColumnName("UserRoleID");
+        builder.Ignore(e => e.RoleCreatedOn);
+    }
+}
+
+public class RoleClaimConfiguration : IEntityTypeConfiguration<RoleClaim>
+{
+    public void Configure(EntityTypeBuilder<RoleClaim> builder)
+    {
+        builder.ToTable("RoleClaim");
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.Id).HasColumnName("RoleClaimID");
+        builder.Property(e => e.RoleId).HasColumnName("RoleID");
+    }
+}
+
+public class UserClaimConfiguration : IEntityTypeConfiguration<UserClaim>
+{
+    public void Configure(EntityTypeBuilder<UserClaim> builder)
+    {
+        builder.ToTable("UserClaim");
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.Id).HasColumnName("UserClaimID");
+        builder.Property(e => e.UserId).HasColumnName("UserID");
+    }
+}
+
+public class RoleTypeConfiguration : IEntityTypeConfiguration<RoleType>
+{
+    public void Configure(EntityTypeBuilder<RoleType> builder)
+    {
+        builder.ToTable("RoleType");
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.Id).HasColumnName("RoleID");
+        builder.Property(e => e.Abbreviation).HasColumnName("RoleAbbreviation");
+        builder.Property(e => e.Name).HasColumnName("RoleName");
+        builder.Property(e => e.Description).HasColumnName("RoleDescription");
+    }
+}

--- a/src/Infrastructure/Data/Configurations/PaymentConfigurations.cs
+++ b/src/Infrastructure/Data/Configurations/PaymentConfigurations.cs
@@ -1,0 +1,43 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Neurocorp.Api.Core.Entities;
+
+namespace Neurocorp.Api.Infrastructure.Data.Configurations;
+
+// EF Core mapping for payments. Extracted verbatim from ApplicationDbContext.OnModelCreating (Chunk 2).
+
+public class PaymentConfiguration : IEntityTypeConfiguration<Payment>
+{
+    public void Configure(EntityTypeBuilder<Payment> builder)
+    {
+        builder.ToTable("Payment");
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.Id).HasColumnName("PaymentID");
+        builder.Property(e => e.CaretakerId).HasColumnName("PaidBy");
+    }
+}
+
+public class SessionPaymentConfiguration : IEntityTypeConfiguration<SessionPayment>
+{
+    public void Configure(EntityTypeBuilder<SessionPayment> builder)
+    {
+        builder.ToTable("SessionPayment");
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.Id).HasColumnName("SessionPaymentID");
+        builder.Property(e => e.TherapySessionId).HasColumnName("SessionID");
+        builder.Property(e => e.PaymentId).HasColumnName("PaymentID");
+    }
+}
+
+public class PaymentTypeConfiguration : IEntityTypeConfiguration<PaymentType>
+{
+    public void Configure(EntityTypeBuilder<PaymentType> builder)
+    {
+        builder.ToTable("PaymentType");
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.Id).HasColumnName("PaymentTypeID");
+        builder.Property(e => e.Abbreviation).HasColumnName("PmtTypeAbbreviation");
+        builder.Property(e => e.Name).HasColumnName("PmtTypeName");
+        builder.Property(e => e.Description).HasColumnName("PmtTypeDescription");
+    }
+}

--- a/src/Infrastructure/Data/Configurations/PeopleConfigurations.cs
+++ b/src/Infrastructure/Data/Configurations/PeopleConfigurations.cs
@@ -1,0 +1,50 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Neurocorp.Api.Core.Entities;
+
+namespace Neurocorp.Api.Infrastructure.Data.Configurations;
+
+// EF Core mapping for the people entities. Extracted verbatim from ApplicationDbContext.OnModelCreating
+// (Chunk 2 — EF mapping modularization). Behavior is unchanged; the DB column names (PatientID,
+// UserID, etc.) are preserved while the C# PK property remains Id (rename deferred to a follow-up).
+
+public class PatientConfiguration : IEntityTypeConfiguration<Patient>
+{
+    public void Configure(EntityTypeBuilder<Patient> builder)
+    {
+        builder.ToTable("Patient");
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.Id).HasColumnName("PatientID");
+    }
+}
+
+public class UserConfiguration : IEntityTypeConfiguration<User>
+{
+    public void Configure(EntityTypeBuilder<User> builder)
+    {
+        builder.ToTable("SystemUser");
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.Id).HasColumnName("UserID");
+    }
+}
+
+public class CaretakerConfiguration : IEntityTypeConfiguration<Caretaker>
+{
+    public void Configure(EntityTypeBuilder<Caretaker> builder)
+    {
+        builder.ToTable("Caretaker");
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.Id).HasColumnName("CaretakerID");
+        builder.Property(e => e.Notes).IsRequired(false);
+    }
+}
+
+public class TherapistConfiguration : IEntityTypeConfiguration<Therapist>
+{
+    public void Configure(EntityTypeBuilder<Therapist> builder)
+    {
+        builder.ToTable("Therapist");
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.Id).HasColumnName("TherapistID");
+    }
+}

--- a/src/Infrastructure/Data/Configurations/ReferenceConfigurations.cs
+++ b/src/Infrastructure/Data/Configurations/ReferenceConfigurations.cs
@@ -1,0 +1,56 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Neurocorp.Api.Core.Entities;
+
+namespace Neurocorp.Api.Infrastructure.Data.Configurations;
+
+// EF Core mapping for sites and specialty reference data + the therapist-specialty link.
+// Extracted verbatim from ApplicationDbContext.OnModelCreating (Chunk 2).
+
+public class SiteConfiguration : IEntityTypeConfiguration<Site>
+{
+    public void Configure(EntityTypeBuilder<Site> builder)
+    {
+        builder.ToTable("Site");
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.Id).HasColumnName("SiteID");
+        builder.Property(e => e.SiteName).IsRequired();
+        builder.Property(e => e.RUC).IsRequired(false);
+        builder.Property(e => e.Address).IsRequired(false);
+        builder.Property(e => e.Latitude).IsRequired(false);
+        builder.Property(e => e.Longitude).IsRequired(false);
+    }
+}
+
+public class SpecialtyTypeConfiguration : IEntityTypeConfiguration<SpecialtyType>
+{
+    public void Configure(EntityTypeBuilder<SpecialtyType> builder)
+    {
+        builder.ToTable("SpecialtyType");
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.Id).HasColumnName("SpecialtyID");
+        builder.Property(e => e.Abbreviation).HasColumnName("SpecialtyAbbreviation");
+        builder.Property(e => e.Name).HasColumnName("SpecialtyName");
+        builder.Property(e => e.Description).HasColumnName("SpecialtyDescription");
+    }
+}
+
+public class TherapistSpecialtyConfiguration : IEntityTypeConfiguration<TherapistSpecialty>
+{
+    public void Configure(EntityTypeBuilder<TherapistSpecialty> builder)
+    {
+        builder.ToTable("TherapistSpecialty");
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.Id).HasColumnName("TherapistSpecialtyID");
+        builder.Property(e => e.TherapistId).HasColumnName("TherapistID");
+        builder.Property(e => e.SpecialtyId).HasColumnName("SpecialtyID");
+        builder.HasOne(e => e.Therapist)
+            .WithMany(t => t.TherapistSpecialties)
+            .HasForeignKey(e => e.TherapistId);
+        builder.HasOne(e => e.SpecialtyType)
+            .WithMany()
+            .HasForeignKey(e => e.SpecialtyId);
+        builder.HasIndex(e => new { e.TherapistId, e.SpecialtyId })
+            .IsUnique();
+    }
+}

--- a/src/Infrastructure/Data/Configurations/SessionConfigurations.cs
+++ b/src/Infrastructure/Data/Configurations/SessionConfigurations.cs
@@ -1,0 +1,60 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Neurocorp.Api.Core.Entities;
+
+namespace Neurocorp.Api.Infrastructure.Data.Configurations;
+
+// EF Core mapping for therapy sessions, appointment confirmations, and appointment status.
+// Extracted verbatim from ApplicationDbContext.OnModelCreating (Chunk 2).
+
+public class TherapySessionConfiguration : IEntityTypeConfiguration<TherapySession>
+{
+    public void Configure(EntityTypeBuilder<TherapySession> builder)
+    {
+        builder.ToTable("TherapySession");
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.Id).HasColumnName("SessionID");
+        builder.Property(e => e.TherapyTypes).IsRequired(false);
+        builder.HasOne(e => e.AppointmentStatus)
+            .WithMany()
+            .HasForeignKey(e => e.AppointmentStatusId);
+        builder.HasMany(e => e.Confirmations)
+            .WithOne(c => c.TherapySession)
+            .HasForeignKey(c => c.SessionId);
+        builder.HasOne(e => e.Site)
+            .WithMany(s => s.TherapySessions)
+            .HasForeignKey(e => e.SiteId);
+        builder.HasOne(e => e.SpecialtyType)
+            .WithMany()
+            .HasForeignKey(e => e.SpecialtyTypeId);
+        builder.HasOne(e => e.TreatmentPlanLine)
+            .WithMany(tpl => tpl.TherapySessions)
+            .HasForeignKey(e => e.TreatmentPlanLineId)
+            .HasConstraintName("TherapySession_ibfk_planline");
+        builder.Property(e => e.TreatmentPlanLineId).HasColumnName("TreatmentPlanLineID");
+    }
+}
+
+public class AppointmentConfirmationConfiguration : IEntityTypeConfiguration<AppointmentConfirmation>
+{
+    public void Configure(EntityTypeBuilder<AppointmentConfirmation> builder)
+    {
+        builder.ToTable("AppointmentConfirmation");
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.Id).HasColumnName("ConfirmationID");
+        builder.Property(e => e.SessionId).HasColumnName("SessionID");
+    }
+}
+
+public class AppointmentStatusConfiguration : IEntityTypeConfiguration<AppointmentStatus>
+{
+    public void Configure(EntityTypeBuilder<AppointmentStatus> builder)
+    {
+        builder.ToTable("AppointmentStatus");
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.Id).HasColumnName("AppointmentStatusID");
+        builder.Property(e => e.Abbreviation).HasColumnName("StatusAbbreviation");
+        builder.Property(e => e.Name).HasColumnName("StatusName");
+        builder.Property(e => e.Description).HasColumnName("StatusDescription");
+    }
+}

--- a/src/Infrastructure/Data/Configurations/TreatmentConfigurations.cs
+++ b/src/Infrastructure/Data/Configurations/TreatmentConfigurations.cs
@@ -1,0 +1,81 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Neurocorp.Api.Core.Entities;
+
+namespace Neurocorp.Api.Infrastructure.Data.Configurations;
+
+// EF Core mapping for the patient-caretaker link and treatment plans/lines.
+// Extracted verbatim from ApplicationDbContext.OnModelCreating (Chunk 2).
+
+public class PatientCaretakerConfiguration : IEntityTypeConfiguration<PatientCaretaker>
+{
+    public void Configure(EntityTypeBuilder<PatientCaretaker> builder)
+    {
+        builder.ToTable("PatientCaretaker");
+        builder.HasKey(pc => pc.Id);
+        builder.Property(pc => pc.Id).HasColumnName("PatientCaretakerID");
+
+        builder.HasOne(pc => pc.Patient)
+            .WithMany(p => p.Caretakers)
+            .HasForeignKey(pc => pc.PatientId);
+
+        builder.HasOne(pc => pc.Caretaker)
+            .WithMany(c => c.Patients)
+            .HasForeignKey(pc => pc.CaretakerId);
+
+        builder.Property(pc => pc.PrimaryCaretaker)
+            .IsRequired();
+
+        builder.Property(pc => pc.RelationshipToPatient)
+            .IsRequired(false);
+
+        // Unique constraint to prevent duplicate caretaker assignments per patient
+        builder.HasIndex(pc => new { pc.PatientId, pc.CaretakerId })
+            .IsUnique();
+    }
+}
+
+public class TreatmentPlanConfiguration : IEntityTypeConfiguration<TreatmentPlan>
+{
+    public void Configure(EntityTypeBuilder<TreatmentPlan> builder)
+    {
+        builder.ToTable("TreatmentPlan");
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.Id).HasColumnName("TreatmentPlanID");
+        builder.Property(e => e.PatientId).HasColumnName("PatientID");
+        builder.Property(e => e.DiscoverySessionId).HasColumnName("DiscoverySessionID");
+        builder.Property(e => e.CreatedByTherapistId).HasColumnName("CreatedByTherapistID");
+        builder.Property(e => e.ResultsDocumentUrl).IsRequired(false);
+        builder.Property(e => e.Notes).IsRequired(false);
+        builder.HasOne(e => e.Patient)
+            .WithMany()
+            .HasForeignKey(e => e.PatientId);
+        builder.HasOne(e => e.DiscoverySession)
+            .WithMany()
+            .HasForeignKey(e => e.DiscoverySessionId);
+        builder.HasOne(e => e.CreatedByTherapist)
+            .WithMany()
+            .HasForeignKey(e => e.CreatedByTherapistId);
+        builder.HasMany(e => e.Lines)
+            .WithOne(l => l.TreatmentPlan)
+            .HasForeignKey(l => l.TreatmentPlanId);
+    }
+}
+
+public class TreatmentPlanLineConfiguration : IEntityTypeConfiguration<TreatmentPlanLine>
+{
+    public void Configure(EntityTypeBuilder<TreatmentPlanLine> builder)
+    {
+        builder.ToTable("TreatmentPlanLine");
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.Id).HasColumnName("TreatmentPlanLineID");
+        builder.Property(e => e.TreatmentPlanId).HasColumnName("TreatmentPlanID");
+        builder.Property(e => e.PreferredTherapistId).HasColumnName("PreferredTherapistID");
+        builder.HasOne(e => e.SpecialtyType)
+            .WithMany()
+            .HasForeignKey(e => e.SpecialtyTypeId);
+        builder.HasOne(e => e.PreferredTherapist)
+            .WithMany()
+            .HasForeignKey(e => e.PreferredTherapistId);
+    }
+}


### PR DESCRIPTION
Extract the ~180-line ApplicationDbContext.OnModelCreating block into per-entity IEntityTypeConfiguration<T> classes and reduce OnModelCreating to a 3-line assembly-scan dispatcher. Behavior is identical — all mappings (table + DB column names like PatientID/SessionID, relationships, indexes, ignores) moved verbatim; no DB changes.

- New: Infrastructure/Data/Configurations/{People,Session,Payment,Auth,Reference, Treatment}Configurations.cs — 20 entity configurations grouped by domain.
- OnModelCreating -> base + ApplyConfigurationsFromAssembly(typeof(ApplicationDbContext).Assembly).

Scope (coordinator decision): modularize only this round; the PK-rename (entity Id -> PatientId/SessionId/...) is DEFERRED to a dedicated follow-up because it ripples across ~137 .Id sites + the shared base classes. The C# PK property stays Id; the column-name "dishonesty" is now contained in the per-entity config classes.

Verification: existing EF mapping tests (DbContextMappingTests, Payment/SessionPayment EntityMappingTests) pass unchanged — confirming preserved mapping. Build clean; full suite green (199 tests).