### PR TITLE
3A follow-up: ProblemDetails sweep of remaining controllers

### DIFF
--- a/src/Web/Controllers/CaretakersController.cs
+++ b/src/Web/Controllers/CaretakersController.cs
@@ -49,6 +49,8 @@ public class CaretakersController : ControllerBase
     }
 
     [HttpPost]
+    [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(CaretakerProfile))]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> CreateCaretaker([FromBody] CaretakerProfileRequest createRequest)
     {
         var createdCaretaker = await _caretakerProfileService.CreateAsync(createRequest);
@@ -56,21 +58,19 @@ public class CaretakersController : ControllerBase
     }
 
     [HttpPut("{id}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> UpdateCaretaker(int id, [FromBody] CaretakerProfileUpdateRequest updateRequest)
     {
-        if (await _caretakerProfileService.VerifyRequestAsync(id, updateRequest))
+        if (!await _caretakerProfileService.VerifyRequestAsync(id, updateRequest))
         {
-            var updateResult = await _caretakerProfileService.UpdateAsync(id, updateRequest);
-            if (updateResult)
-            {
-                return NoContent();
-            }
-            else
-            {
-                return BadRequest("Bad input?");
-            }
+            throw new ArgumentException($"The update request is not valid for caretaker {id}.");
         }
-        return BadRequest();
+        if (!await _caretakerProfileService.UpdateAsync(id, updateRequest))
+        {
+            throw new ArgumentException($"Caretaker {id} could not be updated.");
+        }
+        return NoContent();
     }
 
     [HttpGet("{id}/patients")]
@@ -84,7 +84,7 @@ public class CaretakersController : ControllerBase
 
     [HttpPost("{id}/patients")]
     [ProducesResponseType(StatusCodes.Status201Created)]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> LinkPatient(int id, [FromBody] PatientLinkRequest request)
     {
@@ -93,7 +93,8 @@ public class CaretakersController : ControllerBase
         {
             return Created($"/api/caretakers/{id}/patients", null);
         }
-        return BadRequest("Link already exists or invalid data.");
+        return Problem(statusCode: StatusCodes.Status400BadRequest,
+            detail: "Link already exists or invalid data.", title: "Bad Request");
     }
 
     [HttpDelete("{id}/patients/{patientId}")]

--- a/src/Web/Controllers/LookupsController.cs
+++ b/src/Web/Controllers/LookupsController.cs
@@ -17,11 +17,12 @@ public class LookupsController : ControllerBase
 
     [HttpGet]
     [ProducesResponseType(typeof(IEnumerable<LookupItem>), StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> GetAll(string tableName)
     {
         if (!_lookupService.IsValidTableName(tableName))
-            return BadRequest($"Invalid lookup table name: {tableName}");
+            return Problem(statusCode: StatusCodes.Status400BadRequest,
+                detail: $"Invalid lookup table name: {tableName}", title: "Bad Request");
 
         var items = await _lookupService.GetAllAsync(tableName);
         return Ok(items);
@@ -29,12 +30,13 @@ public class LookupsController : ControllerBase
 
     [HttpGet("{id}")]
     [ProducesResponseType(typeof(LookupItem), StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> GetById(string tableName, int id)
     {
         if (!_lookupService.IsValidTableName(tableName))
-            return BadRequest($"Invalid lookup table name: {tableName}");
+            return Problem(statusCode: StatusCodes.Status400BadRequest,
+                detail: $"Invalid lookup table name: {tableName}", title: "Bad Request");
 
         var item = await _lookupService.GetByIdAsync(tableName, id);
         if (item == null) return NotFound();
@@ -43,11 +45,12 @@ public class LookupsController : ControllerBase
 
     [HttpPost]
     [ProducesResponseType(typeof(LookupItem), StatusCodes.Status201Created)]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> Create(string tableName, [FromBody] LookupCreateRequest request)
     {
         if (!_lookupService.IsValidTableName(tableName))
-            return BadRequest($"Invalid lookup table name: {tableName}");
+            return Problem(statusCode: StatusCodes.Status400BadRequest,
+                detail: $"Invalid lookup table name: {tableName}", title: "Bad Request");
 
         var created = await _lookupService.CreateAsync(tableName, request);
         return CreatedAtAction(nameof(GetById), new { tableName, id = created.Id }, created);
@@ -55,12 +58,13 @@ public class LookupsController : ControllerBase
 
     [HttpPut("{id}")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Update(string tableName, int id, [FromBody] LookupUpdateRequest request)
     {
         if (!_lookupService.IsValidTableName(tableName))
-            return BadRequest($"Invalid lookup table name: {tableName}");
+            return Problem(statusCode: StatusCodes.Status400BadRequest,
+                detail: $"Invalid lookup table name: {tableName}", title: "Bad Request");
 
         var updated = await _lookupService.UpdateAsync(tableName, id, request);
         if (!updated) return NotFound();

--- a/src/Web/Controllers/PatientsController.cs
+++ b/src/Web/Controllers/PatientsController.cs
@@ -93,6 +93,8 @@ public class PatientsController : ControllerBase
     }
 
     [HttpPost]
+    [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(PatientProfile))]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> CreatePatient([FromBody] PatientProfileRequest patientRequest)
     {
         var createdPatient = await _patientProfileService.CreateAsync(patientRequest);
@@ -100,28 +102,30 @@ public class PatientsController : ControllerBase
     }
 
     [HttpPut("{id:int}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> UpdatePatient(int id, [FromBody] PatientProfileUpdateRequest patientRequest)
     {
-        if (await _patientProfileService.VerifyRequestAsync(id))
+        if (!await _patientProfileService.VerifyRequestAsync(id))
         {
-            try
-            {
-                var updateResult = await _patientProfileService.UpdateAsync(id, patientRequest);
-                if (updateResult)
-                {
-                    return NoContent();
-                }
-                else
-                {
-                    return BadRequest("Bad input?");
-                }
-            }
-            catch (InvalidOperationException ex)
-            {
-                return BadRequest(ex.Message);
-            }
+            return Problem(statusCode: StatusCodes.Status400BadRequest,
+                detail: $"The update request is not valid for patient {id}.", title: "Bad Request");
         }
-        return BadRequest();
+        try
+        {
+            if (!await _patientProfileService.UpdateAsync(id, patientRequest))
+            {
+                return Problem(statusCode: StatusCodes.Status400BadRequest,
+                    detail: $"Patient {id} could not be updated.", title: "Bad Request");
+            }
+            return NoContent();
+        }
+        catch (InvalidOperationException ex)
+        {
+            // Domain-rule violation surfaced as a 400 (kept explicit — the global handler maps
+            // InvalidOperationException to 500, not 400).
+            return Problem(statusCode: StatusCodes.Status400BadRequest, detail: ex.Message, title: "Bad Request");
+        }
     }
 
     private async Task<PatientPastDueInfo> PackagePastDueInfoAsync(int patientId)

--- a/src/Web/Controllers/PaymentsController.cs
+++ b/src/Web/Controllers/PaymentsController.cs
@@ -50,34 +50,20 @@ public class PaymentsController : ControllerBase
 
     [HttpPost]
     [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(PaymentRecord))]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> CreatePayment([FromBody] PaymentRecordRequest request)
     {
-        try
-        {
-            var created = await _paymentService.CreateAsync(request);
-            return CreatedAtAction(nameof(GetPayment), new { id = created.PaymentId }, created);
-        }
-        catch (ArgumentException ex)
-        {
-            return BadRequest(ex.Message);
-        }
+        var created = await _paymentService.CreateAsync(request);
+        return CreatedAtAction(nameof(GetPayment), new { id = created.PaymentId }, created);
     }
 
     [HttpPut("{id}")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> UpdatePayment(int id, [FromBody] PaymentRecordUpdateRequest request)
     {
-        try
-        {
-            await _paymentService.UpdateAsync(id, request);
-            return NoContent();
-        }
-        catch (ArgumentException ex)
-        {
-            return BadRequest(ex.Message);
-        }
+        await _paymentService.UpdateAsync(id, request);
+        return NoContent();
     }
 }

--- a/src/Web/Controllers/TherapistsController.cs
+++ b/src/Web/Controllers/TherapistsController.cs
@@ -58,72 +58,52 @@ public class TherapistsController : ControllerBase
         var pastDueInfo = await PackagePastDueInfoAsync(id);
         if (pastDueInfo is not null && pastDueInfo.Party!.IsValid)
         {
-            return Ok(pastDueInfo);  
+            return Ok(pastDueInfo);
         }
         return NotFound();
     }
 
     [HttpPost]
+    [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(TherapistProfile))]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> CreateTherapist([FromBody] TherapistProfileRequest therapistRequest)
     {
-        try
-        {
-            var createdTherapist = await _therapistProfileService.CreateAsync(therapistRequest);
-            return CreatedAtAction(nameof(GetTherapist), new { id = createdTherapist.TherapistId }, createdTherapist);
-        }
-        catch (ArgumentException ex)
-        {
-            return BadRequest(ex.Message);
-        }
+        var createdTherapist = await _therapistProfileService.CreateAsync(therapistRequest);
+        return CreatedAtAction(nameof(GetTherapist), new { id = createdTherapist.TherapistId }, createdTherapist);
     }
 
     [HttpPut("{id}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> UpdateTherapist(int id, [FromBody] TherapistProfileUpdateRequest therapistRequest)
     {
-        try
+        if (!await _therapistProfileService.VerifyRequestAsync(id))
         {
-            if (await _therapistProfileService.VerifyRequestAsync(id))
-            {
-                var updateResult = await _therapistProfileService.UpdateAsync(id, therapistRequest);
-                if (updateResult)
-                {
-                    return NoContent();
-                }
-                else
-                {
-                    return BadRequest("Bad input?");
-                }
-            }
-            return BadRequest();
+            throw new ArgumentException($"The update request is not valid for therapist {id}.");
         }
-        catch (ArgumentException ex)
+        if (!await _therapistProfileService.UpdateAsync(id, therapistRequest))
         {
-            return BadRequest(ex.Message);
+            throw new ArgumentException($"Therapist {id} could not be updated.");
         }
+        return NoContent();
     }
 
     [HttpGet("{id}/statement")]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(TherapistStatement))]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetStatement(int id, [FromQuery] DateOnly? from, [FromQuery] DateOnly? to)
     {
-        try
+        if (from.HasValue && to.HasValue && to.Value < from.Value)
         {
-            if (from.HasValue && to.HasValue && to.Value < from.Value)
-            {
-                return BadRequest("Query parameter 'to' must be on or after 'from'.");
-            }
+            return Problem(statusCode: StatusCodes.Status400BadRequest,
+                detail: "Query parameter 'to' must be on or after 'from'.", title: "Bad Request");
+        }
 
-            var statement = await _therapistStatementService.GetStatementAsync(id, from, to);
-            if (statement == null) return NotFound();
-            return Ok(statement);
-        }
-        catch (ArgumentException ex)
-        {
-            return BadRequest(ex.Message);
-        }
+        var statement = await _therapistStatementService.GetStatementAsync(id, from, to);
+        if (statement == null) return NotFound();
+        return Ok(statement);
     }
 
     private async Task<TherapistPastDueInfo> PackagePastDueInfoAsync(int therapistId)
@@ -148,8 +128,8 @@ public class TherapistsController : ControllerBase
                 PastDueTotalAmount = totalPastDueAmount,
                 AmountPaidSoFar = totalPaidSoFar,
                 Delinquency = patientPastDueSessions,
-            };    
-        }        
+            };
+        }
         return new TherapistPastDueInfo() { Party = new NotFoundProfile() };
-    }    
+    }
 }

--- a/src/Web/Controllers/TreatmentPlansController.cs
+++ b/src/Web/Controllers/TreatmentPlansController.cs
@@ -24,18 +24,11 @@ public class TreatmentPlansController : ControllerBase
 
     [HttpPost]
     [ProducesResponseType(typeof(TreatmentPlanProfile), StatusCodes.Status201Created)]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> Create([FromBody] TreatmentPlanRequest request)
     {
-        try
-        {
-            var result = await _service.CreateAsync(request);
-            return CreatedAtAction(nameof(GetById), new { id = result.Id }, result);
-        }
-        catch (ArgumentException ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
+        var result = await _service.CreateAsync(request);
+        return CreatedAtAction(nameof(GetById), new { id = result.Id }, result);
     }
 
     [HttpGet("active-summary")]
@@ -65,88 +58,53 @@ public class TreatmentPlansController : ControllerBase
 
     [HttpPut("{id}")]
     [ProducesResponseType(typeof(TreatmentPlanProfile), StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> Update(int id, [FromBody] TreatmentPlanRequest request)
     {
-        try
-        {
-            var result = await _service.UpdateAsync(id, request);
-            return Ok(result);
-        }
-        catch (ArgumentException ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
+        var result = await _service.UpdateAsync(id, request);
+        return Ok(result);
     }
 
     [HttpPut("{id}/activate")]
     [ProducesResponseType(typeof(TreatmentPlanProfile), StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> Activate(int id)
     {
-        try
-        {
-            var result = await _service.ActivateAsync(id);
-            return Ok(result);
-        }
-        catch (ArgumentException ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
+        var result = await _service.ActivateAsync(id);
+        return Ok(result);
     }
 
     [HttpPut("{id}/complete")]
     [ProducesResponseType(typeof(TreatmentPlanProfile), StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> Complete(int id)
     {
-        try
-        {
-            var result = await _service.CompleteAsync(id);
-            return Ok(result);
-        }
-        catch (ArgumentException ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
+        var result = await _service.CompleteAsync(id);
+        return Ok(result);
     }
 
     [HttpPut("{id}/cancel")]
     [ProducesResponseType(typeof(TreatmentPlanProfile), StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> Cancel(int id)
     {
-        try
-        {
-            var result = await _service.CancelAsync(id);
-            return Ok(result);
-        }
-        catch (ArgumentException ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
+        var result = await _service.CancelAsync(id);
+        return Ok(result);
     }
 
     [HttpPost("{id}/schedule")]
     [ProducesResponseType(typeof(BulkScheduleResult), StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Schedule(int id, [FromBody] BulkScheduleRequest request)
     {
-        try
-        {
-            var result = await _schedulingService.ScheduleAsync(id, request);
-            return Ok(result);
-        }
-        catch (ArgumentException ex)
-        {
-            return BadRequest(new { error = ex.Message });
-        }
+        var result = await _schedulingService.ScheduleAsync(id, request);
+        return Ok(result);
     }
 
     [HttpGet("{id}/sessions")]
     [ProducesResponseType(typeof(IReadOnlyList<PlanSessionInfo>), StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<IActionResult> GetSessions(int id)
     {
         try
@@ -156,13 +114,14 @@ public class TreatmentPlansController : ControllerBase
         }
         catch (ArgumentException ex)
         {
-            return NotFound(new { error = ex.Message });
+            // This path treats an invalid plan id as "not found" (404) rather than a 400.
+            return Problem(statusCode: StatusCodes.Status404NotFound, detail: ex.Message, title: "Not Found");
         }
     }
 
     [HttpGet("{id}/progress")]
     [ProducesResponseType(typeof(PlanProgressSummary), StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<IActionResult> GetProgress(int id)
     {
         try
@@ -172,7 +131,7 @@ public class TreatmentPlansController : ControllerBase
         }
         catch (ArgumentException ex)
         {
-            return NotFound(new { error = ex.Message });
+            return Problem(statusCode: StatusCodes.Status404NotFound, detail: ex.Message, title: "Not Found");
         }
     }
 }

--- a/tests/Web.Tests/LookupsControllerTests.cs
+++ b/tests/Web.Tests/LookupsControllerTests.cs
@@ -50,7 +50,9 @@ public class LookupsControllerTests
         var result = await _controller.GetAll("invalid");
 
         // Assert
-        Assert.IsType<BadRequestObjectResult>(result);
+        var problem = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(400, problem.StatusCode);
+        Assert.IsType<ProblemDetails>(problem.Value);
     }
 
     // --- GetById ---
@@ -96,7 +98,9 @@ public class LookupsControllerTests
         var result = await _controller.GetById("invalid", 1);
 
         // Assert
-        Assert.IsType<BadRequestObjectResult>(result);
+        var problem = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(400, problem.StatusCode);
+        Assert.IsType<ProblemDetails>(problem.Value);
     }
 
     // --- Create ---
@@ -131,7 +135,9 @@ public class LookupsControllerTests
         var result = await _controller.Create("invalid", request);
 
         // Assert
-        Assert.IsType<BadRequestObjectResult>(result);
+        var problem = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(400, problem.StatusCode);
+        Assert.IsType<ProblemDetails>(problem.Value);
     }
 
     // --- Update ---
@@ -177,6 +183,8 @@ public class LookupsControllerTests
         var result = await _controller.Update("invalid", 1, request);
 
         // Assert
-        Assert.IsType<BadRequestObjectResult>(result);
+        var problem = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(400, problem.StatusCode);
+        Assert.IsType<ProblemDetails>(problem.Value);
     }
 }


### PR DESCRIPTION
Standardize the leftover ad-hoc error responses across the controllers not touched by 3A, so all errors are RFC 7807 ProblemDetails (status codes unchanged).

- TreatmentPlans/Therapists/Payments: drop try/catch that re-wrapped ArgumentException as BadRequest(...) — let it bubble to the GlobalExceptionHandler (-> 400 ProblemDetails). TreatmentPlans GetSessions/GetProgress keep their 404 mapping via Problem(404).
- "Bad input?"/empty BadRequest() in Therapists/Caretakers update -> throw ArgumentException (-> 400), matching the 3A SessionsController pattern. Patients update keeps its explicit InvalidOperationException->400 (the handler maps that type to 500) but via Problem(400).
- Guard-clause string 400s (Lookups "invalid table name", Caretaker link) -> Problem(400).
- Point error [ProducesResponseType] at typeof(ProblemDetails); add missing 201/400 on Create/Update endpoints. Bare NotFound() (resource-by-id) left as-is (clean body-less 404).
- SitesController unchanged (only bare NotFound()).

Updated LookupsControllerTests (invalid-table-name now asserts a 400 ProblemDetails ObjectResult instead of BadRequestObjectResult). Build clean; full suite green (199).