### PR TITLE
fix(infra): silence EF 10103 in DB warmup by using AnyAsync

### DIFF
--- a/src/Infrastructure/Data/WarmupServiceDbContext.cs
+++ b/src/Infrastructure/Data/WarmupServiceDbContext.cs
@@ -20,8 +20,11 @@ public class DbContextWarmupService : IHostedService
         using (var scope = _serviceProvider.CreateScope())
         {
             var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
-            // Perform a dummy query to trigger the model loading
-            await dbContext.TherapySessions.FirstOrDefaultAsync();
+            // Execute a trivial query to force EF model compilation + open the DB connection.
+            // AnyAsync (SELECT EXISTS ...) does this without fetching an arbitrary row, so it
+            // avoids the FirstWithoutOrderByAndFilter warning (EF 10103) a bare FirstOrDefault
+            // would raise — the result is discarded either way.
+            await dbContext.TherapySessions.AnyAsync();
         }
     }
 


### PR DESCRIPTION
The DbContextWarmupService warmed EF on startup with a bare `TherapySessions.FirstOrDefaultAsync()` — a First/FirstOrDefault with neither OrderBy nor filter, which EF flags as FirstWithoutOrderByAndFilterWarning (event 10103). The warmup only needs to force model compilation + open the connection and discards the result, so AnyAsync (SELECT EXISTS ...) serves the same purpose without fetching an arbitrary row — and without the warning.