### PR TITLE
fix(docker): copy vendored access-control manifest into the build con…

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -15,6 +15,11 @@ COPY ./tests/Web.Tests/Web.Tests.csproj ./tests/Web.Tests/
 COPY ./src ./src
 COPY ./tests ./tests
 
+# WP-17: Web.Tests vendors the access-control manifest from ../../docs via a Content item
+# (AccessControlConformanceTests reads it at runtime). The build context omits docs/ otherwise,
+# so copy just that file in or `dotnet build` fails with MSB3030 (file not found).
+COPY ./docs/access-control-matrix.json ./docs/access-control-matrix.json
+
 # Restore the dependencies for the Web project and Test project
 RUN dotnet restore "./src/Core/Core.csproj"
 RUN dotnet restore "./src/Infrastructure/Infrastructure.csproj"


### PR DESCRIPTION
…text

The Docker build context copies ./src and ./tests but not ./docs, so the Web.Tests Content item `..\..\docs\access-control-matrix.json` (vendored manifest read by AccessControlConformanceTests, added in WP-17B-1) couldn't be found and `dotnet build` failed with MSB3030 (/app/docs/access-control-matrix.json not found). PR checks pass because they run dotnet test on a full checkout; the image build is stricter.

Copy just that file into the build stage. It is the only out-of-tree file reference across all csprojs (verified), so this is the complete fix.