### PR TITLE
WP-17 D-6: TreatmentPlans Book/Edit split (manifest b88f98dc47d7)

### DIFF
--- a/docs/access-control-matrix.json
+++ b/docs/access-control-matrix.json
@@ -1,9 +1,9 @@
 {
   "_meta": {
-    "generatedAt": "2026-06-13T08:34:47-05:00",
+    "generatedAt": "2026-06-13T10:13:43-05:00",
     "generator": "tools/generate-access-manifest.sh",
     "hashScope": "sha256 (first 12 hex) of canonical JSON {claims:[{claim,grants}]}, claims+grants sorted; wildcard/restricted cells and all metadata excluded",
-    "semanticHash": "a6bb1eade5ec",
+    "semanticHash": "b88f98dc47d7",
     "source": "access-control-matrix.md"
   },
   "claims": [
@@ -234,6 +234,14 @@
       ]
     },
     {
+      "claim": "Schedule.Rebook",
+      "grants": [
+        "AM",
+        "FD",
+        "MGR"
+      ]
+    },
+    {
       "claim": "Schedule.View",
       "grants": [
         "AM",
@@ -295,10 +303,17 @@
       ]
     },
     {
-      "claim": "TreatmentPlans.Edit",
+      "claim": "TreatmentPlans.Book",
       "grants": [
         "AM",
         "FD",
+        "MGR"
+      ]
+    },
+    {
+      "claim": "TreatmentPlans.Edit",
+      "grants": [
+        "AM",
         "MGR"
       ]
     },

--- a/src/Web/Authorization/AccessControlManifest.cs
+++ b/src/Web/Authorization/AccessControlManifest.cs
@@ -18,5 +18,5 @@ namespace Neurocorp.Api.Web.Authorization;
 public static class AccessControlManifest
 {
     /// <summary>First 12 hex chars of SHA-256 over the manifest's canonical grant tuples.</summary>
-    public const string SemanticHash = "a6bb1eade5ec";
+    public const string SemanticHash = "b88f98dc47d7";
 }

--- a/src/Web/Authorization/Permissions.g.cs
+++ b/src/Web/Authorization/Permissions.g.cs
@@ -7,7 +7,7 @@
 //   (patient-care-super/tools/generate-access-manifest.sh), re-vendor
 //   docs/access-control-matrix.json, then re-run tools/generate-permissions.sh.
 //
-//   Access-control manifest semantic hash: a6bb1eade5ec
+//   Access-control manifest semantic hash: b88f98dc47d7
 // </auto-generated>
 
 namespace Neurocorp.Api.Web.Authorization;
@@ -56,6 +56,7 @@ public static class Permissions
     public const string PaymentsSplit = "Payments.Split";
     public const string PaymentsView = "Payments.View";
     public const string ScheduleBook = "Schedule.Book";
+    public const string ScheduleRebook = "Schedule.Rebook";
     public const string ScheduleView = "Schedule.View";
     public const string StatementsCaretakerView = "Statements.Caretaker.View";
     public const string StatementsTherapistView = "Statements.Therapist.View";
@@ -65,6 +66,7 @@ public static class Permissions
     public const string TherapistsEdit = "Therapists.Edit";
     public const string TherapistsManageSpecialties = "Therapists.ManageSpecialties";
     public const string TherapistsView = "Therapists.View";
+    public const string TreatmentPlansBook = "TreatmentPlans.Book";
     public const string TreatmentPlansEdit = "TreatmentPlans.Edit";
     public const string TreatmentPlansView = "TreatmentPlans.View";
 }

--- a/src/Web/Controllers/TreatmentPlansController.cs
+++ b/src/Web/Controllers/TreatmentPlansController.cs
@@ -24,8 +24,10 @@ public class TreatmentPlansController : ControllerBase
         _schedulingService = schedulingService;
     }
 
+    // WP-17 (D-6): setting up a plan (create) is TreatmentPlans.Book (MGR/AM/FD). Editing an
+    // existing plan's content is the narrower TreatmentPlans.Edit (MGR/AM) — see Update below.
     [HttpPost]
-    [Authorize(Policy = AuthPolicy.PermissionPrefix + Permissions.TreatmentPlansEdit)]
+    [Authorize(Policy = AuthPolicy.PermissionPrefix + Permissions.TreatmentPlansBook)]
     [ProducesResponseType(typeof(TreatmentPlanProfile), StatusCodes.Status201Created)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> Create([FromBody] TreatmentPlanRequest request)
@@ -64,6 +66,8 @@ public class TreatmentPlansController : ControllerBase
         return Ok(results);
     }
 
+    // WP-17 (D-6): editing an existing plan's content is TreatmentPlans.Edit — now MGR/AM only
+    // (FD can set up & schedule a plan via Book, but not change its content).
     [HttpPut("{id}")]
     [Authorize(Policy = AuthPolicy.PermissionPrefix + Permissions.TreatmentPlansEdit)]
     [ProducesResponseType(typeof(TreatmentPlanProfile), StatusCodes.Status200OK)]
@@ -74,8 +78,10 @@ public class TreatmentPlansController : ControllerBase
         return Ok(result);
     }
 
+    // WP-17 (D-6): plan lifecycle transitions (activate/complete/cancel) are part of running a plan
+    // FD set up → TreatmentPlans.Book (MGR/AM/FD), not the MGR/AM-only content Edit.
     [HttpPut("{id}/activate")]
-    [Authorize(Policy = AuthPolicy.PermissionPrefix + Permissions.TreatmentPlansEdit)]
+    [Authorize(Policy = AuthPolicy.PermissionPrefix + Permissions.TreatmentPlansBook)]
     [ProducesResponseType(typeof(TreatmentPlanProfile), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> Activate(int id)
@@ -85,7 +91,7 @@ public class TreatmentPlansController : ControllerBase
     }
 
     [HttpPut("{id}/complete")]
-    [Authorize(Policy = AuthPolicy.PermissionPrefix + Permissions.TreatmentPlansEdit)]
+    [Authorize(Policy = AuthPolicy.PermissionPrefix + Permissions.TreatmentPlansBook)]
     [ProducesResponseType(typeof(TreatmentPlanProfile), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> Complete(int id)
@@ -95,7 +101,7 @@ public class TreatmentPlansController : ControllerBase
     }
 
     [HttpPut("{id}/cancel")]
-    [Authorize(Policy = AuthPolicy.PermissionPrefix + Permissions.TreatmentPlansEdit)]
+    [Authorize(Policy = AuthPolicy.PermissionPrefix + Permissions.TreatmentPlansBook)]
     [ProducesResponseType(typeof(TreatmentPlanProfile), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> Cancel(int id)
@@ -104,9 +110,10 @@ public class TreatmentPlansController : ControllerBase
         return Ok(result);
     }
 
-    // WP-17 (D-6): claim deliberately UNDECIDED — pending human discussion (TreatmentPlans.Edit vs
-    // Schedule.Book). Stays authenticated-only in conformance-baseline.txt until D-6 is resolved.
+    // WP-17 (D-6): bulk-scheduling a plan's sessions is part of setting it up → TreatmentPlans.Book
+    // (MGR/AM/FD). (Schedule.Rebook — changing an existing booking — is a separate, still-future claim.)
     [HttpPost("{id}/schedule")]
+    [Authorize(Policy = AuthPolicy.PermissionPrefix + Permissions.TreatmentPlansBook)]
     [ProducesResponseType(typeof(BulkScheduleResult), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]

--- a/tests/Web.Tests/Authorization/SensitiveCellAuthorizationTests.cs
+++ b/tests/Web.Tests/Authorization/SensitiveCellAuthorizationTests.cs
@@ -31,6 +31,11 @@ namespace Neurocorp.Api.Web.Tests.Authorization;
 /// and representative checks that the broad AM/FD/MGR decorations actually enforce:
 ///   Patients.View         [AM,FD,MGR]   GET  /api/patients (restricted role → 403; FD allowed)
 ///   Appointments.View     [AM,FD,MGR]   GET  /api/sessions/patient/{id}/discovery (D-5; FD allowed)
+///
+/// WP-17 D-6 — treatment-plan setup (Book) vs content edit (Edit):
+///   TreatmentPlans.Edit   [AM,MGR]      PUT  /api/treatment-plans/{id} (content edit; FD denied)
+///   TreatmentPlans.Book   [AM,FD,MGR]   POST /api/treatment-plans, POST …/{id}/schedule,
+///                                       PUT …/{id}/activate|complete|cancel (FD retains setup)
 /// </summary>
 public class SensitiveCellAuthorizationTests : IClassFixture<AccessControlTestFactory>
 {
@@ -66,6 +71,8 @@ public class SensitiveCellAuthorizationTests : IClassFixture<AccessControlTestFa
     [InlineData("GET", "/api/sessions/pastdue", "FD")]
     // Broad AM/FD/MGR decoration still locks out restricted roles entirely (no granular claims).
     [InlineData("GET", "/api/patients", "CARETAKER")]
+    // TreatmentPlans.Edit [AM,MGR] (D-6) — editing an existing plan's content is denied to FD.
+    [InlineData("PUT", "/api/treatment-plans/1", "FD")]
     public async Task RoleWithoutClaim_Is403(string method, string route, string role)
     {
         var response = await SendAsync(method, route, TokenFor(role));
@@ -103,6 +110,14 @@ public class SensitiveCellAuthorizationTests : IClassFixture<AccessControlTestFa
     // Broad AM/FD/MGR decorations let FD through (Patients.View; Appointments.View for D-5 discovery).
     [InlineData("GET", "/api/patients", "FD")]
     [InlineData("GET", "/api/sessions/patient/1/discovery", "FD")]
+    // TreatmentPlans.Edit [AM,MGR] (D-6) — AM and MGR may edit plan content.
+    [InlineData("PUT", "/api/treatment-plans/1", "AM")]
+    [InlineData("PUT", "/api/treatment-plans/1", "MGR")]
+    // TreatmentPlans.Book [AM,FD,MGR] (D-6) — FD retains plan SETUP: create, schedule, lifecycle.
+    [InlineData("POST", "/api/treatment-plans", "FD")]
+    [InlineData("POST", "/api/treatment-plans/1/schedule", "FD")]
+    [InlineData("PUT", "/api/treatment-plans/1/activate", "FD")]
+    [InlineData("PUT", "/api/treatment-plans/1/cancel", "MGR")]
     public async Task RoleWithClaim_IsNotBlocked(string method, string route, string role)
     {
         var response = await SendAsync(method, route, TokenFor(role));

--- a/tests/Web.Tests/Authorization/conformance-baseline.txt
+++ b/tests/Web.Tests/Authorization/conformance-baseline.txt
@@ -9,7 +9,6 @@
 #   BookingController.GetStatuses         — D-1 reference data (appointment statuses for dropdowns)
 #   LookupsController.GetAll/GetById      — D-1 reference data (runtime dropdown reads)
 #   PaymentsController.GetPaymentTypes    — D-1 reference data (payment types for dropdowns)
-#   TreatmentPlansController.Schedule     — D-6 OPEN (TreatmentPlans.Edit vs Schedule.Book)
 #
 # NOT here (authorized imperatively, see AccessControlConformanceTests.ImperativelyAuthorized):
 #   LookupsController.Create/Update       — D-10 per-type Admin.Lookups.<Type>.Manage at runtime
@@ -19,4 +18,3 @@ BookingController.GetStatuses
 LookupsController.GetAll
 LookupsController.GetById
 PaymentsController.GetPaymentTypes
-TreatmentPlansController.Schedule


### PR DESCRIPTION
Matrix split treatment-plan setup from content-edit (D-6). Propagated:
- re-vendored docs/access-control-matrix.json (hash b88f98dc47d7, 47 claims)
- bumped AccessControlManifest.SemanticHash anchor
- regenerated Permissions.g.cs (adds TreatmentPlansBook, ScheduleRebook)
- TreatmentPlansController: Create, Activate, Complete, Cancel, Schedule -> TreatmentPlans.Book (MGR/AM/FD) Update -> TreatmentPlans.Edit (now MGR/AM; FD can set up/schedule but not edit content) Schedule decorated -> removed from conformance baseline (6 entries)
- integration tests: FD->403 on PUT (Update); FD->allowed on Create/Schedule/lifecycle; AM/MGR->allowed on Update

Web.Tests 134/134; full solution 269/269.