### PR TITLE
WP-17: enforce ProviderAmount confidentiality via API response-shaping

### DIFF
--- a/src/Core/BusinessObjects/Sessions/SessionEvent.cs
+++ b/src/Core/BusinessObjects/Sessions/SessionEvent.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace Neurocorp.Api.Core.BusinessObjects.Sessions;
 
 public class SessionEvent
@@ -33,5 +35,11 @@ public class SessionEvent
     public string? SpecialtyAbbreviation { get; set; }
     public string? SpecialtyName { get; set; }
     public bool? IsDiscovery { get; set; }
-    public decimal ProviderAmount { get; set; }
+
+    // WP-17 access-control: ProviderAmount (therapist payout) is confidential — matrix grants
+    // Appointments.ProviderAmount to MGR/AM only (FrontDesk excluded). ProviderAmountResultFilter
+    // sets this to null for callers lacking that claim, and WhenWritingNull omits the property
+    // entirely from the JSON so FD never receives the figure (not just a zeroed value).
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public decimal? ProviderAmount { get; set; }
 }

--- a/src/Web/Authorization/ClaimsPrincipalExtensions.cs
+++ b/src/Web/Authorization/ClaimsPrincipalExtensions.cs
@@ -1,0 +1,25 @@
+using System.Security.Claims;
+using Neurocorp.Api.Core.Authorization;
+
+namespace Neurocorp.Api.Web.Authorization;
+
+/// <summary>
+/// Imperative permission checks for use OUTSIDE the <c>[Authorize]</c> pipeline — e.g. response-shaping
+/// filters that hide confidential fields. Mirrors <see cref="PermissionAuthorizationHandler"/> exactly:
+/// a principal holds a permission if it carries the explicit (<see cref="SystemClaims.PermissionClaimType"/>,
+/// value) claim OR the god-mode wildcard (<see cref="SystemClaims.SystemClaimType"/>,
+/// <see cref="SystemClaims.FullAccessValue"/>).
+/// </summary>
+public static class ClaimsPrincipalExtensions
+{
+    public static bool HasPermission(this ClaimsPrincipal? user, string permission)
+    {
+        if (user is null)
+        {
+            return false;
+        }
+
+        return user.HasClaim(SystemClaims.SystemClaimType, SystemClaims.FullAccessValue)
+            || user.HasClaim(SystemClaims.PermissionClaimType, permission);
+    }
+}

--- a/src/Web/Authorization/ProviderAmountResultFilter.cs
+++ b/src/Web/Authorization/ProviderAmountResultFilter.cs
@@ -1,0 +1,58 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Neurocorp.Api.Core.BusinessObjects.Sessions;
+
+namespace Neurocorp.Api.Web.Authorization;
+
+/// <summary>
+/// WP-17 field-level confidentiality. Strips <see cref="SessionEvent.ProviderAmount"/> (the therapist
+/// payout) from responses when the caller lacks <c>Appointments.ProviderAmount</c> — the access-control
+/// matrix grants that claim to MGR/AM only, so FrontDesk must never receive the figure. Setting the
+/// field to <c>null</c> omits it from the JSON entirely (SessionEvent marks it
+/// <c>[JsonIgnore(WhenWritingNull)]</c>), making the confidentiality real rather than UI-cosmetic.
+///
+/// Registered globally (Startup), so it covers every SessionEvent-returning endpoint today and any
+/// added later. All current SessionEvent endpoints are appointments-context, so the governing claim is
+/// <c>Appointments.ProviderAmount</c>. (<c>Dashboard.ProviderAmount</c> is a reserved/future claim with
+/// no endpoint yet; a future dashboard DTO would get its own shaping keyed on that claim.)
+/// </summary>
+public class ProviderAmountResultFilter : IAsyncResultFilter
+{
+    public async Task OnResultExecutionAsync(ResultExecutingContext context, ResultExecutionDelegate next)
+    {
+        if (context.Result is ObjectResult { Value: not null } result
+            && IsSessionEventPayload(result.Value)
+            && !context.HttpContext.User.HasPermission(Permissions.AppointmentsProviderAmount))
+        {
+            result.Value = Redact(result.Value);
+        }
+
+        await next();
+    }
+
+    private static bool IsSessionEventPayload(object value) =>
+        value is SessionEvent || value is IEnumerable<SessionEvent>;
+
+    private static object Redact(object value)
+    {
+        switch (value)
+        {
+            case SessionEvent single:
+                single.ProviderAmount = null;
+                return single;
+            case IEnumerable<SessionEvent> many:
+                // Materialize so a lazy sequence isn't re-enumerated (unshaped) at serialization time.
+                var list = many.ToList();
+                foreach (var sessionEvent in list)
+                {
+                    sessionEvent.ProviderAmount = null;
+                }
+                return list;
+            default:
+                return value;
+        }
+    }
+}

--- a/src/Web/Startup.cs
+++ b/src/Web/Startup.cs
@@ -52,7 +52,12 @@ public class Startup(IConfiguration configuration, IWebHostEnvironment environme
                     .AllowAnyMethod()
                     .AllowCredentials());
         });
-        services.AddControllers()
+        services.AddControllers(options =>
+        {
+            // WP-17 field-level confidentiality: strips SessionEvent.ProviderAmount from responses
+            // for callers lacking Appointments.ProviderAmount (FrontDesk). See ProviderAmountResultFilter.
+            options.Filters.Add<ProviderAmountResultFilter>();
+        })
         .AddJsonOptions(options =>
         {
             options.JsonSerializerOptions.Converters.Add(new TimeOnlyJsonConverterFactory());

--- a/tests/Web.Tests/Authorization/ProviderAmountShapingTests.cs
+++ b/tests/Web.Tests/Authorization/ProviderAmountShapingTests.cs
@@ -1,0 +1,138 @@
+using System.Security.Claims;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Routing;
+using Neurocorp.Api.Core.Authorization;
+using Neurocorp.Api.Core.BusinessObjects.Sessions;
+using Neurocorp.Api.Web.Authorization;
+using Xunit;
+
+namespace Neurocorp.Api.Web.Tests.Authorization;
+
+/// <summary>
+/// WP-17 ProviderAmount confidentiality. Proves the field-level enforcement in two units that together
+/// guarantee "FrontDesk never receives ProviderAmount in the JSON":
+///   1. <see cref="ProviderAmountResultFilter"/> nulls the field for principals lacking
+///      Appointments.ProviderAmount (FD), and preserves it for holders (AM/MGR) + the wildcard.
+///   2. A null ProviderAmount is omitted from the serialized JSON entirely (the DTO's
+///      [JsonIgnore(WhenWritingNull)]).
+/// Driven at the filter/serialization level rather than over HTTP because the leak is field presence,
+/// not status code — and the integration host's in-memory DB returns empty session lists.
+/// </summary>
+public class ProviderAmountShapingTests
+{
+    private const string ProviderAmountClaim = "Appointments.ProviderAmount";
+
+    private static ClaimsPrincipal Principal(params Claim[] claims) =>
+        new(new ClaimsIdentity(claims, authenticationType: "test"));
+
+    // FD holds Appointments.View/Book but NOT Appointments.ProviderAmount (per the matrix).
+    private static ClaimsPrincipal FrontDesk() =>
+        Principal(
+            new Claim(SystemClaims.PermissionClaimType, "Appointments.View"),
+            new Claim(SystemClaims.PermissionClaimType, "Appointments.Book"));
+
+    private static ClaimsPrincipal Manager() =>
+        Principal(
+            new Claim(SystemClaims.PermissionClaimType, "Appointments.View"),
+            new Claim(SystemClaims.PermissionClaimType, ProviderAmountClaim));
+
+    private static ClaimsPrincipal Wildcard() =>
+        Principal(new Claim(SystemClaims.SystemClaimType, SystemClaims.FullAccessValue));
+
+    private static async Task<ObjectResult> RunFilter(ClaimsPrincipal user, object payload)
+    {
+        var http = new DefaultHttpContext { User = user };
+        var actionContext = new ActionContext(http, new RouteData(), new ActionDescriptor());
+        var result = new ObjectResult(payload);
+        var executing = new ResultExecutingContext(
+            actionContext, new List<IFilterMetadata>(), result, controller: new object());
+        var executed = new ResultExecutedContext(
+            actionContext, new List<IFilterMetadata>(), result, controller: new object());
+
+        await new ProviderAmountResultFilter()
+            .OnResultExecutionAsync(executing, () => Task.FromResult(executed));
+
+        return (ObjectResult)executing.Result;
+    }
+
+    // ── HasPermission extension (mirrors PermissionAuthorizationHandler) ──────────────
+    [Fact]
+    public void HasPermission_true_for_explicit_claim() =>
+        Manager().HasPermission(ProviderAmountClaim).Should().BeTrue();
+
+    [Fact]
+    public void HasPermission_true_for_wildcard() =>
+        Wildcard().HasPermission(ProviderAmountClaim).Should().BeTrue();
+
+    [Fact]
+    public void HasPermission_false_when_claim_absent() =>
+        FrontDesk().HasPermission(ProviderAmountClaim).Should().BeFalse();
+
+    [Fact]
+    public void HasPermission_false_for_null_principal() =>
+        ((ClaimsPrincipal?)null).HasPermission(ProviderAmountClaim).Should().BeFalse();
+
+    // ── filter redaction ─────────────────────────────────────────────────────────────
+    [Fact]
+    public async Task FrontDesk_single_SessionEvent_is_redacted()
+    {
+        var result = await RunFilter(FrontDesk(), new SessionEvent { ProviderAmount = 123.45m });
+        ((SessionEvent)result.Value!).ProviderAmount.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task FrontDesk_SessionEvent_list_is_redacted()
+    {
+        var payload = new List<SessionEvent>
+        {
+            new() { ProviderAmount = 10m },
+            new() { ProviderAmount = 20m },
+        };
+        var result = await RunFilter(FrontDesk(), payload);
+        ((IEnumerable<SessionEvent>)result.Value!).Should().OnlyContain(e => e.ProviderAmount == null);
+    }
+
+    [Fact]
+    public async Task Manager_keeps_ProviderAmount()
+    {
+        var result = await RunFilter(Manager(), new SessionEvent { ProviderAmount = 99m });
+        ((SessionEvent)result.Value!).ProviderAmount.Should().Be(99m);
+    }
+
+    [Fact]
+    public async Task Wildcard_keeps_ProviderAmount()
+    {
+        var result = await RunFilter(Wildcard(), new SessionEvent { ProviderAmount = 99m });
+        ((SessionEvent)result.Value!).ProviderAmount.Should().Be(99m);
+    }
+
+    [Fact]
+    public async Task NonSessionEvent_payload_is_untouched_even_for_frontdesk()
+    {
+        var payload = new { Secret = "keep-me" };
+        var result = await RunFilter(FrontDesk(), payload);
+        result.Value.Should().BeSameAs(payload);
+    }
+
+    // ── serialization: null ⇒ property omitted entirely ──────────────────────────────
+    [Fact]
+    public void Null_ProviderAmount_is_omitted_from_json()
+    {
+        var json = JsonSerializer.Serialize(
+            new SessionEvent { ProviderAmount = null }, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        json.ToLowerInvariant().Should().NotContain("provideramount");
+    }
+
+    [Fact]
+    public void Present_ProviderAmount_is_serialized()
+    {
+        var json = JsonSerializer.Serialize(
+            new SessionEvent { ProviderAmount = 50m }, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        json.ToLowerInvariant().Should().Contain("provideramount");
+    }
+}


### PR DESCRIPTION
Closes the last real WP-17 enforcement gap (17C/audit follow-up): the matrix grants Appointments.ProviderAmount to MGR/AM only, but the API still returned the therapist-payout figure in JSON to any Appointments.View holder — which FrontDesk has. 17C only hid it cosmetically in the UI.

- SessionEvent.ProviderAmount -> decimal? + [JsonIgnore(WhenWritingNull)] so a null value is omitted from the JSON entirely (true absence, not a zero).
- ClaimsPrincipalExtensions.HasPermission(principal, value): imperative check reusing PermissionAuthorizationHandler's logic (explicit claim OR System/ FullAccess wildcard) for use outside [Authorize].
- ProviderAmountResultFilter (global IAsyncResultFilter): nulls ProviderAmount on any SessionEvent / IEnumerable<SessionEvent> response when the caller lacks Appointments.ProviderAmount. Covers all 10 SessionEvent endpoints (4 list + 6 lifecycle) today and any future one. Dashboard.ProviderAmount is reserved (no endpoint yet).
- 11 unit tests (filter redaction per role + HasPermission + null-omits-from-json).

No matrix/manifest/DB change (claims already exist); hash stays b88f98dc47d7. Statements ProviderAmount unaffected (Statements.*.View = AM/MGR, FD can't reach). Solution 280/280 green; generate-permissions.sh --check in sync.

Test artifacts (manual, per role):
  TOK=<mint via login>; curl -s localhost:5245/api/sessions/unconfirmed \
    -H "Authorization: Bearer $TOK" | jq '.[0] | has("providerAmount")'
  # FD -> false (key absent); AM/MGR/SYSADMIN -> true (value present)