### PR TITLE
WP-14B: Service Payments API + authoritative therapist statement

### DIFF
--- a/docs/access-control-matrix.json
+++ b/docs/access-control-matrix.json
@@ -1,9 +1,9 @@
 {
   "_meta": {
-    "generatedAt": "2026-06-13T10:13:43-05:00",
+    "generatedAt": "2026-06-20T14:20:39-05:00",
     "generator": "tools/generate-access-manifest.sh",
     "hashScope": "sha256 (first 12 hex) of canonical JSON {claims:[{claim,grants}]}, claims+grants sorted; wildcard/restricted cells and all metadata excluded",
-    "semanticHash": "b88f98dc47d7",
+    "semanticHash": "b10682734edf",
     "source": "access-control-matrix.md"
   },
   "claims": [
@@ -246,6 +246,19 @@
       "grants": [
         "AM",
         "FD",
+        "MGR"
+      ]
+    },
+    {
+      "claim": "ServicePayments.Record",
+      "grants": [
+        "MGR"
+      ]
+    },
+    {
+      "claim": "ServicePayments.View",
+      "grants": [
+        "AM",
         "MGR"
       ]
     },

--- a/src/Core/BusinessObjects/ServicePayments/QuincenaWindow.cs
+++ b/src/Core/BusinessObjects/ServicePayments/QuincenaWindow.cs
@@ -1,0 +1,12 @@
+namespace Neurocorp.Api.Core.BusinessObjects.ServicePayments;
+
+/// <summary>
+/// The suggested "quincena" pay window for a given date: 1st–15th when the day is
+/// &lt;= 15, otherwise 16th–end-of-month. A UX default for the date-range picker only —
+/// the system imposes no quincena constraint and accepts any range.
+/// </summary>
+public class QuincenaWindow
+{
+    public string From { get; set; } = string.Empty;
+    public string To { get; set; } = string.Empty;
+}

--- a/src/Core/BusinessObjects/ServicePayments/ServiceAllocationDetail.cs
+++ b/src/Core/BusinessObjects/ServicePayments/ServiceAllocationDetail.cs
@@ -1,0 +1,11 @@
+namespace Neurocorp.Api.Core.BusinessObjects.ServicePayments;
+
+/// <summary>One session allocation as rendered on a service-payment record.</summary>
+public class ServiceAllocationDetail
+{
+    public int SessionServicePaymentId { get; set; }
+    public int SessionId { get; set; }
+    public string SessionDate { get; set; } = string.Empty;
+    public string PatientName { get; set; } = string.Empty;
+    public decimal AmountApplied { get; set; }
+}

--- a/src/Core/BusinessObjects/ServicePayments/ServicePaymentRecord.cs
+++ b/src/Core/BusinessObjects/ServicePayments/ServicePaymentRecord.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using Neurocorp.Api.Core.BusinessObjects.Payments;
+
+namespace Neurocorp.Api.Core.BusinessObjects.ServicePayments;
+
+/// <summary>Response shape for a service payment (therapist disbursement) and its allocations.</summary>
+public class ServicePaymentRecord
+{
+    public int ServicePaymentId { get; set; }
+    public int TherapistId { get; set; }
+    public string TherapistName { get; set; } = string.Empty;
+    public DateTime PaymentDate { get; set; }
+    public decimal Amount { get; set; }
+    public PaymentTypeInfo PaymentType { get; set; } = new();
+    public string? ReferenceNumber { get; set; }
+    public string? Notes { get; set; }
+    public List<ServiceAllocationDetail> Allocations { get; set; } = new();
+    public decimal TotalApplied { get; set; }
+    public decimal UnallocatedAmount { get; set; }
+}

--- a/src/Core/BusinessObjects/ServicePayments/ServicePaymentRequest.cs
+++ b/src/Core/BusinessObjects/ServicePayments/ServicePaymentRequest.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+
+namespace Neurocorp.Api.Core.BusinessObjects.ServicePayments;
+
+/// <summary>Create payload for issuing a service payment (therapist disbursement).</summary>
+public class ServicePaymentRequest
+{
+    public int TherapistId { get; set; }
+    public DateTime PaymentDate { get; set; }
+    public decimal Amount { get; set; }
+    public int PaymentTypeId { get; set; }
+    public string? ReferenceNumber { get; set; }
+    public string? Notes { get; set; }
+    public List<SessionServiceAllocationItem> SessionAllocations { get; set; } = new();
+}

--- a/src/Core/BusinessObjects/ServicePayments/SessionServiceAllocationItem.cs
+++ b/src/Core/BusinessObjects/ServicePayments/SessionServiceAllocationItem.cs
@@ -1,0 +1,8 @@
+namespace Neurocorp.Api.Core.BusinessObjects.ServicePayments;
+
+/// <summary>One session's share of a service payment, as submitted on create.</summary>
+public class SessionServiceAllocationItem
+{
+    public int SessionId { get; set; }
+    public decimal AmountApplied { get; set; }
+}

--- a/src/Core/BusinessObjects/ServicePayments/UnpaidProviderSessionSummary.cs
+++ b/src/Core/BusinessObjects/ServicePayments/UnpaidProviderSessionSummary.cs
@@ -1,0 +1,19 @@
+namespace Neurocorp.Api.Core.BusinessObjects.ServicePayments;
+
+/// <summary>
+/// A completed session that still owes the therapist some provider amount, used to
+/// drive the "Pay Therapist" wizard. <c>RemainingProviderAmount</c> =
+/// <c>ProviderAmount - AlreadyApplied</c> across all prior service payments.
+/// </summary>
+public class UnpaidProviderSessionSummary
+{
+    public int SessionId { get; set; }
+    public string SessionDate { get; set; } = string.Empty;
+    public string SessionTime { get; set; } = string.Empty;
+    public int PatientId { get; set; }
+    public string PatientName { get; set; } = string.Empty;
+    public string TherapyType { get; set; } = string.Empty;
+    public decimal ProviderAmount { get; set; }
+    public decimal AlreadyApplied { get; set; }
+    public decimal RemainingProviderAmount { get; set; }
+}

--- a/src/Core/Configurations/Dependencies.cs
+++ b/src/Core/Configurations/Dependencies.cs
@@ -19,6 +19,7 @@ public static class NeurocorpConfigurationExtensions
         services.AddScoped<ICaretakerProfileService, CaretakerProfileService>();
         services.AddScoped<IHandleSessionEvent, SessionEventHandler>();
         services.AddScoped<IPaymentRecordService, PaymentRecordService>();
+        services.AddScoped<IServicePaymentService, ServicePaymentService>();
         services.AddScoped<IAccountStatementService, AccountStatementService>();
         services.AddScoped<ITherapistStatementService, TherapistStatementService>();
         services.AddScoped<IBookingService, BookingService>();

--- a/src/Core/Entities/ServicePayment.cs
+++ b/src/Core/Entities/ServicePayment.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+
+namespace Neurocorp.Api.Core.Entities;
+
+/// <summary>
+/// A disbursement from the clinic to a therapist (therapist payroll). The
+/// direction-flipped mirror of <see cref="Payment"/>: the clinic pays a
+/// therapist instead of receiving from a caretaker. Reuses the
+/// <see cref="PaymentType"/> lookup. Allocated across sessions via
+/// <see cref="SessionServicePayment"/>.
+/// </summary>
+public class ServicePayment : AuditableEntityBase
+{
+    public ServicePayment()
+    {
+        this.Therapist = null!;
+        this.SessionServicePayments = [];
+    }
+
+    public int TherapistId { get; set; }
+    public Therapist Therapist { get; set; }
+    public DateTime PaymentDate { get; set; }
+    public decimal Amount { get; set; }
+    public int PaymentTypeId { get; set; }
+    public PaymentType? PaymentType { get; set; }
+    public string? ReferenceNumber { get; set; }
+    public string? Notes { get; set; }
+
+    /// <summary>
+    /// Self-reference reserved for WP-14.5 append-only reversals/corrections.
+    /// Always null in the WP-14 MVP. Modeled as a bare scalar (no navigation)
+    /// on purpose so EF does not infer a self-referencing relationship.
+    /// </summary>
+    public int? ReversesServicePaymentId { get; set; }
+
+    public ICollection<SessionServicePayment> SessionServicePayments { get; set; }
+}

--- a/src/Core/Entities/SessionServicePayment.cs
+++ b/src/Core/Entities/SessionServicePayment.cs
@@ -1,0 +1,20 @@
+namespace Neurocorp.Api.Core.Entities;
+
+/// <summary>
+/// Junction that allocates a <see cref="ServicePayment"/> across the therapy
+/// sessions it pays for. The direction-flipped mirror of <see cref="SessionPayment"/>.
+/// </summary>
+public class SessionServicePayment : AuditableEntityBase
+{
+    public SessionServicePayment()
+    {
+        this.ServicePayment = null!;
+        this.TherapySession = null!;
+    }
+
+    public int ServicePaymentId { get; set; }
+    public ServicePayment ServicePayment { get; set; }
+    public int TherapySessionId { get; set; }
+    public TherapySession TherapySession { get; set; }
+    public decimal AmountApplied { get; set; }
+}

--- a/src/Core/Interfaces/Repositories/IServicePaymentRepository.cs
+++ b/src/Core/Interfaces/Repositories/IServicePaymentRepository.cs
@@ -1,0 +1,10 @@
+using Neurocorp.Api.Core.Entities;
+
+namespace Neurocorp.Api.Core.Interfaces.Repositories;
+
+public interface IServicePaymentRepository : IRepository<ServicePayment>
+{
+    Task<IReadOnlyList<ServicePayment>> GetByTherapistIdAndDateRangeAsync(int therapistId, DateTime from, DateTime to);
+    Task<ServicePayment?> GetByIdWithDetailsAsync(int servicePaymentId);
+    Task<IReadOnlyList<ServicePayment>> GetByIdsWithDetailsAsync(IEnumerable<int> servicePaymentIds);
+}

--- a/src/Core/Interfaces/Repositories/ISessionServicePaymentRepository.cs
+++ b/src/Core/Interfaces/Repositories/ISessionServicePaymentRepository.cs
@@ -1,0 +1,9 @@
+using Neurocorp.Api.Core.Entities;
+
+namespace Neurocorp.Api.Core.Interfaces.Repositories;
+
+public interface ISessionServicePaymentRepository : IRepository<SessionServicePayment>
+{
+    /// <summary>All service-payment allocations touching any of the given sessions.</summary>
+    Task<IReadOnlyList<SessionServicePayment>> GetBySessionIdsAsync(IEnumerable<int> sessionIds);
+}

--- a/src/Core/Interfaces/Services/IServicePaymentService.cs
+++ b/src/Core/Interfaces/Services/IServicePaymentService.cs
@@ -1,0 +1,17 @@
+using Neurocorp.Api.Core.BusinessObjects.ServicePayments;
+
+namespace Neurocorp.Api.Core.Interfaces.Services;
+
+public interface IServicePaymentService
+{
+    Task<ServicePaymentRecord> CreateAsync(ServicePaymentRequest request);
+    Task<IEnumerable<ServicePaymentRecord>> GetByTherapistAsync(int therapistId, DateOnly? from, DateOnly? to);
+    Task<ServicePaymentRecord?> GetByIdAsync(int servicePaymentId);
+    Task<IEnumerable<UnpaidProviderSessionSummary>> GetUnpaidProviderSessionsAsync(int therapistId, DateOnly? from, DateOnly? to);
+
+    /// <summary>
+    /// Suggested quincena window for <paramref name="date"/> (1st–15th or 16th–EOM).
+    /// A pure UX default — imposes no constraint on what range a payment may cover.
+    /// </summary>
+    QuincenaWindow GetQuincenaWindow(DateOnly date);
+}

--- a/src/Core/Services/ServicePaymentService.cs
+++ b/src/Core/Services/ServicePaymentService.cs
@@ -1,0 +1,251 @@
+using Microsoft.Extensions.Logging;
+using Neurocorp.Api.Core.BusinessObjects.Payments;
+using Neurocorp.Api.Core.BusinessObjects.ServicePayments;
+using Neurocorp.Api.Core.Entities;
+using Neurocorp.Api.Core.Interfaces.Repositories;
+using Neurocorp.Api.Core.Interfaces.Services;
+
+namespace Neurocorp.Api.Core.Services;
+
+public class ServicePaymentService : IServicePaymentService
+{
+    private const string StatusCompleted = "Completed";
+
+    private readonly IServicePaymentRepository _servicePaymentRepo;
+    private readonly ISessionServicePaymentRepository _sessionServicePaymentRepo;
+    private readonly ITherapySessionRepository _sessionRepo;
+    private readonly IRepository<AppointmentStatus> _appointmentStatusRepo;
+    private readonly ILogger<ServicePaymentService> _logger;
+
+    public ServicePaymentService(
+        ILogger<ServicePaymentService> logger,
+        IServicePaymentRepository servicePaymentRepo,
+        ISessionServicePaymentRepository sessionServicePaymentRepo,
+        ITherapySessionRepository sessionRepo,
+        IRepository<AppointmentStatus> appointmentStatusRepo)
+    {
+        _logger = logger;
+        _servicePaymentRepo = servicePaymentRepo;
+        _sessionServicePaymentRepo = sessionServicePaymentRepo;
+        _sessionRepo = sessionRepo;
+        _appointmentStatusRepo = appointmentStatusRepo;
+    }
+
+    public async Task<ServicePaymentRecord> CreateAsync(ServicePaymentRequest request)
+    {
+        _logger.LogInformation("Creating service payment for therapist {TherapistId}, amount {Amount}", request.TherapistId, request.Amount);
+
+        ValidateRequest(request.Amount, request.SessionAllocations);
+
+        // Per-session: cannot apply more than the session still owes the therapist.
+        var sessionIds = request.SessionAllocations.Select(a => a.SessionId).ToList();
+        var existingAllocations = await _sessionServicePaymentRepo.GetBySessionIdsAsync(sessionIds);
+        var appliedBySession = existingAllocations
+            .GroupBy(a => a.TherapySessionId)
+            .ToDictionary(g => g.Key, g => g.Sum(a => a.AmountApplied));
+
+        foreach (var alloc in request.SessionAllocations)
+        {
+            var session = await _sessionRepo.GetByIdAsync(alloc.SessionId)
+                ?? throw new ArgumentException($"Session {alloc.SessionId} not found.");
+
+            var alreadyApplied = appliedBySession.TryGetValue(alloc.SessionId, out var sum) ? sum : 0m;
+            var remaining = session.ProviderAmount - alreadyApplied;
+            if (alloc.AmountApplied > remaining)
+                throw new ArgumentException($"Allocation {alloc.AmountApplied:C} exceeds remaining provider amount {remaining:C} for session {alloc.SessionId}.");
+        }
+
+        var servicePayment = new ServicePayment
+        {
+            TherapistId = request.TherapistId,
+            Amount = request.Amount,
+            PaymentDate = request.PaymentDate,
+            PaymentTypeId = request.PaymentTypeId,
+            ReferenceNumber = request.ReferenceNumber,
+            Notes = request.Notes,
+        };
+
+        var created = await _servicePaymentRepo.AddAsync(servicePayment);
+
+        foreach (var alloc in request.SessionAllocations)
+        {
+            await _sessionServicePaymentRepo.AddAsync(new SessionServicePayment
+            {
+                ServicePaymentId = created.Id,
+                TherapySessionId = alloc.SessionId,
+                AmountApplied = alloc.AmountApplied,
+            });
+        }
+
+        var result = await _servicePaymentRepo.GetByIdWithDetailsAsync(created.Id);
+        return MapToRecord(result!);
+    }
+
+    public async Task<IEnumerable<ServicePaymentRecord>> GetByTherapistAsync(int therapistId, DateOnly? from, DateOnly? to)
+    {
+        var (periodStart, periodEnd) = ResolveRange(from, to);
+        _logger.LogInformation("Listing service payments for therapist {TherapistId} {From}..{To}", therapistId, periodStart, periodEnd);
+
+        var payments = await _servicePaymentRepo.GetByTherapistIdAndDateRangeAsync(
+            therapistId,
+            periodStart.ToDateTime(TimeOnly.MinValue),
+            periodEnd.ToDateTime(TimeOnly.MaxValue));
+
+        return payments.Select(MapToRecord);
+    }
+
+    public async Task<ServicePaymentRecord?> GetByIdAsync(int servicePaymentId)
+    {
+        var payment = await _servicePaymentRepo.GetByIdWithDetailsAsync(servicePaymentId);
+        return payment == null ? null : MapToRecord(payment);
+    }
+
+    public async Task<IEnumerable<UnpaidProviderSessionSummary>> GetUnpaidProviderSessionsAsync(int therapistId, DateOnly? from, DateOnly? to)
+    {
+        var (periodStart, periodEnd) = ResolveRange(from, to);
+        _logger.LogInformation("Listing unpaid provider sessions for therapist {TherapistId} {From}..{To}", therapistId, periodStart, periodEnd);
+
+        var completedId = await ResolveCompletedStatusIdAsync();
+        if (completedId == null) return Enumerable.Empty<UnpaidProviderSessionSummary>();
+
+        var sessions = await _sessionRepo.GetByTherapistIdAndDateRangeAsync(
+            therapistId, periodStart, periodEnd, new[] { completedId.Value });
+
+        var sessionIds = sessions.Select(s => s.Id).ToList();
+        var allocations = await _sessionServicePaymentRepo.GetBySessionIdsAsync(sessionIds);
+        var appliedBySession = allocations
+            .GroupBy(a => a.TherapySessionId)
+            .ToDictionary(g => g.Key, g => g.Sum(a => a.AmountApplied));
+
+        var results = new List<UnpaidProviderSessionSummary>();
+        foreach (var s in sessions.OrderBy(s => s.SessionDate).ThenBy(s => s.SessionTime))
+        {
+            var alreadyApplied = appliedBySession.TryGetValue(s.Id, out var sum) ? sum : 0m;
+            var remaining = s.ProviderAmount - alreadyApplied;
+            if (remaining <= 0) continue;
+
+            results.Add(new UnpaidProviderSessionSummary
+            {
+                SessionId = s.Id,
+                SessionDate = s.SessionDate.ToString("yyyy-MM-dd"),
+                SessionTime = s.SessionTime.ToString("HH:mm"),
+                PatientId = s.PatientId,
+                PatientName = ResolvePatientName(s.Patient),
+                TherapyType = ResolveTherapyType(s),
+                ProviderAmount = s.ProviderAmount,
+                AlreadyApplied = alreadyApplied,
+                RemainingProviderAmount = remaining,
+            });
+        }
+
+        return results;
+    }
+
+    public QuincenaWindow GetQuincenaWindow(DateOnly date)
+    {
+        DateOnly from, to;
+        if (date.Day <= 15)
+        {
+            from = new DateOnly(date.Year, date.Month, 1);
+            to = new DateOnly(date.Year, date.Month, 15);
+        }
+        else
+        {
+            from = new DateOnly(date.Year, date.Month, 16);
+            to = new DateOnly(date.Year, date.Month, DateTime.DaysInMonth(date.Year, date.Month));
+        }
+
+        return new QuincenaWindow
+        {
+            From = from.ToString("yyyy-MM-dd"),
+            To = to.ToString("yyyy-MM-dd"),
+        };
+    }
+
+    private static (DateOnly from, DateOnly to) ResolveRange(DateOnly? from, DateOnly? to)
+    {
+        var periodStart = from ?? DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-90));
+        var periodEnd = to ?? DateOnly.FromDateTime(DateTime.UtcNow);
+        if (periodEnd < periodStart)
+            throw new ArgumentException("Query parameter 'to' must be on or after 'from'.");
+        return (periodStart, periodEnd);
+    }
+
+    private async Task<int?> ResolveCompletedStatusIdAsync()
+    {
+        var statuses = await _appointmentStatusRepo.GetAllAsync();
+        var completed = statuses.FirstOrDefault(s => string.Equals(s.Name, StatusCompleted, StringComparison.OrdinalIgnoreCase));
+        if (completed == null)
+            _logger.LogWarning("AppointmentStatus '{Name}' not found in lookup table", StatusCompleted);
+        return completed?.Id;
+    }
+
+    private static void ValidateRequest(decimal amount, List<SessionServiceAllocationItem> allocations)
+    {
+        // MVP entry is positive-only. Negative (reversal) entries arrive with WP-14.5.
+        if (amount <= 0)
+            throw new ArgumentException("Service payment amount must be greater than zero.");
+
+        var totalApplied = allocations.Sum(a => a.AmountApplied);
+        if (totalApplied > amount)
+            throw new ArgumentException($"Total allocations ({totalApplied:C}) exceed payment amount ({amount:C}).");
+    }
+
+    private static ServicePaymentRecord MapToRecord(ServicePayment sp)
+    {
+        var allocations = sp.SessionServicePayments?.Select(ssp => new ServiceAllocationDetail
+        {
+            SessionServicePaymentId = ssp.Id,
+            SessionId = ssp.TherapySessionId,
+            SessionDate = ssp.TherapySession?.SessionDate.ToString("yyyy-MM-dd") ?? string.Empty,
+            PatientName = ssp.TherapySession?.Patient != null ? ResolvePatientName(ssp.TherapySession.Patient) : string.Empty,
+            AmountApplied = ssp.AmountApplied,
+        }).ToList() ?? new List<ServiceAllocationDetail>();
+
+        var totalApplied = allocations.Sum(a => a.AmountApplied);
+
+        return new ServicePaymentRecord
+        {
+            ServicePaymentId = sp.Id,
+            TherapistId = sp.TherapistId,
+            TherapistName = ResolveTherapistName(sp.Therapist),
+            PaymentDate = sp.PaymentDate,
+            Amount = sp.Amount,
+            PaymentType = sp.PaymentType != null
+                ? new PaymentTypeInfo
+                {
+                    PaymentTypeId = sp.PaymentType.Id,
+                    Abbreviation = sp.PaymentType.Abbreviation,
+                    Name = sp.PaymentType.Name,
+                }
+                : new PaymentTypeInfo(),
+            ReferenceNumber = sp.ReferenceNumber,
+            Notes = sp.Notes,
+            Allocations = allocations,
+            TotalApplied = totalApplied,
+            UnallocatedAmount = sp.Amount - totalApplied,
+        };
+    }
+
+    private static string ResolveTherapistName(Therapist? therapist)
+    {
+        if (therapist?.User == null) return string.Empty;
+        return $"{therapist.User.LastName}, {therapist.User.FirstName}".Trim();
+    }
+
+    private static string ResolvePatientName(Patient? patient)
+    {
+        if (patient?.User == null) return string.Empty;
+        var middle = string.IsNullOrWhiteSpace(patient.User.MiddleName) ? string.Empty : $" {patient.User.MiddleName}";
+        return $"{patient.User.LastName}, {patient.User.FirstName}{middle}".Trim();
+    }
+
+    private static string ResolveTherapyType(TherapySession s)
+    {
+        if (s.SpecialtyType != null && !string.IsNullOrWhiteSpace(s.SpecialtyType.Name))
+            return s.SpecialtyType.Name;
+        if (!string.IsNullOrWhiteSpace(s.TherapyTypes))
+            return s.TherapyTypes;
+        return "N/A";
+    }
+}

--- a/src/Core/Services/TherapistStatementService.cs
+++ b/src/Core/Services/TherapistStatementService.cs
@@ -15,18 +15,24 @@ public class TherapistStatementService : ITherapistStatementService
     private readonly ITherapistProfileService _therapistProfileService;
     private readonly ITherapySessionRepository _sessionRepo;
     private readonly IRepository<AppointmentStatus> _appointmentStatusRepo;
+    private readonly ISessionServicePaymentRepository _sessionServicePaymentRepo;
+    private readonly IServicePaymentRepository _servicePaymentRepo;
     private readonly ILogger<TherapistStatementService> _logger;
 
     public TherapistStatementService(
         ILogger<TherapistStatementService> logger,
         ITherapistProfileService therapistProfileService,
         ITherapySessionRepository sessionRepo,
-        IRepository<AppointmentStatus> appointmentStatusRepo)
+        IRepository<AppointmentStatus> appointmentStatusRepo,
+        ISessionServicePaymentRepository sessionServicePaymentRepo,
+        IServicePaymentRepository servicePaymentRepo)
     {
         _logger = logger;
         _therapistProfileService = therapistProfileService;
         _sessionRepo = sessionRepo;
         _appointmentStatusRepo = appointmentStatusRepo;
+        _sessionServicePaymentRepo = sessionServicePaymentRepo;
+        _servicePaymentRepo = servicePaymentRepo;
     }
 
     public async Task<TherapistStatement?> GetStatementAsync(int therapistId, DateOnly? from, DateOnly? to)
@@ -113,13 +119,29 @@ public class TherapistStatementService : ITherapistStatementService
             .OrderBy(b => b.PatientName, StringComparer.OrdinalIgnoreCase)
             .ToList();
 
-        // 6. Compute summary
+        // 6. Service payments (WP-14): join the payroll allocations recorded against any session
+        //    in this statement's range. The statement is authoritative (not pro-forma) once any
+        //    payment touches the period; until then it remains an estimate.
+        var inRangeSessionIds = sessions.Select(s => s.Id).ToList();
+        var inRangeSessionIdSet = new HashSet<int>(inRangeSessionIds);
+        var allocations = await _sessionServicePaymentRepo.GetBySessionIdsAsync(inRangeSessionIds);
+        var totalServicePaymentsApplied = allocations.Sum(a => a.AmountApplied);
+
+        var servicePaymentIds = allocations.Select(a => a.ServicePaymentId).Distinct().ToList();
+        var servicePayments = await _servicePaymentRepo.GetByIdsWithDetailsAsync(servicePaymentIds);
+        var servicePaymentItems = servicePayments
+            .OrderByDescending(p => p.PaymentDate)
+            .Select(p => MapServicePaymentItem(p, inRangeSessionIdSet))
+            .ToList();
+
+        var isProForma = allocations.Count == 0;
+
+        // 7. Compute summary
         var totalCompleted = patientBlocks.Sum(p => p.CompletedCount);
         var totalNonBillable = patientBlocks.Sum(p => p.NonBillableCount);
         var totalFee = patientBlocks.Sum(p => p.SubtotalFee);
         var totalDiscount = patientBlocks.Sum(p => p.SubtotalDiscount);
         var totalProvider = patientBlocks.Sum(p => p.SubtotalProviderAmount);
-        var totalServicePaymentsApplied = 0m; // pro-forma: ServicePayments not tracked yet
         var estimatedAmountDue = totalProvider - totalServicePaymentsApplied;
 
         var summary = new TherapistStatementSummary
@@ -140,9 +162,9 @@ public class TherapistStatementService : ITherapistStatementService
             StatementDate = DateOnly.FromDateTime(DateTime.UtcNow).ToString("yyyy-MM-dd"),
             PeriodStart = periodStart.ToString("yyyy-MM-dd"),
             PeriodEnd = periodEnd.ToString("yyyy-MM-dd"),
-            IsProForma = true,
+            IsProForma = isProForma,
             Patients = patientBlocks,
-            ServicePayments = new List<ServicePaymentItem>(),
+            ServicePayments = servicePaymentItems,
             Summary = summary,
         };
     }
@@ -190,5 +212,41 @@ public class TherapistStatementService : ITherapistStatementService
         if (patient?.User == null) return string.Empty;
         var middle = string.IsNullOrWhiteSpace(patient.User.MiddleName) ? string.Empty : $" {patient.User.MiddleName}";
         return $"{patient.User.LastName}, {patient.User.FirstName}{middle}".Trim();
+    }
+
+    /// <summary>
+    /// Maps a ServicePayment to a statement line. ALL of the payment's allocations are listed
+    /// (per WP-14 open-Q 9) even when some fall outside this statement's period; a note is added
+    /// when that happens so the reader understands only a subset of allocations is in-range.
+    /// </summary>
+    private static ServicePaymentItem MapServicePaymentItem(ServicePayment p, HashSet<int> inRangeSessionIds)
+    {
+        var allocations = p.SessionServicePayments?
+            .Select(ssp => new ServicePaymentAllocation
+            {
+                SessionId = ssp.TherapySessionId,
+                AmountApplied = ssp.AmountApplied,
+            })
+            .ToList() ?? new List<ServicePaymentAllocation>();
+
+        var coversOutOfRange = allocations.Any(a => !inRangeSessionIds.Contains(a.SessionId));
+        var notes = p.Notes ?? string.Empty;
+        if (coversOutOfRange)
+        {
+            notes = string.IsNullOrWhiteSpace(notes)
+                ? "Covers sessions outside this period."
+                : $"{notes} (Covers sessions outside this period.)";
+        }
+
+        return new ServicePaymentItem
+        {
+            ServicePaymentId = p.Id,
+            PaymentDate = p.PaymentDate.ToString("yyyy-MM-dd"),
+            Amount = p.Amount,
+            PaymentTypeName = p.PaymentType?.Name ?? string.Empty,
+            ReferenceNumber = p.ReferenceNumber ?? string.Empty,
+            Notes = notes,
+            Allocations = allocations,
+        };
     }
 }

--- a/src/Infrastructure/Configurations/Dependencies.cs
+++ b/src/Infrastructure/Configurations/Dependencies.cs
@@ -58,6 +58,8 @@ public static class NeurocorpConfigurationExtensions
         services.AddScoped<ITherapySessionRepository, TherapySessionRepository>();
         services.AddScoped<IPaymentRepository, PaymentRepository>();
         services.AddScoped<ISessionPaymentRepository, SessionPaymentRepository>();
+        services.AddScoped<IServicePaymentRepository, ServicePaymentRepository>();
+        services.AddScoped<ISessionServicePaymentRepository, SessionServicePaymentRepository>();
         services.AddScoped<IUserRepository, UserRepository>();
         services.AddScoped<IUserRoleRepository, UserRoleRepository>();
         services.AddScoped<ISessionEventRepository, SessionEventRepository>();

--- a/src/Infrastructure/Data/ApplicationDbContext.cs
+++ b/src/Infrastructure/Data/ApplicationDbContext.cs
@@ -30,6 +30,8 @@ public class ApplicationDbContext : DbContext
     public DbSet<TherapySession> TherapySessions { get; set; }
     public DbSet<Payment> Payments { get; set; }
     public DbSet<SessionPayment> SessionPayments { get; set; }
+    public DbSet<ServicePayment> ServicePayments { get; set; }
+    public DbSet<SessionServicePayment> SessionServicePayments { get; set; }
     public DbSet<PaymentType> PaymentTypes { get; set; }
     public DbSet<AppointmentStatus> AppointmentStatuses { get; set; }
     public DbSet<AppointmentConfirmation> AppointmentConfirmations { get; set; }

--- a/src/Infrastructure/Data/Configurations/ServicePaymentConfigurations.cs
+++ b/src/Infrastructure/Data/Configurations/ServicePaymentConfigurations.cs
@@ -1,0 +1,35 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Neurocorp.Api.Core.Entities;
+
+namespace Neurocorp.Api.Infrastructure.Data.Configurations;
+
+// EF Core mapping for the therapist-payroll tables (WP-14B). Mirrors PaymentConfigurations:
+// only DB column-name renames are declared; relationships are inferred by convention from the
+// navigation properties (ServicePayment.SessionServicePayments / .Therapist / .PaymentType).
+
+public class ServicePaymentConfiguration : IEntityTypeConfiguration<ServicePayment>
+{
+    public void Configure(EntityTypeBuilder<ServicePayment> builder)
+    {
+        builder.ToTable("ServicePayment");
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.Id).HasColumnName("ServicePaymentID");
+        builder.Property(e => e.TherapistId).HasColumnName("TherapistID");
+        // ReversesServicePaymentID is a bare scalar (no navigation) — mapped for completeness,
+        // reserved for WP-14.5 reversals; EF does not model the self-FK relationship.
+        builder.Property(e => e.ReversesServicePaymentId).HasColumnName("ReversesServicePaymentID");
+    }
+}
+
+public class SessionServicePaymentConfiguration : IEntityTypeConfiguration<SessionServicePayment>
+{
+    public void Configure(EntityTypeBuilder<SessionServicePayment> builder)
+    {
+        builder.ToTable("SessionServicePayment");
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.Id).HasColumnName("SessionServicePaymentID");
+        builder.Property(e => e.TherapySessionId).HasColumnName("SessionID");
+        builder.Property(e => e.ServicePaymentId).HasColumnName("ServicePaymentID");
+    }
+}

--- a/src/Infrastructure/Repositories/ServicePaymentRepository.cs
+++ b/src/Infrastructure/Repositories/ServicePaymentRepository.cs
@@ -1,0 +1,41 @@
+using Microsoft.EntityFrameworkCore;
+using Neurocorp.Api.Core.Entities;
+using Neurocorp.Api.Core.Interfaces.Repositories;
+using Neurocorp.Api.Infrastructure.Data;
+
+namespace Neurocorp.Api.Infrastructure.Repositories;
+
+public class ServicePaymentRepository(ApplicationDbContext dbContext) :
+    EfRepository<ServicePayment>(dbContext), IServicePaymentRepository
+{
+    private IQueryable<ServicePayment> WithDetails() =>
+        _dbContext.ServicePayments
+            .Include(sp => sp.Therapist).ThenInclude(t => t.User)
+            .Include(sp => sp.PaymentType)
+            .Include(sp => sp.SessionServicePayments).ThenInclude(ssp => ssp.TherapySession).ThenInclude(ts => ts.Patient).ThenInclude(pt => pt!.User);
+
+    public async Task<IReadOnlyList<ServicePayment>> GetByTherapistIdAndDateRangeAsync(int therapistId, DateTime from, DateTime to)
+    {
+        return await WithDetails()
+            .Where(sp => sp.TherapistId == therapistId && sp.PaymentDate >= from && sp.PaymentDate <= to)
+            .OrderByDescending(sp => sp.PaymentDate)
+            .ToListAsync();
+    }
+
+    public async Task<ServicePayment?> GetByIdWithDetailsAsync(int servicePaymentId)
+    {
+        return await WithDetails()
+            .FirstOrDefaultAsync(sp => sp.Id == servicePaymentId);
+    }
+
+    public async Task<IReadOnlyList<ServicePayment>> GetByIdsWithDetailsAsync(IEnumerable<int> servicePaymentIds)
+    {
+        var ids = servicePaymentIds.Distinct().ToList();
+        if (ids.Count == 0) return new List<ServicePayment>();
+
+        return await WithDetails()
+            .Where(sp => ids.Contains(sp.Id))
+            .OrderByDescending(sp => sp.PaymentDate)
+            .ToListAsync();
+    }
+}

--- a/src/Infrastructure/Repositories/SessionServicePaymentRepository.cs
+++ b/src/Infrastructure/Repositories/SessionServicePaymentRepository.cs
@@ -1,0 +1,20 @@
+using Microsoft.EntityFrameworkCore;
+using Neurocorp.Api.Core.Entities;
+using Neurocorp.Api.Core.Interfaces.Repositories;
+using Neurocorp.Api.Infrastructure.Data;
+
+namespace Neurocorp.Api.Infrastructure.Repositories;
+
+public class SessionServicePaymentRepository(ApplicationDbContext dbContext) :
+    EfRepository<SessionServicePayment>(dbContext), ISessionServicePaymentRepository
+{
+    public async Task<IReadOnlyList<SessionServicePayment>> GetBySessionIdsAsync(IEnumerable<int> sessionIds)
+    {
+        var ids = sessionIds.Distinct().ToList();
+        if (ids.Count == 0) return new List<SessionServicePayment>();
+
+        return await _dbContext.SessionServicePayments
+            .Where(ssp => ids.Contains(ssp.TherapySessionId))
+            .ToListAsync();
+    }
+}

--- a/src/Web/Authorization/AccessControlManifest.cs
+++ b/src/Web/Authorization/AccessControlManifest.cs
@@ -18,5 +18,5 @@ namespace Neurocorp.Api.Web.Authorization;
 public static class AccessControlManifest
 {
     /// <summary>First 12 hex chars of SHA-256 over the manifest's canonical grant tuples.</summary>
-    public const string SemanticHash = "b88f98dc47d7";
+    public const string SemanticHash = "b10682734edf";
 }

--- a/src/Web/Authorization/Permissions.g.cs
+++ b/src/Web/Authorization/Permissions.g.cs
@@ -7,7 +7,7 @@
 //   (patient-care-super/tools/generate-access-manifest.sh), re-vendor
 //   docs/access-control-matrix.json, then re-run tools/generate-permissions.sh.
 //
-//   Access-control manifest semantic hash: b88f98dc47d7
+//   Access-control manifest semantic hash: b10682734edf
 // </auto-generated>
 
 namespace Neurocorp.Api.Web.Authorization;
@@ -58,6 +58,8 @@ public static class Permissions
     public const string ScheduleBook = "Schedule.Book";
     public const string ScheduleRebook = "Schedule.Rebook";
     public const string ScheduleView = "Schedule.View";
+    public const string ServicePaymentsRecord = "ServicePayments.Record";
+    public const string ServicePaymentsView = "ServicePayments.View";
     public const string StatementsCaretakerView = "Statements.Caretaker.View";
     public const string StatementsTherapistView = "Statements.Therapist.View";
     public const string StatementsView = "Statements.View";

--- a/src/Web/Controllers/ServicePaymentsController.cs
+++ b/src/Web/Controllers/ServicePaymentsController.cs
@@ -1,0 +1,77 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Neurocorp.Api.Core.BusinessObjects.ServicePayments;
+using Neurocorp.Api.Core.Interfaces.Services;
+using Neurocorp.Api.Web.Authorization;
+
+namespace Neurocorp.Api.Web.Controllers;
+
+[ApiController]
+[Route("api/service-payments")]
+public class ServicePaymentsController : ControllerBase
+{
+    private readonly IServicePaymentService _servicePaymentService;
+    private readonly ILogger<ServicePaymentsController> _logger;
+
+    public ServicePaymentsController(ILogger<ServicePaymentsController> logger, IServicePaymentService servicePaymentService)
+    {
+        _logger = logger;
+        _servicePaymentService = servicePaymentService;
+    }
+
+    // WP-14: viewing therapist payroll exposes ProviderAmount-derived figures, so it follows the
+    // same confidentiality rule as Appointments.ProviderAmount — MGR/AM only, FD excluded.
+    [HttpGet]
+    [Authorize(Policy = AuthPolicy.PermissionPrefix + Permissions.ServicePaymentsView)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<ServicePaymentRecord>))]
+    public async Task<IActionResult> GetServicePayments([FromQuery] int therapistId, [FromQuery] DateOnly? from, [FromQuery] DateOnly? to)
+    {
+        var payments = await _servicePaymentService.GetByTherapistAsync(therapistId, from, to);
+        return Ok(payments);
+    }
+
+    [HttpGet("{id}")]
+    [Authorize(Policy = AuthPolicy.PermissionPrefix + Permissions.ServicePaymentsView)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ServicePaymentRecord))]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetServicePayment(int id)
+    {
+        var payment = await _servicePaymentService.GetByIdAsync(id);
+        if (payment == null) return NotFound();
+        return Ok(payment);
+    }
+
+    // Feeds the "Pay Therapist" wizard: completed sessions in range that still owe the therapist.
+    [HttpGet("unpaid-sessions")]
+    [Authorize(Policy = AuthPolicy.PermissionPrefix + Permissions.ServicePaymentsView)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<UnpaidProviderSessionSummary>))]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> GetUnpaidSessions([FromQuery] int therapistId, [FromQuery] DateOnly? from, [FromQuery] DateOnly? to)
+    {
+        var sessions = await _servicePaymentService.GetUnpaidProviderSessionsAsync(therapistId, from, to);
+        return Ok(sessions);
+    }
+
+    // Pure date helper for the date-range picker default. Gated with View for consistency
+    // (the whole feature is MGR/AM-only); the window is a UX hint, not a constraint.
+    [HttpGet("quincena")]
+    [Authorize(Policy = AuthPolicy.PermissionPrefix + Permissions.ServicePaymentsView)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(QuincenaWindow))]
+    public IActionResult GetQuincena([FromQuery] DateOnly? date)
+    {
+        var window = _servicePaymentService.GetQuincenaWindow(date ?? DateOnly.FromDateTime(DateTime.UtcNow));
+        return Ok(window);
+    }
+
+    // WP-14: issuing a disbursement is MGR-only (owner-level). The append-only reversal/adjust
+    // capability arrives with WP-14.5 (separate claim).
+    [HttpPost]
+    [Authorize(Policy = AuthPolicy.PermissionPrefix + Permissions.ServicePaymentsRecord)]
+    [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(ServicePaymentRecord))]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> CreateServicePayment([FromBody] ServicePaymentRequest request)
+    {
+        var created = await _servicePaymentService.CreateAsync(request);
+        return CreatedAtAction(nameof(GetServicePayment), new { id = created.ServicePaymentId }, created);
+    }
+}

--- a/test-scripts/wp-14b-service-payments.sh
+++ b/test-scripts/wp-14b-service-payments.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# WP-14B: Service Payments (therapist payroll) API curl test script
+#
+# Endpoints (all under /api/service-payments):
+#   GET  /api/service-payments?therapistId=&from=&to=        -> ServicePayments.View (MGR, AM)
+#   GET  /api/service-payments/{id}                          -> ServicePayments.View (MGR, AM)
+#   GET  /api/service-payments/unpaid-sessions?therapistId=&from=&to=  -> ServicePayments.View
+#   GET  /api/service-payments/quincena?date=YYYY-MM-DD      -> ServicePayments.View
+#   POST /api/service-payments                               -> ServicePayments.Record (MGR only)
+#
+# Also re-run the therapist statement to confirm it flips to authoritative:
+#   GET  /api/therapists/{id}/statement?from=&to=            -> isProForma=false once paid
+#
+# Auth: every endpoint is claim-gated. Provide a JWT in TOKEN (MGR token to exercise POST;
+#   MGR/AM token for the GETs). Without a token the secured calls return 401, and an AM token
+#   returns 403 on POST — both are expected negative cases shown below.
+#
+# Prereqs:
+#   - API running locally on :5245 (`dotnet run --project src/Web/Web.csproj`)
+#   - RoleClaim seed applied so MGR holds ServicePayments.View/.Record and AM holds .View
+#   - jq installed for pretty printing (optional)
+#
+# Usage:
+#   TOKEN=$MGR_JWT THERAPIST_ID=1 ./test-scripts/wp-14b-service-payments.sh
+
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost:5245}"
+THERAPIST_ID="${THERAPIST_ID:-1}"
+TOKEN="${TOKEN:-}"
+PAYMENT_TYPE_ID="${PAYMENT_TYPE_ID:-1}"
+FROM="${FROM:-2026-04-01}"
+TO="${TO:-2026-04-15}"
+
+PRETTY="cat"
+if command -v jq >/dev/null 2>&1; then PRETTY="jq ."; fi
+
+AUTH=()
+if [ -n "$TOKEN" ]; then AUTH=(-H "Authorization: Bearer ${TOKEN}"); fi
+
+echo "=================================================================="
+echo "Test 1: Quincena helper for a mid-month date (expect 1st-15th)"
+echo "  GET ${BASE_URL}/api/service-payments/quincena?date=2026-04-10"
+echo "=================================================================="
+curl -sS -w "\nHTTP %{http_code}\n" "${AUTH[@]}" \
+    "${BASE_URL}/api/service-payments/quincena?date=2026-04-10" | $PRETTY
+echo
+
+echo "=================================================================="
+echo "Test 2: Unpaid provider sessions for the period (drives the wizard)"
+echo "  GET ${BASE_URL}/api/service-payments/unpaid-sessions?therapistId=${THERAPIST_ID}&from=${FROM}&to=${TO}"
+echo "  Expect: completed sessions whose remainingProviderAmount > 0"
+echo "=================================================================="
+curl -sS -w "\nHTTP %{http_code}\n" "${AUTH[@]}" \
+    "${BASE_URL}/api/service-payments/unpaid-sessions?therapistId=${THERAPIST_ID}&from=${FROM}&to=${TO}" | $PRETTY
+echo
+
+echo "=================================================================="
+echo "Test 3: Issue a service payment (POST -> 201). Requires an MGR token."
+echo "  Adjust sessionAllocations to real unpaid session IDs from Test 2."
+echo "  POST ${BASE_URL}/api/service-payments"
+echo "=================================================================="
+curl -sS -w "\nHTTP %{http_code}\n" "${AUTH[@]}" \
+    -H "Content-Type: application/json" \
+    -X POST "${BASE_URL}/api/service-payments" \
+    -d "{
+          \"therapistId\": ${THERAPIST_ID},
+          \"paymentDate\": \"2026-04-16T00:00:00\",
+          \"amount\": 60.00,
+          \"paymentTypeId\": ${PAYMENT_TYPE_ID},
+          \"referenceNumber\": \"TX-1001\",
+          \"notes\": \"April first-quincena\",
+          \"sessionAllocations\": [ { \"sessionId\": 1, \"amountApplied\": 60.00 } ]
+        }" | $PRETTY
+echo
+
+echo "=================================================================="
+echo "Test 4: List service payments for the therapist"
+echo "  GET ${BASE_URL}/api/service-payments?therapistId=${THERAPIST_ID}&from=${FROM}&to=2026-04-30"
+echo "=================================================================="
+curl -sS -w "\nHTTP %{http_code}\n" "${AUTH[@]}" \
+    "${BASE_URL}/api/service-payments?therapistId=${THERAPIST_ID}&from=${FROM}&to=2026-04-30" | $PRETTY
+echo
+
+echo "=================================================================="
+echo "Test 5: Statement is now authoritative (isProForma=false)"
+echo "  GET ${BASE_URL}/api/therapists/${THERAPIST_ID}/statement?from=${FROM}&to=2026-04-30"
+echo "  Expect: isProForma=false, summary.totalServicePaymentsApplied > 0,"
+echo "          estimatedAmountDue = totalProviderAmount - applied, servicePayments[] populated"
+echo "=================================================================="
+curl -sS -w "\nHTTP %{http_code}\n" "${AUTH[@]}" \
+    "${BASE_URL}/api/therapists/${THERAPIST_ID}/statement?from=${FROM}&to=2026-04-30" | $PRETTY
+echo
+
+echo "=================================================================="
+echo "Test 6 (negative): POST with an AM token should be 403 (Record is MGR-only)"
+echo "  Set TOKEN=\$AM_JWT and re-run; expect HTTP 403 on the POST above."
+echo "Test 7 (negative): any secured call with no token should be 401."
+echo "=================================================================="
+
+echo "All WP-14B tests complete."

--- a/tests/Core.Tests/ServicePaymentServiceTests.cs
+++ b/tests/Core.Tests/ServicePaymentServiceTests.cs
@@ -1,0 +1,204 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Neurocorp.Api.Core.BusinessObjects.ServicePayments;
+using Neurocorp.Api.Core.Entities;
+using Neurocorp.Api.Core.Interfaces.Repositories;
+using Neurocorp.Api.Core.Services;
+
+namespace Core.Tests;
+
+public class ServicePaymentServiceTests
+{
+    private const int TherapistId = 42;
+    private static readonly AppointmentStatus CompletedStatus = new() { Id = 4, Name = "Completed" };
+
+    private static (
+        ServicePaymentService Service,
+        Mock<IServicePaymentRepository> ServicePaymentRepo,
+        Mock<ISessionServicePaymentRepository> SspRepo,
+        Mock<ITherapySessionRepository> SessionRepo
+    ) BuildService(
+        IReadOnlyList<TherapySession>? completedSessions = null,
+        IReadOnlyList<SessionServicePayment>? existingAllocations = null)
+    {
+        var logger = Mock.Of<ILogger<ServicePaymentService>>();
+
+        var spRepo = new Mock<IServicePaymentRepository>();
+        var sspRepo = new Mock<ISessionServicePaymentRepository>();
+        var sessionRepo = new Mock<ITherapySessionRepository>();
+        var statusRepo = new Mock<IRepository<AppointmentStatus>>();
+
+        statusRepo.Setup(r => r.GetAllAsync()).ReturnsAsync(new List<AppointmentStatus> { CompletedStatus });
+
+        var allocations = existingAllocations ?? new List<SessionServicePayment>();
+        sspRepo
+            .Setup(r => r.GetBySessionIdsAsync(It.IsAny<IEnumerable<int>>()))
+            .ReturnsAsync((IEnumerable<int> ids) =>
+            {
+                var set = ids.ToHashSet();
+                return allocations.Where(a => set.Contains(a.TherapySessionId)).ToList();
+            });
+        sspRepo.Setup(r => r.AddAsync(It.IsAny<SessionServicePayment>()))
+            .ReturnsAsync((SessionServicePayment s) => s);
+
+        var sessions = completedSessions ?? new List<TherapySession>();
+        sessionRepo
+            .Setup(r => r.GetByTherapistIdAndDateRangeAsync(It.IsAny<int>(), It.IsAny<DateOnly>(), It.IsAny<DateOnly>(), It.IsAny<IEnumerable<int>>()))
+            .ReturnsAsync(sessions);
+        sessionRepo
+            .Setup(r => r.GetByIdAsync(It.IsAny<int>()))
+            .ReturnsAsync((int id) => sessions.FirstOrDefault(s => s.Id == id));
+
+        var service = new ServicePaymentService(logger, spRepo.Object, sspRepo.Object, sessionRepo.Object, statusRepo.Object);
+        return (service, spRepo, sspRepo, sessionRepo);
+    }
+
+    private static TherapySession Session(int id, decimal providerAmount, DateOnly? date = null) => new()
+    {
+        Id = id,
+        PatientId = 1,
+        TherapistId = TherapistId,
+        SessionDate = date ?? new DateOnly(2026, 4, 5),
+        SessionTime = new TimeOnly(9, 0),
+        AppointmentStatusId = CompletedStatus.Id,
+        ProviderAmount = providerAmount,
+        Patient = new Patient { Id = 1, User = new User { Id = 100, FirstName = "Dan", LastName = "Green" } },
+    };
+
+    [Fact]
+    public async Task CreateAsync_PersistsPaymentAndAllocations()
+    {
+        var (service, spRepo, sspRepo, _) = BuildService(
+            completedSessions: new List<TherapySession> { Session(1, 60m), Session(2, 60m) });
+
+        spRepo.Setup(r => r.AddAsync(It.IsAny<ServicePayment>()))
+            .ReturnsAsync((ServicePayment sp) => { sp.Id = 500; return sp; });
+
+        spRepo.Setup(r => r.GetByIdWithDetailsAsync(500)).ReturnsAsync(new ServicePayment
+        {
+            Id = 500,
+            TherapistId = TherapistId,
+            Amount = 120m,
+            PaymentDate = new DateTime(2026, 4, 20),
+            PaymentType = new PaymentType { Id = 1, Name = "Bank Transfer", Abbreviation = "ACH" },
+            Therapist = new Therapist { Id = TherapistId, User = new User { Id = 9, FirstName = "Jane", LastName = "Smith" } },
+            SessionServicePayments = new List<SessionServicePayment>
+            {
+                new() { Id = 1, ServicePaymentId = 500, TherapySessionId = 1, AmountApplied = 60m, TherapySession = Session(1, 60m) },
+                new() { Id = 2, ServicePaymentId = 500, TherapySessionId = 2, AmountApplied = 60m, TherapySession = Session(2, 60m) },
+            },
+        });
+
+        var request = new ServicePaymentRequest
+        {
+            TherapistId = TherapistId,
+            Amount = 120m,
+            PaymentDate = new DateTime(2026, 4, 20),
+            PaymentTypeId = 1,
+            SessionAllocations = new List<SessionServiceAllocationItem>
+            {
+                new() { SessionId = 1, AmountApplied = 60m },
+                new() { SessionId = 2, AmountApplied = 60m },
+            },
+        };
+
+        var result = await service.CreateAsync(request);
+
+        result.ServicePaymentId.Should().Be(500);
+        result.TherapistName.Should().Be("Smith, Jane");
+        result.Allocations.Should().HaveCount(2);
+        result.TotalApplied.Should().Be(120m);
+        result.UnallocatedAmount.Should().Be(0m);
+        spRepo.Verify(r => r.AddAsync(It.IsAny<ServicePayment>()), Times.Once);
+        sspRepo.Verify(r => r.AddAsync(It.IsAny<SessionServicePayment>()), Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task CreateAsync_Throws_WhenAmountNotPositive()
+    {
+        var (service, _, _, _) = BuildService();
+        var request = new ServicePaymentRequest { TherapistId = TherapistId, Amount = 0m, PaymentTypeId = 1 };
+
+        var act = async () => await service.CreateAsync(request);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task CreateAsync_Throws_WhenAllocationsExceedAmount()
+    {
+        var (service, _, _, _) = BuildService(completedSessions: new List<TherapySession> { Session(1, 200m) });
+        var request = new ServicePaymentRequest
+        {
+            TherapistId = TherapistId,
+            Amount = 50m,
+            PaymentTypeId = 1,
+            SessionAllocations = new List<SessionServiceAllocationItem> { new() { SessionId = 1, AmountApplied = 100m } },
+        };
+
+        var act = async () => await service.CreateAsync(request);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task CreateAsync_Throws_WhenAllocationExceedsRemainingProviderAmount()
+    {
+        // Session provider amount is 60; 40 already applied → only 20 remains, but we try 50.
+        var existing = new List<SessionServicePayment>
+        {
+            new() { Id = 1, ServicePaymentId = 99, TherapySessionId = 1, AmountApplied = 40m },
+        };
+        var (service, _, _, _) = BuildService(
+            completedSessions: new List<TherapySession> { Session(1, 60m) },
+            existingAllocations: existing);
+
+        var request = new ServicePaymentRequest
+        {
+            TherapistId = TherapistId,
+            Amount = 50m,
+            PaymentTypeId = 1,
+            SessionAllocations = new List<SessionServiceAllocationItem> { new() { SessionId = 1, AmountApplied = 50m } },
+        };
+
+        var act = async () => await service.CreateAsync(request);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task GetUnpaidProviderSessionsAsync_ExcludesFullyPaidSessions()
+    {
+        // Session 1 fully paid (60 of 60); session 2 partly paid (20 of 60 → 40 remains).
+        var sessions = new List<TherapySession> { Session(1, 60m), Session(2, 60m) };
+        var existing = new List<SessionServicePayment>
+        {
+            new() { Id = 1, ServicePaymentId = 99, TherapySessionId = 1, AmountApplied = 60m },
+            new() { Id = 2, ServicePaymentId = 99, TherapySessionId = 2, AmountApplied = 20m },
+        };
+        var (service, _, _, _) = BuildService(completedSessions: sessions, existingAllocations: existing);
+
+        var result = (await service.GetUnpaidProviderSessionsAsync(TherapistId, new DateOnly(2026, 4, 1), new DateOnly(2026, 4, 30))).ToList();
+
+        result.Should().HaveCount(1);
+        result[0].SessionId.Should().Be(2);
+        result[0].AlreadyApplied.Should().Be(20m);
+        result[0].RemainingProviderAmount.Should().Be(40m);
+    }
+
+    [Theory]
+    [InlineData(2026, 4, 10, "2026-04-01", "2026-04-15")]  // day <= 15 → first half
+    [InlineData(2026, 4, 15, "2026-04-01", "2026-04-15")]  // boundary day 15
+    [InlineData(2026, 4, 16, "2026-04-16", "2026-04-30")]  // boundary day 16 → second half
+    [InlineData(2026, 2, 20, "2026-02-16", "2026-02-28")]  // EOM for non-leap February
+    public void GetQuincenaWindow_ReturnsExpectedWindow(int y, int m, int d, string expectedFrom, string expectedTo)
+    {
+        var (service, _, _, _) = BuildService();
+
+        var window = service.GetQuincenaWindow(new DateOnly(y, m, d));
+
+        window.From.Should().Be(expectedFrom);
+        window.To.Should().Be(expectedTo);
+    }
+}

--- a/tests/Core.Tests/TherapistStatementServiceTests.cs
+++ b/tests/Core.Tests/TherapistStatementServiceTests.cs
@@ -21,7 +21,10 @@ public class TherapistStatementServiceTests
     private static (
         TherapistStatementService Service,
         Mock<ITherapySessionRepository> SessionRepoMock
-    ) BuildService(IReadOnlyList<TherapySession> sessions)
+    ) BuildService(
+        IReadOnlyList<TherapySession> sessions,
+        IReadOnlyList<SessionServicePayment>? allocations = null,
+        IReadOnlyList<ServicePayment>? servicePayments = null)
     {
         var fakeLogger = Mock.Of<ILogger<TherapistStatementService>>();
 
@@ -47,11 +50,33 @@ public class TherapistStatementServiceTests
                     .ToList();
             });
 
+        var allAllocations = allocations ?? new List<SessionServicePayment>();
+        var sspRepo = new Mock<ISessionServicePaymentRepository>();
+        sspRepo
+            .Setup(r => r.GetBySessionIdsAsync(It.IsAny<IEnumerable<int>>()))
+            .ReturnsAsync((IEnumerable<int> sessionIds) =>
+            {
+                var set = sessionIds.ToHashSet();
+                return allAllocations.Where(a => set.Contains(a.TherapySessionId)).ToList();
+            });
+
+        var allPayments = servicePayments ?? new List<ServicePayment>();
+        var spRepo = new Mock<IServicePaymentRepository>();
+        spRepo
+            .Setup(r => r.GetByIdsWithDetailsAsync(It.IsAny<IEnumerable<int>>()))
+            .ReturnsAsync((IEnumerable<int> ids) =>
+            {
+                var set = ids.ToHashSet();
+                return allPayments.Where(p => set.Contains(p.Id)).ToList();
+            });
+
         var service = new TherapistStatementService(
             fakeLogger,
             profileService.Object,
             sessionRepo.Object,
-            statusRepo.Object);
+            statusRepo.Object,
+            sspRepo.Object,
+            spRepo.Object);
 
         return (service, sessionRepo);
     }
@@ -99,13 +124,8 @@ public class TherapistStatementServiceTests
     [Fact]
     public async Task GetStatementAsync_ReturnsNull_WhenTherapistNotFound()
     {
-        // Arrange
-        var fakeLogger = Mock.Of<ILogger<TherapistStatementService>>();
-        var profileService = new Mock<ITherapistProfileService>();
-        profileService.Setup(s => s.GetByIdAsync(It.IsAny<int>())).ReturnsAsync((TherapistProfile?)null);
-        var statusRepo = new Mock<IRepository<AppointmentStatus>>();
-        var sessionRepo = new Mock<ITherapySessionRepository>();
-        var service = new TherapistStatementService(fakeLogger, profileService.Object, sessionRepo.Object, statusRepo.Object);
+        // Arrange — BuildService sets up the profile for TherapistId only; any other id is unknown
+        var (service, _) = BuildService(new List<TherapySession>());
 
         // Act
         var result = await service.GetStatementAsync(999, null, null);
@@ -188,10 +208,69 @@ public class TherapistStatementServiceTests
         block.SubtotalFee.Should().Be(500m);       // 100+100+100+200
         block.SubtotalDiscount.Should().Be(30m);   // 10+0+0+20
 
-        // Pro-forma flag + empty ServicePayments
+        // No service payments recorded → still pro-forma, empty ServicePayments
         result.IsProForma.Should().BeTrue();
         result.ServicePayments.Should().BeEmpty();
         result.Summary.TotalServicePaymentsApplied.Should().Be(0m);
+    }
+
+    [Fact]
+    public async Task GetStatementAsync_WithServicePayments_IsAuthoritativeAndSubtractsApplied()
+    {
+        // Arrange — two completed sessions (provider 60 + 120 = 180)
+        var patient = MakePatient(1, "Alice", "Anderson");
+        var sessions = new List<TherapySession>
+        {
+            MakeSession(101, patient, new DateOnly(2026, 4, 1), new TimeOnly(9, 0), CompletedStatus, providerAmount: 60m),
+            MakeSession(104, patient, new DateOnly(2026, 4, 4), new TimeOnly(12, 0), CompletedStatus, providerAmount: 120m),
+        };
+
+        // ServicePayment #500 covers in-range session 101 ($60) AND an out-of-range session 888 ($40).
+        var payment = new ServicePayment
+        {
+            Id = 500,
+            TherapistId = TherapistId,
+            PaymentDate = new DateTime(2026, 4, 20),
+            Amount = 100m,
+            PaymentType = new PaymentType { Id = 1, Name = "Bank Transfer", Abbreviation = "ACH" },
+            ReferenceNumber = "TX-77",
+            Notes = "April quincena",
+            SessionServicePayments = new List<SessionServicePayment>
+            {
+                new() { Id = 9001, ServicePaymentId = 500, TherapySessionId = 101, AmountApplied = 60m },
+                new() { Id = 9002, ServicePaymentId = 500, TherapySessionId = 888, AmountApplied = 40m },
+            },
+        };
+        // Allocation rows visible to the statement (the repo filters to in-range sessions).
+        var allocations = new List<SessionServicePayment>
+        {
+            new() { Id = 9001, ServicePaymentId = 500, TherapySessionId = 101, AmountApplied = 60m },
+            new() { Id = 9002, ServicePaymentId = 500, TherapySessionId = 888, AmountApplied = 40m },
+        };
+
+        var (service, _) = BuildService(sessions, allocations, new List<ServicePayment> { payment });
+
+        // Act
+        var result = await service.GetStatementAsync(
+            TherapistId,
+            new DateOnly(2026, 4, 1),
+            new DateOnly(2026, 4, 30));
+
+        // Assert — authoritative, with applied subtracted (only the in-range $60 counts)
+        result.Should().NotBeNull();
+        result!.IsProForma.Should().BeFalse();
+        result.Summary.TotalProviderAmount.Should().Be(180m);
+        result.Summary.TotalServicePaymentsApplied.Should().Be(60m);
+        result.Summary.EstimatedAmountDue.Should().Be(120m);
+
+        // ServicePayments[] populated; cross-period payment lists ALL allocations + a note
+        result.ServicePayments.Should().HaveCount(1);
+        var item = result.ServicePayments[0];
+        item.ServicePaymentId.Should().Be(500);
+        item.Amount.Should().Be(100m);
+        item.PaymentTypeName.Should().Be("Bank Transfer");
+        item.Allocations.Should().HaveCount(2);
+        item.Notes.Should().Contain("outside this period");
     }
 
     [Fact]
@@ -265,7 +344,7 @@ public class TherapistStatementServiceTests
     }
 
     [Fact]
-    public async Task GetStatementAsync_AlwaysSetsIsProFormaTrue_AndReturnsEmptyServicePayments()
+    public async Task GetStatementAsync_NoServicePayments_StaysProForma_AndReturnsEmptyServicePayments()
     {
         // Arrange — empty session set
         var (service, _) = BuildService(new List<TherapySession>());

--- a/tests/Infrastructure.Tests/ServicePaymentEntityMappingTests.cs
+++ b/tests/Infrastructure.Tests/ServicePaymentEntityMappingTests.cs
@@ -1,0 +1,229 @@
+using Xunit;
+using Microsoft.EntityFrameworkCore;
+using Neurocorp.Api.Core.Entities;
+using Neurocorp.Api.Infrastructure.Data;
+
+namespace Infrastructure.Tests.Repositories;
+
+public class ServicePaymentEntityMappingTests
+{
+    private static DbContextOptions<ApplicationDbContext> CreateInMemoryOptions(string dbName)
+    {
+        return new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: dbName)
+            .Options;
+    }
+
+    private static void SeedTherapistAndPaymentType(ApplicationDbContext context)
+    {
+        context.PaymentTypes.Add(new PaymentType { Id = 1, Abbreviation = "ACH", Name = "Bank Transfer" });
+        context.Therapists.Add(new Therapist
+        {
+            Id = 1,
+            User = new User { Id = 1, FirstName = "Jane", LastName = "Smith" }
+        });
+    }
+
+    [Fact]
+    public async Task ServicePayment_CanBePersisted_WithAllProperties()
+    {
+        var options = CreateInMemoryOptions(nameof(ServicePayment_CanBePersisted_WithAllProperties));
+        var paymentDate = DateTime.UtcNow;
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            SeedTherapistAndPaymentType(context);
+            await context.SaveChangesAsync();
+        }
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            context.ServicePayments.Add(new ServicePayment
+            {
+                Id = 1,
+                TherapistId = 1,
+                PaymentTypeId = 1,
+                Amount = 500.00m,
+                PaymentDate = paymentDate,
+                ReferenceNumber = "TX-100",
+                Notes = "April quincena",
+            });
+            await context.SaveChangesAsync();
+        }
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            var sp = await context.ServicePayments.FindAsync(1);
+            Assert.NotNull(sp);
+            Assert.Equal(1, sp!.TherapistId);
+            Assert.Equal(1, sp.PaymentTypeId);
+            Assert.Equal(500.00m, sp.Amount);
+            Assert.Equal(paymentDate, sp.PaymentDate);
+            Assert.Equal("TX-100", sp.ReferenceNumber);
+            Assert.Equal("April quincena", sp.Notes);
+            Assert.Null(sp.ReversesServicePaymentId);
+        }
+    }
+
+    [Fact]
+    public async Task ServicePayment_TherapistNavigation_LoadsCorrectly()
+    {
+        var options = CreateInMemoryOptions(nameof(ServicePayment_TherapistNavigation_LoadsCorrectly));
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            SeedTherapistAndPaymentType(context);
+            await context.SaveChangesAsync();
+        }
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            context.ServicePayments.Add(new ServicePayment
+            {
+                Id = 1,
+                TherapistId = 1,
+                PaymentTypeId = 1,
+                Amount = 200.00m,
+                PaymentDate = DateTime.UtcNow,
+            });
+            await context.SaveChangesAsync();
+        }
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            var sp = await context.ServicePayments
+                .Include(p => p.Therapist).ThenInclude(t => t.User)
+                .FirstAsync(p => p.Id == 1);
+
+            Assert.NotNull(sp.Therapist);
+            Assert.NotNull(sp.Therapist.User);
+            Assert.Equal("Smith", sp.Therapist.User!.LastName);
+        }
+    }
+
+    [Fact]
+    public async Task ServicePayment_SessionServicePaymentsCollection_LoadsCorrectly()
+    {
+        var options = CreateInMemoryOptions(nameof(ServicePayment_SessionServicePaymentsCollection_LoadsCorrectly));
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            SeedTherapistAndPaymentType(context);
+            context.Patients.Add(new Patient { Id = 1, User = new User { Id = 2, FirstName = "Dan", LastName = "Green" } });
+            context.TherapySessions.Add(new TherapySession
+            {
+                Id = 1, PatientId = 1, TherapistId = 1,
+                SessionDate = DateOnly.FromDateTime(DateTime.UtcNow), SessionTime = new TimeOnly(9, 0),
+                Amount = 100m, ProviderAmount = 60m, Notes = "S1"
+            });
+            context.TherapySessions.Add(new TherapySession
+            {
+                Id = 2, PatientId = 1, TherapistId = 1,
+                SessionDate = DateOnly.FromDateTime(DateTime.UtcNow), SessionTime = new TimeOnly(10, 0),
+                Amount = 100m, ProviderAmount = 60m, Notes = "S2"
+            });
+            await context.SaveChangesAsync();
+        }
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            context.ServicePayments.Add(new ServicePayment
+            {
+                Id = 1, TherapistId = 1, PaymentTypeId = 1, Amount = 120.00m, PaymentDate = DateTime.UtcNow,
+            });
+            await context.SaveChangesAsync();
+        }
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            context.SessionServicePayments.Add(new SessionServicePayment { Id = 1, ServicePaymentId = 1, TherapySessionId = 1, AmountApplied = 60.00m });
+            context.SessionServicePayments.Add(new SessionServicePayment { Id = 2, ServicePaymentId = 1, TherapySessionId = 2, AmountApplied = 60.00m });
+            await context.SaveChangesAsync();
+        }
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            var sp = await context.ServicePayments
+                .Include(p => p.SessionServicePayments)
+                .FirstAsync(p => p.Id == 1);
+
+            Assert.NotNull(sp.SessionServicePayments);
+            Assert.Equal(2, sp.SessionServicePayments.Count);
+            Assert.All(sp.SessionServicePayments, ssp => Assert.Equal(60.00m, ssp.AmountApplied));
+        }
+    }
+
+    [Fact]
+    public async Task ServicePayment_AuditColumns_AreStamped_OnSave()
+    {
+        var options = CreateInMemoryOptions(nameof(ServicePayment_AuditColumns_AreStamped_OnSave));
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            SeedTherapistAndPaymentType(context);
+            await context.SaveChangesAsync();
+        }
+
+        DateTime before;
+        using (var context = new ApplicationDbContext(options))
+        {
+            before = DateTime.UtcNow;
+            context.ServicePayments.Add(new ServicePayment
+            {
+                Id = 1, TherapistId = 1, PaymentTypeId = 1, Amount = 250.00m, PaymentDate = before,
+            });
+            await context.SaveChangesAsync();
+        }
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            var sp = await context.ServicePayments.FindAsync(1);
+            Assert.NotNull(sp);
+            Assert.NotEqual(default, sp!.CreatedTimestamp);
+            Assert.NotEqual(default, sp.LastUpdatedTimestamp);
+        }
+    }
+
+    [Fact]
+    public async Task ServicePayment_NegativeAmounts_RoundTrip_ForAppendOnlyReversals()
+    {
+        // Append-only readiness (WP-14.5): Amount / AmountApplied may be negative.
+        var options = CreateInMemoryOptions(nameof(ServicePayment_NegativeAmounts_RoundTrip_ForAppendOnlyReversals));
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            SeedTherapistAndPaymentType(context);
+            context.Patients.Add(new Patient { Id = 1, User = new User { Id = 2, FirstName = "Dan", LastName = "Green" } });
+            context.TherapySessions.Add(new TherapySession
+            {
+                Id = 1, PatientId = 1, TherapistId = 1,
+                SessionDate = DateOnly.FromDateTime(DateTime.UtcNow), SessionTime = new TimeOnly(9, 0),
+                Amount = 100m, ProviderAmount = 60m, Notes = "S1"
+            });
+            await context.SaveChangesAsync();
+        }
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            context.ServicePayments.Add(new ServicePayment
+            {
+                Id = 2, TherapistId = 1, PaymentTypeId = 1, Amount = -60.00m, PaymentDate = DateTime.UtcNow,
+                ReversesServicePaymentId = 1, Notes = "reversal",
+            });
+            context.SessionServicePayments.Add(new SessionServicePayment { Id = 1, ServicePaymentId = 2, TherapySessionId = 1, AmountApplied = -60.00m });
+            await context.SaveChangesAsync();
+        }
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            var sp = await context.ServicePayments.FindAsync(2);
+            Assert.NotNull(sp);
+            Assert.Equal(-60.00m, sp!.Amount);
+            Assert.Equal(1, sp.ReversesServicePaymentId);
+
+            var ssp = await context.SessionServicePayments.FindAsync(1);
+            Assert.NotNull(ssp);
+            Assert.Equal(-60.00m, ssp!.AmountApplied);
+        }
+    }
+}


### PR DESCRIPTION
Therapist payroll (ServicePayment): the direction-flipped mirror of the Caretaker Payment stack. Reuses the PaymentType lookup.

- Entities ServicePayment + SessionServicePayment (+ EF config, DbSets)
- DTOs, IServicePaymentRepository / ISessionServicePaymentRepository (+ impls), IServicePaymentService / ServicePaymentService, ServicePaymentsController
- Endpoints (all claim-gated): GET list, GET {id}, GET unpaid-sessions, GET quincena (ServicePayments.View — MGR/AM); POST (ServicePayments.Record — MGR)
- Statement integration: TherapistStatementService joins SessionServicePayment, computes totalServicePaymentsApplied + estimatedAmountDue, populates servicePayments[] (all allocations + cross-period note), flips IsProForma=false once any payment touches an in-range session
- Append-only ready: amount/applied may be negative; validation is positive-only for the MVP. No reversal endpoint yet (WP-14.5)
- Re-vendored manifest b10682734edf + regenerated Permissions.g.cs + bumped AccessControlManifest anchor
- Tests: ServicePaymentEntityMappingTests, ServicePaymentServiceTests, plus a non-pro-forma TherapistStatementService case. Full solution green (297).
- curl test script test-scripts/wp-14b-service-payments.sh