### PR TITLE
fix(logging): silence redundant ExceptionHandlerMiddleware error log

### DIFF
--- a/src/Web/Middleware/GlobalExceptionHandler.cs
+++ b/src/Web/Middleware/GlobalExceptionHandler.cs
@@ -15,6 +15,12 @@ namespace Neurocorp.Api.Web.Middleware;
 /// earlier by the auth layer (AuthProblemDetails / PasswordChangeRequiredMiddleware) and never
 /// reach here. The shared ProblemDetails shape (type/instance/traceId) is applied centrally by
 /// CustomizeProblemDetails in Startup.
+///
+/// This handler is the single source of truth for exception logging: it logs handled 4xx at
+/// Information and only genuine 5xx at Error (below). The built-in <c>ExceptionHandlerMiddleware</c>
+/// also logs every caught exception at Error ("An unhandled exception has occurred…") — redundant
+/// and misleading for the 4xx we translate cleanly — so that one framework category is set to
+/// "None" in appsettings. Real failures still surface via the LogError call here.
 /// </summary>
 public sealed class GlobalExceptionHandler : IExceptionHandler
 {

--- a/src/Web/appsettings.Development.json
+++ b/src/Web/appsettings.Development.json
@@ -2,7 +2,8 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddleware": "None"
     }
   },
   "ConnectionStrings": {

--- a/src/Web/appsettings.json
+++ b/src/Web/appsettings.json
@@ -2,7 +2,8 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddleware": "None"
     }
   },
   "ConnectionStrings": {


### PR DESCRIPTION
Negative-path tests (and real 4xx requests) deliberately throw e.g. ArgumentException -> GlobalExceptionHandler translates them to a clean 400 and logs at the correct level (Info for handled 4xx, Error only for real 5xx). .NET 8's built-in ExceptionHandlerMiddleware ALSO logs every caught exception at Error ("An unhandled exception has occurred...") with a full stack trace — redundant and alarming for the 4xx we handle cleanly, and it made passing tests look like they were throwing.

Set the Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddleware log category to "None" in appsettings(.Development).json — the exact category in the noisy log line. GlobalExceptionHandler remains the single source of truth for exception logging, so genuine 5xx still surface via its LogError.

Solution stays 295 green.