### PR TITLE
WP-14.5B: reverse a service payment (append-only) + ServicePayments.A…

### DIFF
--- a/docs/access-control-matrix.json
+++ b/docs/access-control-matrix.json
@@ -1,9 +1,9 @@
 {
   "_meta": {
-    "generatedAt": "2026-06-20T14:20:39-05:00",
+    "generatedAt": "2026-06-29T19:18:00-05:00",
     "generator": "tools/generate-access-manifest.sh",
     "hashScope": "sha256 (first 12 hex) of canonical JSON {claims:[{claim,grants}]}, claims+grants sorted; wildcard/restricted cells and all metadata excluded",
-    "semanticHash": "b10682734edf",
+    "semanticHash": "16599d6c39fc",
     "source": "access-control-matrix.md"
   },
   "claims": [
@@ -246,6 +246,12 @@
       "grants": [
         "AM",
         "FD",
+        "MGR"
+      ]
+    },
+    {
+      "claim": "ServicePayments.Adjust",
+      "grants": [
         "MGR"
       ]
     },

--- a/src/Core/BusinessObjects/ServicePayments/ReverseServicePaymentRequest.cs
+++ b/src/Core/BusinessObjects/ServicePayments/ReverseServicePaymentRequest.cs
@@ -1,0 +1,12 @@
+namespace Neurocorp.Api.Core.BusinessObjects.ServicePayments;
+
+/// <summary>
+/// Payload for reversing a service payment (WP-14.5). Append-only: the reversal writes an
+/// offsetting negative <see cref="Entities.ServicePayment"/> linked to the original via
+/// <c>ReversesServicePaymentID</c>; the original is never mutated or deleted. A reason is
+/// required and is recorded in the reversal entry's Notes for audit.
+/// </summary>
+public class ReverseServicePaymentRequest
+{
+    public string Reason { get; set; } = string.Empty;
+}

--- a/src/Core/BusinessObjects/ServicePayments/ServicePaymentRecord.cs
+++ b/src/Core/BusinessObjects/ServicePayments/ServicePaymentRecord.cs
@@ -17,4 +17,16 @@ public class ServicePaymentRecord
     public List<ServiceAllocationDetail> Allocations { get; set; } = new();
     public decimal TotalApplied { get; set; }
     public decimal UnallocatedAmount { get; set; }
+
+    /// <summary>
+    /// If set, this record is itself a reversal entry (WP-14.5) — an offsetting negative
+    /// disbursement that reverses the referenced original payment. Null for normal payments.
+    /// </summary>
+    public int? ReversesServicePaymentId { get; set; }
+
+    /// <summary>
+    /// True when this payment has been reversed by a later reversal entry. Originals that are
+    /// already reversed (or are themselves reversals) cannot be reversed again.
+    /// </summary>
+    public bool IsReversed { get; set; }
 }

--- a/src/Core/Interfaces/Repositories/IServicePaymentRepository.cs
+++ b/src/Core/Interfaces/Repositories/IServicePaymentRepository.cs
@@ -7,4 +7,13 @@ public interface IServicePaymentRepository : IRepository<ServicePayment>
     Task<IReadOnlyList<ServicePayment>> GetByTherapistIdAndDateRangeAsync(int therapistId, DateTime from, DateTime to);
     Task<ServicePayment?> GetByIdWithDetailsAsync(int servicePaymentId);
     Task<IReadOnlyList<ServicePayment>> GetByIdsWithDetailsAsync(IEnumerable<int> servicePaymentIds);
+
+    /// <summary>True if a reversal entry already exists for <paramref name="servicePaymentId"/> (WP-14.5).</summary>
+    Task<bool> IsReversedAsync(int servicePaymentId);
+
+    /// <summary>
+    /// Of the given original payment ids, returns those that have a reversal entry — one query for the
+    /// list view, robust to the reversal falling outside the queried date range.
+    /// </summary>
+    Task<IReadOnlyCollection<int>> GetReversedOriginalIdsAsync(IEnumerable<int> originalIds);
 }

--- a/src/Core/Interfaces/Services/IServicePaymentService.cs
+++ b/src/Core/Interfaces/Services/IServicePaymentService.cs
@@ -5,6 +5,17 @@ namespace Neurocorp.Api.Core.Interfaces.Services;
 public interface IServicePaymentService
 {
     Task<ServicePaymentRecord> CreateAsync(ServicePaymentRequest request);
+
+    /// <summary>
+    /// Reverse a service payment (WP-14.5, append-only). Writes one offsetting negative
+    /// <see cref="Entities.ServicePayment"/> (negative <c>Amount</c> + negative allocations for every
+    /// session the original covered) linked via <c>ReversesServicePaymentID</c>; the original is left
+    /// untouched. The negative allocations re-open those sessions as unpaid. Throws
+    /// <see cref="Exceptions.NotFoundException"/> if the original is missing, or
+    /// <see cref="ArgumentException"/> if it is itself a reversal or has already been reversed.
+    /// </summary>
+    Task<ServicePaymentRecord> ReverseAsync(int servicePaymentId, ReverseServicePaymentRequest request);
+
     Task<IEnumerable<ServicePaymentRecord>> GetByTherapistAsync(int therapistId, DateOnly? from, DateOnly? to);
     Task<ServicePaymentRecord?> GetByIdAsync(int servicePaymentId);
     Task<IEnumerable<UnpaidProviderSessionSummary>> GetUnpaidProviderSessionsAsync(int therapistId, DateOnly? from, DateOnly? to);

--- a/src/Core/Services/ServicePaymentService.cs
+++ b/src/Core/Services/ServicePaymentService.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging;
 using Neurocorp.Api.Core.BusinessObjects.Payments;
 using Neurocorp.Api.Core.BusinessObjects.ServicePayments;
 using Neurocorp.Api.Core.Entities;
+using Neurocorp.Api.Core.Exceptions;
 using Neurocorp.Api.Core.Interfaces.Repositories;
 using Neurocorp.Api.Core.Interfaces.Services;
 
@@ -84,6 +85,50 @@ public class ServicePaymentService : IServicePaymentService
         return MapToRecord(result!);
     }
 
+    public async Task<ServicePaymentRecord> ReverseAsync(int servicePaymentId, ReverseServicePaymentRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.Reason))
+            throw new ArgumentException("A reason is required to reverse a service payment.");
+
+        _logger.LogInformation("Reversing service payment {ServicePaymentId}", servicePaymentId);
+
+        var original = await _servicePaymentRepo.GetByIdWithDetailsAsync(servicePaymentId)
+            ?? throw new NotFoundException("ServicePayment", servicePaymentId);
+
+        // Append-only: only an original disbursement can be reversed — never a reversal entry itself.
+        if (original.ReversesServicePaymentId != null || original.Amount < 0)
+            throw new ArgumentException("This payment is itself a reversal and cannot be reversed.");
+
+        if (await _servicePaymentRepo.IsReversedAsync(servicePaymentId))
+            throw new ArgumentException("This payment has already been reversed.");
+
+        var reversal = new ServicePayment
+        {
+            TherapistId = original.TherapistId,
+            Amount = -original.Amount,
+            PaymentDate = DateTime.UtcNow,
+            PaymentTypeId = original.PaymentTypeId,
+            ReferenceNumber = original.ReferenceNumber,
+            Notes = $"Reversal of payment #{original.Id}: {request.Reason.Trim()}",
+            ReversesServicePaymentId = original.Id,
+        };
+
+        var created = await _servicePaymentRepo.AddAsync(reversal);
+
+        foreach (var alloc in original.SessionServicePayments)
+        {
+            await _sessionServicePaymentRepo.AddAsync(new SessionServicePayment
+            {
+                ServicePaymentId = created.Id,
+                TherapySessionId = alloc.TherapySessionId,
+                AmountApplied = -alloc.AmountApplied,
+            });
+        }
+
+        var result = await _servicePaymentRepo.GetByIdWithDetailsAsync(created.Id);
+        return MapToRecord(result!);
+    }
+
     public async Task<IEnumerable<ServicePaymentRecord>> GetByTherapistAsync(int therapistId, DateOnly? from, DateOnly? to)
     {
         var (periodStart, periodEnd) = ResolveRange(from, to);
@@ -94,13 +139,15 @@ public class ServicePaymentService : IServicePaymentService
             periodStart.ToDateTime(TimeOnly.MinValue),
             periodEnd.ToDateTime(TimeOnly.MaxValue));
 
-        return payments.Select(MapToRecord);
+        var reversedIds = await _servicePaymentRepo.GetReversedOriginalIdsAsync(payments.Select(p => p.Id));
+        return payments.Select(p => MapToRecord(p, reversedIds.Contains(p.Id)));
     }
 
     public async Task<ServicePaymentRecord?> GetByIdAsync(int servicePaymentId)
     {
         var payment = await _servicePaymentRepo.GetByIdWithDetailsAsync(servicePaymentId);
-        return payment == null ? null : MapToRecord(payment);
+        if (payment == null) return null;
+        return MapToRecord(payment, await _servicePaymentRepo.IsReversedAsync(servicePaymentId));
     }
 
     public async Task<IEnumerable<UnpaidProviderSessionSummary>> GetUnpaidProviderSessionsAsync(int therapistId, DateOnly? from, DateOnly? to)
@@ -353,7 +400,7 @@ public class ServicePaymentService : IServicePaymentService
             throw new ArgumentException($"Total allocations ({totalApplied:C}) exceed payment amount ({amount:C}).");
     }
 
-    private static ServicePaymentRecord MapToRecord(ServicePayment sp)
+    private static ServicePaymentRecord MapToRecord(ServicePayment sp, bool isReversed = false)
     {
         var allocations = sp.SessionServicePayments?.Select(ssp => new ServiceAllocationDetail
         {
@@ -386,6 +433,8 @@ public class ServicePaymentService : IServicePaymentService
             Allocations = allocations,
             TotalApplied = totalApplied,
             UnallocatedAmount = sp.Amount - totalApplied,
+            ReversesServicePaymentId = sp.ReversesServicePaymentId,
+            IsReversed = isReversed,
         };
     }
 

--- a/src/Infrastructure/Repositories/ServicePaymentRepository.cs
+++ b/src/Infrastructure/Repositories/ServicePaymentRepository.cs
@@ -38,4 +38,22 @@ public class ServicePaymentRepository(ApplicationDbContext dbContext) :
             .OrderByDescending(sp => sp.PaymentDate)
             .ToListAsync();
     }
+
+    public async Task<bool> IsReversedAsync(int servicePaymentId)
+    {
+        return await _dbContext.ServicePayments
+            .AnyAsync(sp => sp.ReversesServicePaymentId == servicePaymentId);
+    }
+
+    public async Task<IReadOnlyCollection<int>> GetReversedOriginalIdsAsync(IEnumerable<int> originalIds)
+    {
+        var ids = originalIds.Distinct().ToList();
+        if (ids.Count == 0) return Array.Empty<int>();
+
+        return await _dbContext.ServicePayments
+            .Where(sp => sp.ReversesServicePaymentId != null && ids.Contains(sp.ReversesServicePaymentId.Value))
+            .Select(sp => sp.ReversesServicePaymentId!.Value)
+            .Distinct()
+            .ToListAsync();
+    }
 }

--- a/src/Web/Authorization/AccessControlManifest.cs
+++ b/src/Web/Authorization/AccessControlManifest.cs
@@ -18,5 +18,5 @@ namespace Neurocorp.Api.Web.Authorization;
 public static class AccessControlManifest
 {
     /// <summary>First 12 hex chars of SHA-256 over the manifest's canonical grant tuples.</summary>
-    public const string SemanticHash = "b10682734edf";
+    public const string SemanticHash = "16599d6c39fc";
 }

--- a/src/Web/Authorization/Permissions.g.cs
+++ b/src/Web/Authorization/Permissions.g.cs
@@ -7,7 +7,7 @@
 //   (patient-care-super/tools/generate-access-manifest.sh), re-vendor
 //   docs/access-control-matrix.json, then re-run tools/generate-permissions.sh.
 //
-//   Access-control manifest semantic hash: b10682734edf
+//   Access-control manifest semantic hash: 16599d6c39fc
 // </auto-generated>
 
 namespace Neurocorp.Api.Web.Authorization;
@@ -58,6 +58,7 @@ public static class Permissions
     public const string ScheduleBook = "Schedule.Book";
     public const string ScheduleRebook = "Schedule.Rebook";
     public const string ScheduleView = "Schedule.View";
+    public const string ServicePaymentsAdjust = "ServicePayments.Adjust";
     public const string ServicePaymentsRecord = "ServicePayments.Record";
     public const string ServicePaymentsView = "ServicePayments.View";
     public const string StatementsCaretakerView = "Statements.Caretaker.View";

--- a/src/Web/Controllers/ServicePaymentsController.cs
+++ b/src/Web/Controllers/ServicePaymentsController.cs
@@ -110,8 +110,7 @@ public class ServicePaymentsController : ControllerBase
         return Ok(window);
     }
 
-    // WP-14: issuing a disbursement is MGR-only (owner-level). The append-only reversal/adjust
-    // capability arrives with WP-14.5 (separate claim).
+    // WP-14: issuing a disbursement is MGR-only (owner-level).
     [HttpPost]
     [Authorize(Policy = AuthPolicy.PermissionPrefix + Permissions.ServicePaymentsRecord)]
     [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(ServicePaymentRecord))]
@@ -120,5 +119,18 @@ public class ServicePaymentsController : ControllerBase
     {
         var created = await _servicePaymentService.CreateAsync(request);
         return CreatedAtAction(nameof(GetServicePayment), new { id = created.ServicePaymentId }, created);
+    }
+
+    // WP-14.5: reverse a disbursement via an append-only offsetting entry. MGR-only (ServicePayments.Adjust);
+    // the original is never mutated. Returns the new reversal record (negative amount + allocations).
+    [HttpPost("{id}/reverse")]
+    [Authorize(Policy = AuthPolicy.PermissionPrefix + Permissions.ServicePaymentsAdjust)]
+    [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(ServicePaymentRecord))]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> ReverseServicePayment(int id, [FromBody] ReverseServicePaymentRequest request)
+    {
+        var reversal = await _servicePaymentService.ReverseAsync(id, request);
+        return CreatedAtAction(nameof(GetServicePayment), new { id = reversal.ServicePaymentId }, reversal);
     }
 }

--- a/tests/Core.Tests/ServicePaymentServiceTests.cs
+++ b/tests/Core.Tests/ServicePaymentServiceTests.cs
@@ -4,6 +4,7 @@ using Moq;
 using Neurocorp.Api.Core.BusinessObjects.ServicePayments;
 using Neurocorp.Api.Core.BusinessObjects.Therapists;
 using Neurocorp.Api.Core.Entities;
+using Neurocorp.Api.Core.Exceptions;
 using Neurocorp.Api.Core.Interfaces.Repositories;
 using Neurocorp.Api.Core.Interfaces.Services;
 using Neurocorp.Api.Core.Services;
@@ -65,6 +66,11 @@ public class ServicePaymentServiceTests
             .ReturnsAsync((ServicePayment sp) => { sp.Id = nextId++; createdById[sp.Id] = sp; return sp; });
         spRepo.Setup(r => r.GetByIdWithDetailsAsync(It.IsAny<int>()))
             .ReturnsAsync((int id) => createdById.TryGetValue(id, out var sp) ? sp : null);
+
+        // Reversal helpers default to "nothing reversed"; individual tests override.
+        spRepo.Setup(r => r.IsReversedAsync(It.IsAny<int>())).ReturnsAsync(false);
+        spRepo.Setup(r => r.GetReversedOriginalIdsAsync(It.IsAny<IEnumerable<int>>()))
+            .ReturnsAsync(Array.Empty<int>());
 
         var service = new ServicePaymentService(logger, spRepo.Object, sspRepo.Object, sessionRepo.Object, statusRepo.Object, therapistSvc.Object);
         return (service, spRepo, sspRepo, sessionRepo);
@@ -402,5 +408,128 @@ public class ServicePaymentServiceTests
         });
 
         await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    // ---- WP-14.5: reversal -------------------------------------------------
+
+    private static ServicePayment OriginalPayment(int id = 500, decimal amount = 120m) => new()
+    {
+        Id = id,
+        TherapistId = TherapistId,
+        Amount = amount,
+        PaymentDate = new DateTime(2026, 4, 20),
+        PaymentTypeId = 1,
+        ReferenceNumber = "CHK-1",
+        ReversesServicePaymentId = null,
+        PaymentType = new PaymentType { Id = 1, Name = "Check", Abbreviation = "CHK" },
+        Therapist = new Therapist { Id = TherapistId, User = new User { Id = 9, FirstName = "Jane", LastName = "Smith" } },
+        SessionServicePayments = new List<SessionServicePayment>
+        {
+            new() { Id = 1, ServicePaymentId = id, TherapySessionId = 1, AmountApplied = 60m, TherapySession = Session(1, 60m) },
+            new() { Id = 2, ServicePaymentId = id, TherapySessionId = 2, AmountApplied = 60m, TherapySession = Session(2, 60m) },
+        },
+    };
+
+    [Fact]
+    public async Task ReverseAsync_WritesOffsettingEntry_WithNegativeAmountAndAllocations()
+    {
+        var (service, spRepo, sspRepo, _) = BuildService();
+        var original = OriginalPayment();
+
+        ServicePayment? captured = null;
+        spRepo.Setup(r => r.GetByIdWithDetailsAsync(500)).ReturnsAsync(original);
+        spRepo.Setup(r => r.AddAsync(It.IsAny<ServicePayment>()))
+            .ReturnsAsync((ServicePayment sp) => { sp.Id = 999; captured = sp; return sp; });
+        spRepo.Setup(r => r.GetByIdWithDetailsAsync(999)).ReturnsAsync(() => captured);
+
+        var capturedAllocations = new List<SessionServicePayment>();
+        sspRepo.Setup(r => r.AddAsync(It.IsAny<SessionServicePayment>()))
+            .ReturnsAsync((SessionServicePayment ssp) => { capturedAllocations.Add(ssp); return ssp; });
+
+        var result = await service.ReverseAsync(500, new ReverseServicePaymentRequest { Reason = "duplicate payment" });
+
+        captured.Should().NotBeNull();
+        captured!.Amount.Should().Be(-120m);
+        captured.ReversesServicePaymentId.Should().Be(500);
+        captured.TherapistId.Should().Be(TherapistId);
+        captured.PaymentTypeId.Should().Be(1);
+        captured.Notes.Should().Be("Reversal of payment #500: duplicate payment");
+
+        capturedAllocations.Should().HaveCount(2);
+        capturedAllocations.Should().OnlyContain(a => a.ServicePaymentId == 999);
+        capturedAllocations.Select(a => a.AmountApplied).Should().BeEquivalentTo(new[] { -60m, -60m });
+
+        result.Amount.Should().Be(-120m);
+        result.ReversesServicePaymentId.Should().Be(500);
+    }
+
+    [Fact]
+    public async Task ReverseAsync_Throws_WhenOriginalNotFound()
+    {
+        var (service, spRepo, _, _) = BuildService();
+        spRepo.Setup(r => r.GetByIdWithDetailsAsync(404)).ReturnsAsync((ServicePayment?)null);
+
+        var act = async () => await service.ReverseAsync(404, new ReverseServicePaymentRequest { Reason = "x" });
+
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task ReverseAsync_Throws_WhenReasonMissing()
+    {
+        var (service, _, _, _) = BuildService();
+
+        var act = async () => await service.ReverseAsync(500, new ReverseServicePaymentRequest { Reason = "  " });
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task ReverseAsync_Throws_WhenAlreadyReversed()
+    {
+        var (service, spRepo, _, _) = BuildService();
+        spRepo.Setup(r => r.GetByIdWithDetailsAsync(500)).ReturnsAsync(OriginalPayment());
+        spRepo.Setup(r => r.IsReversedAsync(500)).ReturnsAsync(true);
+
+        var act = async () => await service.ReverseAsync(500, new ReverseServicePaymentRequest { Reason = "x" });
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task ReverseAsync_Throws_WhenReversingAReversal()
+    {
+        var (service, spRepo, _, _) = BuildService();
+        var reversal = OriginalPayment(id: 600, amount: -120m);
+        reversal.ReversesServicePaymentId = 500; // this row is itself a reversal
+        spRepo.Setup(r => r.GetByIdWithDetailsAsync(600)).ReturnsAsync(reversal);
+
+        var act = async () => await service.ReverseAsync(600, new ReverseServicePaymentRequest { Reason = "x" });
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task GetByTherapistAsync_FlagsReversedOriginalsAndReversalRows()
+    {
+        var (service, spRepo, _, _) = BuildService();
+        var original = OriginalPayment(id: 500);
+        var reversal = OriginalPayment(id: 600, amount: -120m);
+        reversal.ReversesServicePaymentId = 500;
+
+        spRepo.Setup(r => r.GetByTherapistIdAndDateRangeAsync(TherapistId, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .ReturnsAsync(new List<ServicePayment> { original, reversal });
+        spRepo.Setup(r => r.GetReversedOriginalIdsAsync(It.IsAny<IEnumerable<int>>()))
+            .ReturnsAsync(new[] { 500 });
+
+        var records = (await service.GetByTherapistAsync(TherapistId, null, null)).ToList();
+
+        var originalRecord = records.Single(r => r.ServicePaymentId == 500);
+        originalRecord.IsReversed.Should().BeTrue();
+        originalRecord.ReversesServicePaymentId.Should().BeNull();
+
+        var reversalRecord = records.Single(r => r.ServicePaymentId == 600);
+        reversalRecord.IsReversed.Should().BeFalse();
+        reversalRecord.ReversesServicePaymentId.Should().Be(500);
     }
 }

--- a/tests/Core.Tests/TherapistStatementServiceTests.cs
+++ b/tests/Core.Tests/TherapistStatementServiceTests.cs
@@ -344,6 +344,62 @@ public class TherapistStatementServiceTests
     }
 
     [Fact]
+    public async Task GetStatementAsync_FullyReversedPayment_NetsAmountDueBackUp_AndStaysAuthoritative()
+    {
+        // WP-14.5: a payment ($60 on session 101) fully reversed by an offsetting -$60 entry.
+        // Net applied = 0, so EstimatedAmountDue returns to the full provider amount. The statement
+        // stays authoritative (IsProForma=false) because payments WERE recorded — even though they
+        // net to zero (allocations.Count > 0).
+        var patient = MakePatient(1, "Alice", "Anderson");
+        var sessions = new List<TherapySession>
+        {
+            MakeSession(101, patient, new DateOnly(2026, 4, 1), new TimeOnly(9, 0), CompletedStatus, providerAmount: 60m),
+        };
+
+        var original = new ServicePayment
+        {
+            Id = 500,
+            TherapistId = TherapistId,
+            PaymentDate = new DateTime(2026, 4, 20),
+            Amount = 60m,
+            PaymentType = new PaymentType { Id = 1, Name = "Check", Abbreviation = "CHK" },
+            SessionServicePayments = new List<SessionServicePayment>
+            {
+                new() { Id = 9001, ServicePaymentId = 500, TherapySessionId = 101, AmountApplied = 60m },
+            },
+        };
+        var reversal = new ServicePayment
+        {
+            Id = 600,
+            TherapistId = TherapistId,
+            PaymentDate = new DateTime(2026, 4, 25),
+            Amount = -60m,
+            ReversesServicePaymentId = 500,
+            PaymentType = new PaymentType { Id = 1, Name = "Check", Abbreviation = "CHK" },
+            SessionServicePayments = new List<SessionServicePayment>
+            {
+                new() { Id = 9002, ServicePaymentId = 600, TherapySessionId = 101, AmountApplied = -60m },
+            },
+        };
+        var allocations = new List<SessionServicePayment>
+        {
+            new() { Id = 9001, ServicePaymentId = 500, TherapySessionId = 101, AmountApplied = 60m },
+            new() { Id = 9002, ServicePaymentId = 600, TherapySessionId = 101, AmountApplied = -60m },
+        };
+
+        var (service, _) = BuildService(sessions, allocations, new List<ServicePayment> { original, reversal });
+
+        var result = await service.GetStatementAsync(TherapistId, new DateOnly(2026, 4, 1), new DateOnly(2026, 4, 30));
+
+        result.Should().NotBeNull();
+        result!.Summary.TotalProviderAmount.Should().Be(60m);
+        result.Summary.TotalServicePaymentsApplied.Should().Be(0m);   // +60 and -60 net out
+        result.Summary.EstimatedAmountDue.Should().Be(60m);           // owed again
+        result.IsProForma.Should().BeFalse();                         // payments were recorded
+        result.ServicePayments.Should().HaveCount(2);
+    }
+
+    [Fact]
     public async Task GetStatementAsync_NoServicePayments_StaysProForma_AndReturnsEmptyServicePayments()
     {
         // Arrange — empty session set

--- a/tests/Web.Tests/Authorization/SensitiveCellAuthorizationTests.cs
+++ b/tests/Web.Tests/Authorization/SensitiveCellAuthorizationTests.cs
@@ -73,6 +73,9 @@ public class SensitiveCellAuthorizationTests : IClassFixture<AccessControlTestFa
     [InlineData("GET", "/api/patients", "CARETAKER")]
     // TreatmentPlans.Edit [AM,MGR] (D-6) — editing an existing plan's content is denied to FD.
     [InlineData("PUT", "/api/treatment-plans/1", "FD")]
+    // ServicePayments.Adjust [MGR] (WP-14.5) — reversing a disbursement is MGR-only; AM (view-only) and FD denied.
+    [InlineData("POST", "/api/service-payments/1/reverse", "AM")]
+    [InlineData("POST", "/api/service-payments/1/reverse", "FD")]
     public async Task RoleWithoutClaim_Is403(string method, string route, string role)
     {
         var response = await SendAsync(method, route, TokenFor(role));
@@ -118,6 +121,9 @@ public class SensitiveCellAuthorizationTests : IClassFixture<AccessControlTestFa
     [InlineData("POST", "/api/treatment-plans/1/schedule", "FD")]
     [InlineData("PUT", "/api/treatment-plans/1/activate", "FD")]
     [InlineData("PUT", "/api/treatment-plans/1/cancel", "MGR")]
+    // ServicePayments.Adjust [MGR] (WP-14.5) — MGR may reverse; SYSADMIN via wildcard.
+    [InlineData("POST", "/api/service-payments/1/reverse", "MGR")]
+    [InlineData("POST", "/api/service-payments/1/reverse", "SYSADMIN")]
     public async Task RoleWithClaim_IsNotBlocked(string method, string route, string role)
     {
         var response = await SendAsync(method, route, TokenFor(role));


### PR DESCRIPTION
…djust

Add POST /api/service-payments/{id}/reverse, gated by the new MGR-only ServicePayments.Adjust claim. Reversal writes one offsetting ServicePayment (negative Amount + negative allocation per covered session) linked via ReversesServicePaymentID; the original is never mutated. The negative allocations re-open those sessions as unpaid, so a correction is reverse + re-issue through the existing create flow.

- ReverseAsync service method (required reason; rejects reversing a reversal or an already-reversed payment; 404 when missing) bypassing the positive-only create guard. Repo IsReversedAsync / GetReversedOriginalIdsAsync.
- ServicePaymentRecord gains reversesServicePaymentId + isReversed; list view flags reversed originals in one query.
- Re-vendored manifest + regenerated Permissions.g.cs; bumped AccessControlManifest.SemanticHash to 16599d6c39fc.
- Tests: reversal create/guards, statement netting + IsProForma nuance, sensitive-cell authz (MGR/SYSADMIN pass, AM/FD 403). Solution green.