### PR TITLE
fix(wp-14.5): reversal uses local business date; History sort tiebrea…

### DIFF
--- a/src/Core/BusinessObjects/ServicePayments/ReverseServicePaymentRequest.cs
+++ b/src/Core/BusinessObjects/ServicePayments/ReverseServicePaymentRequest.cs
@@ -9,4 +9,12 @@ namespace Neurocorp.Api.Core.BusinessObjects.ServicePayments;
 public class ReverseServicePaymentRequest
 {
     public string Reason { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The business date to stamp on the reversal entry, as the user's local calendar day. The UI
+    /// sends "today" in the browser's timezone so the reversal lines up with the other (date-only)
+    /// payments in the history. When omitted, the server falls back to today's UTC date. The precise
+    /// reversal instant is always preserved separately in the audit <c>CreatedTimestamp</c>.
+    /// </summary>
+    public DateTime? PaymentDate { get; set; }
 }

--- a/src/Core/Services/ServicePaymentService.cs
+++ b/src/Core/Services/ServicePaymentService.cs
@@ -106,7 +106,10 @@ public class ServicePaymentService : IServicePaymentService
         {
             TherapistId = original.TherapistId,
             Amount = -original.Amount,
-            PaymentDate = DateTime.UtcNow,
+            // Use the client's local business date (date-only, like every other payment) so the reversal
+            // lines up in the history; fall back to today's UTC date only when the client omits it. The
+            // exact reversal instant is preserved separately in the audit CreatedTimestamp.
+            PaymentDate = request.PaymentDate ?? DateTime.UtcNow.Date,
             PaymentTypeId = original.PaymentTypeId,
             ReferenceNumber = original.ReferenceNumber,
             Notes = $"Reversal of payment #{original.Id}: {request.Reason.Trim()}",

--- a/src/Infrastructure/Repositories/ServicePaymentRepository.cs
+++ b/src/Infrastructure/Repositories/ServicePaymentRepository.cs
@@ -18,7 +18,10 @@ public class ServicePaymentRepository(ApplicationDbContext dbContext) :
     {
         return await WithDetails()
             .Where(sp => sp.TherapistId == therapistId && sp.PaymentDate >= from && sp.PaymentDate <= to)
+            // PaymentDate is a date-only business date, so ties (e.g. a reversal + its re-issuance on the
+            // same day) are broken by issuance order (auto-increment Id) — newest action first.
             .OrderByDescending(sp => sp.PaymentDate)
+            .ThenByDescending(sp => sp.Id)
             .ToListAsync();
     }
 
@@ -36,6 +39,7 @@ public class ServicePaymentRepository(ApplicationDbContext dbContext) :
         return await WithDetails()
             .Where(sp => ids.Contains(sp.Id))
             .OrderByDescending(sp => sp.PaymentDate)
+            .ThenByDescending(sp => sp.Id)
             .ToListAsync();
     }
 

--- a/tests/Core.Tests/ServicePaymentServiceTests.cs
+++ b/tests/Core.Tests/ServicePaymentServiceTests.cs
@@ -464,6 +464,27 @@ public class ServicePaymentServiceTests
     }
 
     [Fact]
+    public async Task ReverseAsync_StampsTheProvidedPaymentDate_NotUtcNow()
+    {
+        // Regression (WP-14.5): the reversal must record the client-supplied local business date so it
+        // lines up with the other date-only payments — not DateTime.UtcNow, which can roll to the next
+        // calendar day for users west of UTC.
+        var (service, spRepo, _, _) = BuildService();
+        var original = OriginalPayment();
+
+        ServicePayment? captured = null;
+        spRepo.Setup(r => r.GetByIdWithDetailsAsync(500)).ReturnsAsync(original);
+        spRepo.Setup(r => r.AddAsync(It.IsAny<ServicePayment>()))
+            .ReturnsAsync((ServicePayment sp) => { sp.Id = 999; captured = sp; return sp; });
+        spRepo.Setup(r => r.GetByIdWithDetailsAsync(999)).ReturnsAsync(() => captured);
+
+        var localToday = new DateTime(2026, 6, 29);
+        await service.ReverseAsync(500, new ReverseServicePaymentRequest { Reason = "wrong therapist", PaymentDate = localToday });
+
+        captured!.PaymentDate.Should().Be(localToday);
+    }
+
+    [Fact]
     public async Task ReverseAsync_Throws_WhenOriginalNotFound()
     {
         var (service, spRepo, _, _) = BuildService();

--- a/tests/Infrastructure.Tests/ServicePaymentRepositoryTests.cs
+++ b/tests/Infrastructure.Tests/ServicePaymentRepositoryTests.cs
@@ -1,0 +1,40 @@
+using Microsoft.EntityFrameworkCore;
+using Neurocorp.Api.Core.Entities;
+using Neurocorp.Api.Infrastructure.Data;
+using Neurocorp.Api.Infrastructure.Repositories;
+using Xunit;
+
+namespace Infrastructure.Tests.Repositories;
+
+public class ServicePaymentRepositoryTests
+{
+    private static DbContextOptions<ApplicationDbContext> InMemory(string name) =>
+        new DbContextOptionsBuilder<ApplicationDbContext>().UseInMemoryDatabase(name).Options;
+
+    [Fact]
+    public async Task GetByTherapistIdAndDateRange_OrdersByDateThenIssuanceOrder()
+    {
+        // Regression (WP-14.5): same-day rows (a reversal + its re-issuance) must be ordered by
+        // issuance (auto-increment Id) within a date, so the History table reads newest-action-first
+        // instead of an undefined tie order. Insertion order is 10,11,12; 11 and 12 share Jun 29 with
+        // 12 issued last (highest Id) -> expected order 12, 11, 10.
+        var options = InMemory(nameof(GetByTherapistIdAndDateRange_OrdersByDateThenIssuanceOrder));
+
+        using (var ctx = new ApplicationDbContext(options))
+        {
+            ctx.PaymentTypes.Add(new PaymentType { Id = 1, Abbreviation = "CHK", Name = "Check" });
+            ctx.Therapists.Add(new Therapist { Id = 1, User = new User { Id = 1, FirstName = "Jane", LastName = "Smith" } });
+            ctx.ServicePayments.Add(new ServicePayment { Id = 10, TherapistId = 1, PaymentTypeId = 1, Amount = 100m, PaymentDate = new DateTime(2026, 6, 20) });
+            ctx.ServicePayments.Add(new ServicePayment { Id = 11, TherapistId = 1, PaymentTypeId = 1, Amount = -100m, PaymentDate = new DateTime(2026, 6, 29), ReversesServicePaymentId = 10 });
+            ctx.ServicePayments.Add(new ServicePayment { Id = 12, TherapistId = 1, PaymentTypeId = 1, Amount = 100m, PaymentDate = new DateTime(2026, 6, 29) });
+            await ctx.SaveChangesAsync();
+        }
+
+        using (var ctx = new ApplicationDbContext(options))
+        {
+            var repo = new ServicePaymentRepository(ctx);
+            var result = await repo.GetByTherapistIdAndDateRangeAsync(1, new DateTime(2026, 6, 1), new DateTime(2026, 6, 30));
+            Assert.Equal(new[] { 12, 11, 10 }, result.Select(p => p.Id).ToArray());
+        }
+    }
+}


### PR DESCRIPTION
…k by issuance

Two History-table bugs from the reverse feature:

- ReverseAsync stamped PaymentDate = DateTime.UtcNow, a UTC instant that rolls to the next calendar day for users west of UTC (showed e.g. Jun 30 for a Jun 29 reversal). Now it stamps the client-supplied local business date (ReverseServicePaymentRequest.PaymentDate), consistent with every other date-only payment; falls back to UtcNow.Date when omitted. Exact instant is still in the audit CreatedTimestamp.
- The list query ordered by PaymentDate only, so same-day rows (a reversal + its re-issuance) had an undefined tie order. Now PaymentDate DESC, Id DESC (issuance order) — newest action first. Applied to both list queries.

Regression-test-first: failing service + repository tests, then fix. Core.Tests 32 / Infrastructure.Tests 64 green.