### PR TITLE
WP-18B: surface patient Cedula through the API

### DIFF
--- a/src/Core/BusinessObjects/Patients/PatientProfile.cs
+++ b/src/Core/BusinessObjects/Patients/PatientProfile.cs
@@ -13,6 +13,7 @@ public class PatientProfile : IProfile
     public int UserId { get; set; }
     public string PatientName { get; set; }
     public string? MedicalRecordNumber { get; set; }
+    public string? Cedula { get; set; }
     public DateTime DateOfBirth { get; set; }
     public string? Email { get; set; }
     public string? PhoneNumber { get; set; }

--- a/src/Core/BusinessObjects/Patients/PatientProfileRequest.cs
+++ b/src/Core/BusinessObjects/Patients/PatientProfileRequest.cs
@@ -10,6 +10,7 @@ public class PatientProfileRequest
         this.LastName = string.Empty;
         this.MiddleName = string.Empty;
         this.MedicalRecordNumber = string.Empty;
+        this.Cedula = string.Empty;
         this.Email = string.Empty;
         this.PhoneNumber = string.Empty;
         this.Gender = string.Empty;
@@ -21,6 +22,7 @@ public class PatientProfileRequest
     [Required]
     public string LastName { get; set; }
     public string MedicalRecordNumber { get; set; }
+    public string Cedula { get; set; }
     [Required]
     public DateTime DateOfBirth { get; set; }
     [Required]

--- a/src/Core/BusinessObjects/Patients/PatientProfileUpdateRequest.cs
+++ b/src/Core/BusinessObjects/Patients/PatientProfileUpdateRequest.cs
@@ -25,6 +25,7 @@ public class PatientProfileUpdateRequest
     public string Gender { get; set; }
     public bool ActiveStatus { get; set; }
     public string? MedicalRecordNumber { get; set; }
+    public string? Cedula { get; set; }
 
     public override string ToString()
     {

--- a/src/Core/Entities/Patient.cs
+++ b/src/Core/Entities/Patient.cs
@@ -11,6 +11,7 @@ public class Patient : PersonBase
     public DateTime? DateOfBirth { get; set; }
     public string? Gender { get; set; }
     public string? MedicalRecordNumber { get; set; }
+    public string? Cedula { get; set; }
     public ICollection<PatientCaretaker>? Caretakers { get; set; }
 
     public bool HasTemporaryMrn()
@@ -26,7 +27,8 @@ public class Patient : PersonBase
         .Append("Uid: ").Append(this.User!.Id).Append("  ")
         .Append("DoB: ").Append((this.DateOfBirth ?? DateTime.MinValue).ToShortDateString()).Append("  ")
         .Append("G: ").Append(this.Gender).Append("  ")
-        .Append("Mrn: ").Append(this.MedicalRecordNumber);
+        .Append("Mrn: ").Append(this.MedicalRecordNumber).Append("  ")
+        .Append("Ced: ").Append(this.Cedula);
         return sb.ToString();
     }
     

--- a/src/Core/Services/PatientProfileService.cs
+++ b/src/Core/Services/PatientProfileService.cs
@@ -87,6 +87,7 @@ public class PatientProfileService : IPatientProfileService
             UserId = newUser.Id,
             PatientName = $"{newUser.LastName}, {newUser.FirstName} {newUser.MiddleName}".Trim(),
             MedicalRecordNumber = newPatient.MedicalRecordNumber,
+            Cedula = newPatient.Cedula,
             DateOfBirth = newPatient.DateOfBirth ?? DateTime.MinValue,
             Email = newUser.Email,
             PhoneNumber = newUser.PhoneNumber,
@@ -158,7 +159,8 @@ public class PatientProfileService : IPatientProfileService
             User = user,
             DateOfBirth = patientRequest.DateOfBirth,
             Gender = patientRequest.Gender,
-            MedicalRecordNumber = patientRequest.MedicalRecordNumber
+            MedicalRecordNumber = patientRequest.MedicalRecordNumber,
+            Cedula = string.IsNullOrWhiteSpace(patientRequest.Cedula) ? null : patientRequest.Cedula
         };
     }
 

--- a/src/Infrastructure/Data/Configurations/PeopleConfigurations.cs
+++ b/src/Infrastructure/Data/Configurations/PeopleConfigurations.cs
@@ -15,6 +15,7 @@ public class PatientConfiguration : IEntityTypeConfiguration<Patient>
         builder.ToTable("Patient");
         builder.HasKey(e => e.Id);
         builder.Property(e => e.Id).HasColumnName("PatientID");
+        builder.Property(e => e.Cedula).HasMaxLength(50);
     }
 }
 

--- a/src/Infrastructure/Repositories/PatientProfileRepository.cs
+++ b/src/Infrastructure/Repositories/PatientProfileRepository.cs
@@ -75,6 +75,8 @@ public class PatientProfileRepository(ApplicationDbContext dbContext) :
         { patientOnFile.DateOfBirth = patientRequest.DateOfBirth; }
         if (!string.IsNullOrEmpty(patientRequest.MedicalRecordNumber))
         { patientOnFile.MedicalRecordNumber = patientRequest.MedicalRecordNumber; }
+        if (!string.IsNullOrEmpty(patientRequest.Cedula))
+        { patientOnFile.Cedula = patientRequest.Cedula; }
 
         return patientOnFile;
     }
@@ -105,6 +107,7 @@ public class PatientProfileRepository(ApplicationDbContext dbContext) :
             IsActive = p.User.ActiveStatus,
             PatientName = $"{p.User.LastName}, {p.User.FirstName} {p.User.MiddleName}".Trim(),
             MedicalRecordNumber = p.MedicalRecordNumber,
+            Cedula = p.Cedula,
             Gender = p.Gender,
             DateOfBirth = p.DateOfBirth ?? DateTime.MinValue,
             Email = p.User.Email,

--- a/src/Web/Controllers/PatientsController.cs
+++ b/src/Web/Controllers/PatientsController.cs
@@ -106,6 +106,7 @@ public class PatientsController : ControllerBase
     [Authorize(Policy = AuthPolicy.PermissionPrefix + Permissions.PatientsEdit)]
     [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(PatientProfile))]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
     public async Task<IActionResult> CreatePatient([FromBody] PatientProfileRequest patientRequest)
     {
         var createdPatient = await _patientProfileService.CreateAsync(patientRequest);
@@ -116,6 +117,7 @@ public class PatientsController : ControllerBase
     [Authorize(Policy = AuthPolicy.PermissionPrefix + Permissions.PatientsEdit)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
     public async Task<IActionResult> UpdatePatient(int id, [FromBody] PatientProfileUpdateRequest patientRequest)
     {
         if (!await _patientProfileService.VerifyRequestAsync(id))

--- a/src/Web/Middleware/GlobalExceptionHandler.cs
+++ b/src/Web/Middleware/GlobalExceptionHandler.cs
@@ -84,6 +84,10 @@ public sealed class GlobalExceptionHandler : IExceptionHandler
         {
             return "A user with this email address already exists.";
         }
+        if (message.Contains("uq_patient_cedula", StringComparison.OrdinalIgnoreCase))
+        {
+            return "A patient with this Cedula already exists.";
+        }
         return "A record with this value already exists.";
     }
 }

--- a/tests/Core.Tests/PatientProfileServiceTests.cs
+++ b/tests/Core.Tests/PatientProfileServiceTests.cs
@@ -179,6 +179,43 @@ public class PatientProfileServiceTests
         mockPatientRepo.Verify(r => r.UpdateAsync(It.IsAny<Patient>()), Times.Never);
     }
 
+    [Theory]
+    [InlineData("001-1234567-8", "001-1234567-8")] // provided value flows to the new entity
+    [InlineData("", null)]                          // blank normalized to null (avoids unique-constraint clash)
+    [InlineData("   ", null)]                        // whitespace normalized to null
+    public async Task CreateAsync_MapsCedula_NormalizingBlankToNull(string requestCedula, string? expectedCedula)
+    {
+        // Arrange
+        var fakeLogger = Mock.Of<ILogger<PatientProfileService>>();
+        var mockProfileRepo = Mock.Of<IPatientProfileRepository>();
+        var mockPatientRepo = new Mock<IPatientRepository>();
+        var mockUserRepo = new Mock<IUserRepository>();
+        var mockUserRoleRepo = new Mock<IUserRoleRepository>();
+
+        var savedUser = new User { Id = 10, FirstName = "Jane", LastName = "Doe", MiddleName = "", Email = "j@d.com", PhoneNumber = "555", ActiveStatus = true };
+        mockUserRepo.Setup(r => r.AddAsync(It.IsAny<User>())).ReturnsAsync(savedUser);
+
+        // Capture the Patient the service builds so we can assert on the mapped Cedula.
+        Patient? captured = null;
+        mockPatientRepo.Setup(r => r.AddAsync(It.IsAny<Patient>()))
+            .Callback<Patient>(p => captured = p)
+            .ReturnsAsync((Patient p) => { p.Id = 5; return p; });
+
+        mockUserRoleRepo.Setup(r => r.AddAsync(It.IsAny<UserRole>())).ReturnsAsync(new UserRole { UserRoleId = 1 });
+
+        var fakePatientCaretakerRepo = Mock.Of<IPatientCaretakerRepository>();
+        var svc = new PatientProfileService(fakeLogger, mockProfileRepo, mockPatientRepo.Object, mockUserRepo.Object, mockUserRoleRepo.Object, fakePatientCaretakerRepo, FakeTherapySessionRepo());
+        var request = new PatientProfileRequest { FirstName = "Jane", LastName = "Doe", Email = "j@d.com", PhoneNumber = "555", Gender = "F", DateOfBirth = DateTime.Today, MedicalRecordNumber = "MRN-002", Cedula = requestCedula };
+
+        // Act
+        var result = await svc.CreateAsync(request);
+
+        // Assert
+        Assert.NotNull(captured);
+        Assert.Equal(expectedCedula, captured!.Cedula);
+        Assert.Equal(expectedCedula, result.Cedula);
+    }
+
     [Fact]
     public async Task UpdateAsync_ActivateWithTempMrn_ThrowsInvalidOperation()
     {

--- a/tests/Infrastructure.Tests/PatientProfileRepositoryTests.cs
+++ b/tests/Infrastructure.Tests/PatientProfileRepositoryTests.cs
@@ -69,4 +69,49 @@ public class PatientProfileRepositoryTests
             Assert.Equal(requestedStatus, user.ActiveStatus);
         }
     }
+
+    [Fact]
+    public async Task UpdateAsync_Cedula_IsMappedPersistedAndProjected()
+    {
+        // Arrange
+        var options = CreateInMemoryOptions("PatientCedula_RoundTrip");
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            context.Patients.Add(new Patient
+            {
+                Id = 1,
+                Gender = "M",
+                MedicalRecordNumber = "MRN-001",
+                User = new User { Id = 1, FirstName = "John", LastName = "Doe", ActiveStatus = true }
+            });
+            await context.SaveChangesAsync();
+        }
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            var repository = new PatientProfileRepository(context);
+            var updateRequest = new PatientProfileUpdateRequest
+            {
+                FirstName = "John",
+                LastName = "Doe",
+                ActiveStatus = true,
+                Cedula = "001-1234567-8"
+            };
+
+            // Act — the returned profile is built by ExtractPatientProfile
+            var result = await repository.UpdateAsync(1, 1, updateRequest);
+
+            // Assert — read projection surfaces the new value
+            Assert.Equal("001-1234567-8", result.Cedula);
+        }
+
+        // Assert — value was persisted to the Patient entity (MapToUpdatedPatient)
+        using (var context = new ApplicationDbContext(options))
+        {
+            var patient = await context.Patients.FindAsync(1);
+            Assert.NotNull(patient);
+            Assert.Equal("001-1234567-8", patient.Cedula);
+        }
+    }
 }


### PR DESCRIPTION
Thread Cedula (government ID, string?) through the Patient feature exactly where MedicalRecordNumber flows: entity, EF config (HasMaxLength 50), the 3 DTOs, and all 4 mapping sites. On create, blank Cedula is normalized to NULL so the unique constraint doesn't clash on omitted values. Age stays UI-only (no API surface).

Duplicate Cedula returns 409 Conflict via the existing GlobalExceptionHandler 1062 mapping (new uq_patient_cedula friendly message). 409 declared on POST/PUT.

Tests: service create-maps-Cedula + blank->null normalization (theory); repository update+read round-trip. Full suite 320 green (Core 106 / Infra 65 / Web 149); build clean.