### PR TITLE
Swagger UI: JWT Bearer auth (Authorize button + per-operation lock)

### DIFF
--- a/src/Web/Startup.cs
+++ b/src/Web/Startup.cs
@@ -21,6 +21,7 @@ using Neurocorp.Api.Core.Interfaces.Services;
 using Neurocorp.Api.Web.Authentication;
 using Neurocorp.Api.Web.Authorization;
 using Neurocorp.Api.Web.Middleware;
+using Neurocorp.Api.Web.Swagger;
 
 namespace Neurocorp.Api.Web;
 
@@ -83,7 +84,27 @@ public class Startup(IConfiguration configuration, IWebHostEnvironment environme
         // Register the Swagger generator, defining one or more Swagger documents
         services.AddSwaggerGen(c =>
         {
-            c.SwaggerDoc("v1", new OpenApiInfo { Title = "Neurocorp Web API", Version = "v1" });
+            c.SwaggerDoc("v1", new OpenApiInfo
+            {
+                Title = "Neurocorp Web API",
+                Version = "v1",
+                Description = "JWT Bearer auth: obtain a token via POST /api/auth/login, click " +
+                    "Authorize, and paste it. Note: while an account is in the must-change-password " +
+                    "state, a valid token is still restricted to the password-change flow " +
+                    "(PasswordChangeRequiredMiddleware)."
+            });
+            // Bearer scheme + per-operation requirement so secured endpoints (everything without
+            // [AllowAnonymous], per the fallback policy below) carry the lock icon and send the token.
+            c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+            {
+                Name = "Authorization",
+                Type = SecuritySchemeType.Http,
+                Scheme = "bearer",
+                BearerFormat = "JWT",
+                In = ParameterLocation.Header,
+                Description = "Paste the raw access token from POST /api/auth/login (no 'Bearer ' prefix)."
+            });
+            c.OperationFilter<BearerSecurityOperationFilter>();
         });
 
         // Register the hosted service

--- a/src/Web/Swagger/BearerSecurityOperationFilter.cs
+++ b/src/Web/Swagger/BearerSecurityOperationFilter.cs
@@ -1,0 +1,35 @@
+using System.Linq;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace Neurocorp.Api.Web.Swagger;
+
+/// <summary>
+/// Stamps the Bearer security requirement on every operation that does NOT opt out via
+/// <c>[AllowAnonymous]</c> (login, refresh, health checks). Because the app runs a fallback
+/// policy requiring an authenticated user (see Startup), "not anonymous" == "secured", so the
+/// Swagger UI lock icon reflects reality instead of decorating everything (or nothing).
+/// </summary>
+public class BearerSecurityOperationFilter : IOperationFilter
+{
+    public void Apply(OpenApiOperation operation, OperationFilterContext context)
+    {
+        var isAnonymous = context.ApiDescription.ActionDescriptor.EndpointMetadata
+            .OfType<IAllowAnonymous>()
+            .Any();
+        if (isAnonymous) return;
+
+        operation.Security.Add(new OpenApiSecurityRequirement
+        {
+            [new OpenApiSecurityScheme
+            {
+                Reference = new OpenApiReference
+                {
+                    Type = ReferenceType.SecurityScheme,
+                    Id = "Bearer"
+                }
+            }] = System.Array.Empty<string>()
+        });
+    }
+}

--- a/tests/Web.Tests/Swagger/SwaggerBearerSecurityTests.cs
+++ b/tests/Web.Tests/Swagger/SwaggerBearerSecurityTests.cs
@@ -1,0 +1,72 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi.Models;
+using Neurocorp.Api.Web.Tests.Authorization;
+using Swashbuckle.AspNetCore.Swagger;
+
+namespace Neurocorp.Api.Web.Tests.Swagger;
+
+/// <summary>
+/// Swagger JWT Bearer auth (intake 2026-06-13-001): the generated OpenAPI document must declare
+/// the Bearer security scheme, and the per-operation requirement must mirror reality — stamped on
+/// every secured operation (the fallback policy default) and absent from [AllowAnonymous] ones
+/// (login/refresh), so the UI lock icons and Authorize button work as expected.
+/// Asserts against the doc produced by the REAL host (via <see cref="AccessControlTestFactory"/>),
+/// not a hand-built filter context.
+/// </summary>
+public class SwaggerBearerSecurityTests : IClassFixture<AccessControlTestFactory>
+{
+    private readonly OpenApiDocument _doc;
+
+    public SwaggerBearerSecurityTests(AccessControlTestFactory factory)
+    {
+        var provider = factory.Services.GetRequiredService<ISwaggerProvider>();
+        _doc = provider.GetSwagger("v1");
+    }
+
+    [Fact]
+    public void Document_declares_the_bearer_security_scheme()
+    {
+        _doc.Components.SecuritySchemes.Should().ContainKey("Bearer");
+        var scheme = _doc.Components.SecuritySchemes["Bearer"];
+        scheme.Type.Should().Be(SecuritySchemeType.Http);
+        scheme.Scheme.Should().Be("bearer");
+        scheme.BearerFormat.Should().Be("JWT");
+    }
+
+    [Fact]
+    public void Anonymous_login_operation_has_no_security_requirement()
+    {
+        var login = _doc.Paths["/api/Auth/login"].Operations[OperationType.Post];
+        login.Security.Should().BeEmpty("[AllowAnonymous] endpoints must not demand a token");
+    }
+
+    [Fact]
+    public void Secured_operations_carry_the_bearer_requirement()
+    {
+        var patients = _doc.Paths["/api/Patients"].Operations[OperationType.Get];
+        patients.Security.Should().ContainSingle()
+            .Which.Keys.Should().ContainSingle(s => s.Reference.Id == "Bearer");
+    }
+
+    [Fact]
+    public void Every_operation_is_either_bearer_secured_or_deliberately_anonymous()
+    {
+        // The fallback policy secures everything that doesn't opt out, so each operation must
+        // either carry the Bearer requirement or be a known-anonymous surface. Catches a future
+        // endpoint slipping through the operation filter unlabeled.
+        foreach (var (path, item) in _doc.Paths)
+        {
+            foreach (var (type, operation) in item.Operations)
+            {
+                var hasBearer = operation.Security
+                    .Any(req => req.Keys.Any(s => s.Reference?.Id == "Bearer"));
+                // HealthController is class-level [AllowAnonymous] (K8s probes).
+                var isKnownAnonymous = path is "/api/Auth/login" or "/api/Auth/refresh"
+                    || path.StartsWith("/api/Health/");
+                (hasBearer || isKnownAnonymous).Should().BeTrue(
+                    $"operation {type} {path} is neither Bearer-secured nor a known anonymous surface");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Resolves intake 2026-06-13-001. AddSwaggerGen now declares an http/bearer/JWT security scheme, and BearerSecurityOperationFilter stamps the requirement on every operation without [AllowAnonymous] — matching the fallback policy, so lock icons reflect reality (login/refresh/health stay unlocked). Doc description notes the must-change-password token restriction. Dev-only surface: UseSwagger remains gated on IsDevelopment.

Tests: SwaggerBearerSecurityTests asserts against the real host's generated document (scheme present, login unlocked, secured ops locked, and a sweep that every operation is either Bearer-secured or known-anonymous).