### PR TITLE
fix: allow clearing a patient Cedula back to NULL (explicit erase)

### DIFF
--- a/src/Infrastructure/Repositories/PatientProfileRepository.cs
+++ b/src/Infrastructure/Repositories/PatientProfileRepository.cs
@@ -75,8 +75,14 @@ public class PatientProfileRepository(ApplicationDbContext dbContext) :
         { patientOnFile.DateOfBirth = patientRequest.DateOfBirth; }
         if (!string.IsNullOrEmpty(patientRequest.MedicalRecordNumber))
         { patientOnFile.MedicalRecordNumber = patientRequest.MedicalRecordNumber; }
-        if (!string.IsNullOrEmpty(patientRequest.Cedula))
-        { patientOnFile.Cedula = patientRequest.Cedula; }
+        // Cedula supports an explicit erase (intake 2026-06-29-001 item 3): omitted/null = leave
+        // as-is; present but blank = clear to NULL (unique index allows multiple NULLs); else set.
+        if (patientRequest.Cedula != null)
+        {
+            patientOnFile.Cedula = string.IsNullOrWhiteSpace(patientRequest.Cedula)
+                ? null
+                : patientRequest.Cedula;
+        }
 
         return patientOnFile;
     }

--- a/tests/Infrastructure.Tests/PatientProfileRepositoryTests.cs
+++ b/tests/Infrastructure.Tests/PatientProfileRepositoryTests.cs
@@ -114,4 +114,102 @@ public class PatientProfileRepositoryTests
             Assert.Equal("001-1234567-8", patient.Cedula);
         }
     }
+
+    // Regression (intake 2026-06-29-001 item 3): a present-but-blank Cedula in the update request
+    // is an explicit "erase" and must clear the column to NULL. Previously the blank was silently
+    // ignored (same non-empty⇒assign pattern as MRN), so a Cedula could never be removed.
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task UpdateAsync_BlankCedula_ClearsToNull(string blank)
+    {
+        // Arrange — patient already has a Cedula on file
+        var options = CreateInMemoryOptions($"PatientCedula_Clear_{blank.Length}");
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            context.Patients.Add(new Patient
+            {
+                Id = 1,
+                Gender = "M",
+                MedicalRecordNumber = "MRN-001",
+                Cedula = "001-1234567-8",
+                User = new User { Id = 1, FirstName = "John", LastName = "Doe", ActiveStatus = true }
+            });
+            await context.SaveChangesAsync();
+        }
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            var repository = new PatientProfileRepository(context);
+            var updateRequest = new PatientProfileUpdateRequest
+            {
+                FirstName = "John",
+                LastName = "Doe",
+                ActiveStatus = true,
+                Cedula = blank
+            };
+
+            // Act
+            var result = await repository.UpdateAsync(1, 1, updateRequest);
+
+            // Assert — projection reflects the erase
+            Assert.Null(result.Cedula);
+        }
+
+        // Assert — NULL persisted (not the old value, not the blank string)
+        using (var context = new ApplicationDbContext(options))
+        {
+            var patient = await context.Patients.FindAsync(1);
+            Assert.NotNull(patient);
+            Assert.Null(patient.Cedula);
+        }
+    }
+
+    // Companion: an OMITTED Cedula (null in the DTO) still means "leave as-is" — partial updates
+    // that don't mention the field must not wipe it.
+    [Fact]
+    public async Task UpdateAsync_OmittedCedula_LeavesExistingValueUnchanged()
+    {
+        // Arrange
+        var options = CreateInMemoryOptions("PatientCedula_Omitted");
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            context.Patients.Add(new Patient
+            {
+                Id = 1,
+                Gender = "M",
+                MedicalRecordNumber = "MRN-001",
+                Cedula = "001-1234567-8",
+                User = new User { Id = 1, FirstName = "John", LastName = "Doe", ActiveStatus = true }
+            });
+            await context.SaveChangesAsync();
+        }
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            var repository = new PatientProfileRepository(context);
+            var updateRequest = new PatientProfileUpdateRequest
+            {
+                FirstName = "John",
+                LastName = "Doe",
+                ActiveStatus = true,
+                Cedula = null
+            };
+
+            // Act
+            var result = await repository.UpdateAsync(1, 1, updateRequest);
+
+            // Assert
+            Assert.Equal("001-1234567-8", result.Cedula);
+        }
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            var patient = await context.Patients.FindAsync(1);
+            Assert.NotNull(patient);
+            Assert.Equal("001-1234567-8", patient.Cedula);
+        }
+    }
 }


### PR DESCRIPTION
Intake 2026-06-29-001 item 3. MapToUpdatedPatient ignored empty strings (non-empty=>assign, same pattern as MRN), so a Cedula could be set or changed but never removed. Now: omitted/null = leave as-is; present-but-blank = clear to NULL (uq_patient_cedula allows multiple NULLs); non-blank = set. Contract updated in patient-care-super (_contracts/patients-api.md).

Regression tests (written red first): blank + whitespace clear to NULL and project as null; omitted Cedula still leaves the stored value untouched.