### PR TITLE
WP-19A: map Patient.Notes (V021) in entity + EF config, exposed nowhere

### DIFF
--- a/src/Core/Entities/Patient.cs
+++ b/src/Core/Entities/Patient.cs
@@ -12,6 +12,10 @@ public class Patient : PersonBase
     public string? Gender { get; set; }
     public string? MedicalRecordNumber { get; set; }
     public string? Cedula { get; set; }
+    // WP-19A: free-text remarks written by the legacy import ([LEGACY-IMPORT: ...] provenance
+    // markers). Deliberately NOT surfaced in any DTO/endpoint/UI — the property exists so the
+    // entity stays conformant with the DB schema (V021) for /audit-db-api.
+    public string? Notes { get; set; }
     public ICollection<PatientCaretaker>? Caretakers { get; set; }
 
     public bool HasTemporaryMrn()

--- a/src/Infrastructure/Data/Configurations/PeopleConfigurations.cs
+++ b/src/Infrastructure/Data/Configurations/PeopleConfigurations.cs
@@ -16,6 +16,7 @@ public class PatientConfiguration : IEntityTypeConfiguration<Patient>
         builder.HasKey(e => e.Id);
         builder.Property(e => e.Id).HasColumnName("PatientID");
         builder.Property(e => e.Cedula).HasMaxLength(50);
+        builder.Property(e => e.Notes).IsRequired(false);
     }
 }
 


### PR DESCRIPTION
Companion to patient-care-db V021__add_notes_to_patient. The legacy import writes [LEGACY-IMPORT: ...] provenance markers into Patient.Notes; per the WP-19 design the column is DB-only from the product's perspective — this property exists solely so the entity stays conformant with the schema for /audit-db-api. Not added to any DTO, mapping, endpoint, or UI type (mirrors the existing Caretaker.Notes precedent). 327 tests green.