### PR TITLE
WP-20B: paid-in-range visibility on unpaid-sessions + payroll-preview

### DIFF
--- a/src/Core/BusinessObjects/ServicePayments/PaidByPaymentRef.cs
+++ b/src/Core/BusinessObjects/ServicePayments/PaidByPaymentRef.cs
@@ -1,0 +1,14 @@
+namespace Neurocorp.Api.Core.BusinessObjects.ServicePayments;
+
+/// <summary>
+/// One service-payment allocation that covered (part of) a session in the requested range,
+/// so the UI can show <i>which</i> payment already settled it (WP-20). Reversal allocations
+/// appear like any other (negative <c>AmountApplied</c>) — they net into the session's total.
+/// </summary>
+public class PaidByPaymentRef
+{
+    public int ServicePaymentId { get; set; }
+    public string ReferenceNumber { get; set; } = string.Empty;
+    public string PaymentDate { get; set; } = string.Empty;
+    public decimal AmountApplied { get; set; }
+}

--- a/src/Core/BusinessObjects/ServicePayments/PaidInRangeSummary.cs
+++ b/src/Core/BusinessObjects/ServicePayments/PaidInRangeSummary.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+
+namespace Neurocorp.Api.Core.BusinessObjects.ServicePayments;
+
+/// <summary>
+/// "Paid in range" rollup for a therapist + range (WP-20): sessions already covered by prior
+/// service payments, so the payable list can reconcile against the raw data.
+/// <c>TotalApplied</c> is the invariant term — Σ <c>AmountApplied</c> across ALL completed
+/// sessions in range (including partials still listed as payable), so that
+/// Σ ProviderAmount = Σ RemainingProviderAmount (payable) + <c>TotalApplied</c>.
+/// </summary>
+public class PaidInRangeSummary
+{
+    /// <summary>How many sessions in range are fully paid (remaining &lt;= 0).</summary>
+    public int FullyPaidSessionCount { get; set; }
+
+    /// <summary>Σ ProviderAmount of the fully-paid sessions.</summary>
+    public decimal FullyPaidTotal { get; set; }
+
+    /// <summary>Σ AmountApplied across all sessions in range (incl. partially-paid ones).</summary>
+    public decimal TotalApplied { get; set; }
+
+    /// <summary>Every session with any allocation (fully or partially paid), with payment refs.</summary>
+    public List<PaidProviderSessionDetail> Sessions { get; set; } = new();
+}

--- a/src/Core/BusinessObjects/ServicePayments/PaidProviderSessionDetail.cs
+++ b/src/Core/BusinessObjects/ServicePayments/PaidProviderSessionDetail.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+
+namespace Neurocorp.Api.Core.BusinessObjects.ServicePayments;
+
+/// <summary>
+/// A completed session in the requested range that already has service-payment money applied
+/// (fully or partially paid), with the payment reference(s) that covered it (WP-20).
+/// <c>RemainingProviderAmount</c> is 0 when fully paid; when &gt; 0 the session is partially
+/// paid and also appears in the payable list.
+/// </summary>
+public class PaidProviderSessionDetail
+{
+    public int SessionId { get; set; }
+    public string SessionDate { get; set; } = string.Empty;
+    public string SessionTime { get; set; } = string.Empty;
+    public string PatientName { get; set; } = string.Empty;
+    public string TherapyType { get; set; } = string.Empty;
+    public decimal ProviderAmount { get; set; }
+    public decimal AmountApplied { get; set; }
+    public decimal RemainingProviderAmount { get; set; }
+    public List<PaidByPaymentRef> PaymentReferences { get; set; } = new();
+}

--- a/src/Core/BusinessObjects/ServicePayments/PayrollPreviewTherapist.cs
+++ b/src/Core/BusinessObjects/ServicePayments/PayrollPreviewTherapist.cs
@@ -12,5 +12,12 @@ public class PayrollPreviewTherapist
     public string TherapistName { get; set; } = string.Empty;
     public int SessionCount { get; set; }
     public decimal TotalRemaining { get; set; }
+
+    /// <summary>Fully-paid sessions the therapist has in the window (WP-20, context only).</summary>
+    public int PaidSessionCount { get; set; }
+
+    /// <summary>Σ AmountApplied across all of the therapist's in-range sessions (WP-20, context only).</summary>
+    public decimal PaidTotal { get; set; }
+
     public List<UnpaidProviderSessionSummary> Sessions { get; set; } = new();
 }

--- a/src/Core/BusinessObjects/ServicePayments/UnpaidProviderSessionsResult.cs
+++ b/src/Core/BusinessObjects/ServicePayments/UnpaidProviderSessionsResult.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+
+namespace Neurocorp.Api.Core.BusinessObjects.ServicePayments;
+
+/// <summary>
+/// Envelope for GET /api/service-payments/unpaid-sessions (WP-20): the payable list that
+/// drives the "Pay Therapist" wizard (element shape unchanged) plus a "paid in range"
+/// summary of sessions already covered by prior service payments, so the UI can always
+/// reconcile the range: Σ ProviderAmount = Σ RemainingProviderAmount + PaidInRange.TotalApplied.
+/// </summary>
+public class UnpaidProviderSessionsResult
+{
+    /// <summary>Completed sessions that still owe the therapist (remaining &gt; 0), ordered by date/time.</summary>
+    public List<UnpaidProviderSessionSummary> Sessions { get; set; } = new();
+
+    /// <summary>Sessions in range already (fully or partially) paid, with the covering payment refs.</summary>
+    public PaidInRangeSummary PaidInRange { get; set; } = new();
+}

--- a/src/Core/Interfaces/Services/IServicePaymentService.cs
+++ b/src/Core/Interfaces/Services/IServicePaymentService.cs
@@ -20,6 +20,15 @@ public interface IServicePaymentService
     Task<ServicePaymentRecord?> GetByIdAsync(int servicePaymentId);
     Task<IEnumerable<UnpaidProviderSessionSummary>> GetUnpaidProviderSessionsAsync(int therapistId, DateOnly? from, DateOnly? to);
 
+    /// <summary>
+    /// Full payable/paid partition of a therapist's completed sessions in the window (WP-20):
+    /// the payable list (identical to <see cref="GetUnpaidProviderSessionsAsync"/>) plus a
+    /// "paid in range" summary of sessions already covered by prior service payments, with the
+    /// covering payment reference(s). Upholds the reconciliation invariant
+    /// Σ ProviderAmount = Σ RemainingProviderAmount (payable) + PaidInRange.TotalApplied.
+    /// </summary>
+    Task<UnpaidProviderSessionsResult> GetProviderSessionsBreakdownAsync(int therapistId, DateOnly? from, DateOnly? to);
+
     /// <summary>Per-therapist rollup of who is owed what in the window (drives the "Run Payroll" preview).</summary>
     Task<IEnumerable<PayrollPreviewTherapist>> GetPayrollPreviewAsync(DateOnly? from, DateOnly? to);
 

--- a/src/Core/Services/ServicePaymentService.cs
+++ b/src/Core/Services/ServicePaymentService.cs
@@ -155,43 +155,87 @@ public class ServicePaymentService : IServicePaymentService
 
     public async Task<IEnumerable<UnpaidProviderSessionSummary>> GetUnpaidProviderSessionsAsync(int therapistId, DateOnly? from, DateOnly? to)
     {
+        // WP-20: the payable list is the Sessions half of the full breakdown — batch payroll and
+        // every other caller keep identical behavior.
+        return (await GetProviderSessionsBreakdownAsync(therapistId, from, to)).Sessions;
+    }
+
+    public async Task<UnpaidProviderSessionsResult> GetProviderSessionsBreakdownAsync(int therapistId, DateOnly? from, DateOnly? to)
+    {
         var (periodStart, periodEnd) = ResolveRange(from, to);
-        _logger.LogInformation("Listing unpaid provider sessions for therapist {TherapistId} {From}..{To}", therapistId, periodStart, periodEnd);
+        _logger.LogInformation("Listing provider session breakdown for therapist {TherapistId} {From}..{To}", therapistId, periodStart, periodEnd);
+
+        var result = new UnpaidProviderSessionsResult();
 
         var completedId = await ResolveCompletedStatusIdAsync();
-        if (completedId == null) return Enumerable.Empty<UnpaidProviderSessionSummary>();
+        if (completedId == null) return result;
 
         var sessions = await _sessionRepo.GetByTherapistIdAndDateRangeAsync(
             therapistId, periodStart, periodEnd, new[] { completedId.Value });
 
         var sessionIds = sessions.Select(s => s.Id).ToList();
         var allocations = await _sessionServicePaymentRepo.GetBySessionIdsAsync(sessionIds);
-        var appliedBySession = allocations
+        var allocationsBySession = allocations
             .GroupBy(a => a.TherapySessionId)
-            .ToDictionary(g => g.Key, g => g.Sum(a => a.AmountApplied));
+            .ToDictionary(g => g.Key, g => g.ToList());
 
-        var results = new List<UnpaidProviderSessionSummary>();
         foreach (var s in sessions.OrderBy(s => s.SessionDate).ThenBy(s => s.SessionTime))
         {
-            var alreadyApplied = appliedBySession.TryGetValue(s.Id, out var sum) ? sum : 0m;
+            var sessionAllocations = allocationsBySession.TryGetValue(s.Id, out var list)
+                ? list
+                : new List<SessionServicePayment>();
+            var alreadyApplied = sessionAllocations.Sum(a => a.AmountApplied);
             var remaining = s.ProviderAmount - alreadyApplied;
-            if (remaining <= 0) continue;
 
-            results.Add(new UnpaidProviderSessionSummary
+            // The invariant term: every applied cent in range counts, incl. partially-paid sessions.
+            result.PaidInRange.TotalApplied += alreadyApplied;
+
+            if (remaining > 0)
             {
-                SessionId = s.Id,
-                SessionDate = s.SessionDate.ToString("yyyy-MM-dd"),
-                SessionTime = s.SessionTime.ToString("HH:mm"),
-                PatientId = s.PatientId,
-                PatientName = ResolvePatientName(s.Patient),
-                TherapyType = ResolveTherapyType(s),
-                ProviderAmount = s.ProviderAmount,
-                AlreadyApplied = alreadyApplied,
-                RemainingProviderAmount = remaining,
-            });
+                result.Sessions.Add(new UnpaidProviderSessionSummary
+                {
+                    SessionId = s.Id,
+                    SessionDate = s.SessionDate.ToString("yyyy-MM-dd"),
+                    SessionTime = s.SessionTime.ToString("HH:mm"),
+                    PatientId = s.PatientId,
+                    PatientName = ResolvePatientName(s.Patient),
+                    TherapyType = ResolveTherapyType(s),
+                    ProviderAmount = s.ProviderAmount,
+                    AlreadyApplied = alreadyApplied,
+                    RemainingProviderAmount = remaining,
+                });
+            }
+
+            if (alreadyApplied > 0)
+            {
+                result.PaidInRange.Sessions.Add(new PaidProviderSessionDetail
+                {
+                    SessionId = s.Id,
+                    SessionDate = s.SessionDate.ToString("yyyy-MM-dd"),
+                    SessionTime = s.SessionTime.ToString("HH:mm"),
+                    PatientName = ResolvePatientName(s.Patient),
+                    TherapyType = ResolveTherapyType(s),
+                    ProviderAmount = s.ProviderAmount,
+                    AmountApplied = alreadyApplied,
+                    RemainingProviderAmount = remaining > 0 ? remaining : 0m,
+                    PaymentReferences = sessionAllocations.Select(a => new PaidByPaymentRef
+                    {
+                        ServicePaymentId = a.ServicePaymentId,
+                        ReferenceNumber = a.ServicePayment?.ReferenceNumber ?? string.Empty,
+                        PaymentDate = a.ServicePayment?.PaymentDate.ToString("yyyy-MM-dd") ?? string.Empty,
+                        AmountApplied = a.AmountApplied,
+                    }).ToList(),
+                });
+
+                if (remaining <= 0)
+                {
+                    result.PaidInRange.FullyPaidSessionCount++;
+                    result.PaidInRange.FullyPaidTotal += s.ProviderAmount;
+                }
+            }
         }
 
-        return results;
+        return result;
     }
 
     public async Task<IEnumerable<PayrollPreviewTherapist>> GetPayrollPreviewAsync(DateOnly? from, DateOnly? to)
@@ -204,7 +248,10 @@ public class ServicePaymentService : IServicePaymentService
         var rows = new List<PayrollPreviewTherapist>();
         foreach (var t in therapists.Where(t => t.IsActive))
         {
-            var unpaid = (await GetUnpaidProviderSessionsAsync(t.TherapistId, periodStart, periodEnd)).ToList();
+            var breakdown = await GetProviderSessionsBreakdownAsync(t.TherapistId, periodStart, periodEnd);
+            var unpaid = breakdown.Sessions;
+            // The preview lists who is *owed*: a therapist with only-paid sessions in range is
+            // still skipped — the WP-20 paid context rides existing rows only.
             if (unpaid.Count == 0) continue;
 
             rows.Add(new PayrollPreviewTherapist
@@ -213,6 +260,8 @@ public class ServicePaymentService : IServicePaymentService
                 TherapistName = t.TherapistName,
                 SessionCount = unpaid.Count,
                 TotalRemaining = unpaid.Sum(s => s.RemainingProviderAmount),
+                PaidSessionCount = breakdown.PaidInRange.FullyPaidSessionCount,
+                PaidTotal = breakdown.PaidInRange.TotalApplied,
                 Sessions = unpaid,
             });
         }

--- a/src/Infrastructure/Repositories/SessionServicePaymentRepository.cs
+++ b/src/Infrastructure/Repositories/SessionServicePaymentRepository.cs
@@ -14,6 +14,7 @@ public class SessionServicePaymentRepository(ApplicationDbContext dbContext) :
         if (ids.Count == 0) return new List<SessionServicePayment>();
 
         return await _dbContext.SessionServicePayments
+            .Include(ssp => ssp.ServicePayment) // WP-20: payment reference/date for the paid-in-range detail
             .Where(ssp => ids.Contains(ssp.TherapySessionId))
             .ToListAsync();
     }

--- a/src/Web/Controllers/ServicePaymentsController.cs
+++ b/src/Web/Controllers/ServicePaymentsController.cs
@@ -41,15 +41,18 @@ public class ServicePaymentsController : ControllerBase
         return Ok(payment);
     }
 
-    // Feeds the "Pay Therapist" wizard: completed sessions in range that still owe the therapist.
+    // Feeds the "Pay Therapist" wizard: completed sessions in range that still owe the therapist,
+    // plus the WP-20 "paid in range" summary so the payable list reconciles against the raw data.
+    // Response is the envelope { sessions, paidInRange } — a deliberate breaking shape change
+    // shipping in lockstep with the UI (WP-20C).
     [HttpGet("unpaid-sessions")]
     [Authorize(Policy = AuthPolicy.PermissionPrefix + Permissions.ServicePaymentsView)]
-    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<UnpaidProviderSessionSummary>))]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(UnpaidProviderSessionsResult))]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> GetUnpaidSessions([FromQuery] int therapistId, [FromQuery] DateOnly? from, [FromQuery] DateOnly? to)
     {
-        var sessions = await _servicePaymentService.GetUnpaidProviderSessionsAsync(therapistId, from, to);
-        return Ok(sessions);
+        var result = await _servicePaymentService.GetProviderSessionsBreakdownAsync(therapistId, from, to);
+        return Ok(result);
     }
 
     // "Run Payroll" preview: every therapist owed money in the window (count + total + sessions).

--- a/test-scripts/wp-20b-paid-in-range.sh
+++ b/test-scripts/wp-20b-paid-in-range.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# WP-20B: Payroll "paid in range" visibility — curl test script
+#
+# Endpoints (all under /api/service-payments):
+#   GET /api/service-payments/unpaid-sessions?therapistId=&from=&to=  -> ServicePayments.View (MGR, AM)
+#       Response is now the WP-20 envelope: { sessions: [...], paidInRange: {...} }
+#       (breaking shape change — ships in lockstep with the UI, WP-20C)
+#   GET /api/service-payments/payroll-preview?from=&to=               -> ServicePayments.View (MGR, AM)
+#       Rows gain two additive fields: paidSessionCount, paidTotal
+#
+# Reconciliation invariant (over Completed sessions in range):
+#   Σ providerAmount = Σ remainingProviderAmount (sessions) + paidInRange.totalApplied
+#
+# Auth: every endpoint is claim-gated. Provide a JWT in TOKEN (MGR/AM token).
+#   Without a token the secured calls return 401 (expected negative case).
+#
+# Prereqs:
+#   - API running locally on :5245 (`dotnet run --project src/Web/Web.csproj`)
+#   - RoleClaim seed applied so MGR/AM hold ServicePayments.View
+#   - jq installed for pretty printing (optional)
+#
+# Usage:
+#   TOKEN=$MGR_JWT THERAPIST_ID=23 ./test-scripts/wp-20b-paid-in-range.sh
+
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost:5245}"
+THERAPIST_ID="${THERAPIST_ID:-23}"
+TOKEN="${TOKEN:-}"
+FROM="${FROM:-2026-05-30}"
+TO="${TO:-2026-06-12}"
+
+PRETTY="cat"
+if command -v jq >/dev/null 2>&1; then PRETTY="jq ."; fi
+
+AUTH=()
+if [ -n "$TOKEN" ]; then AUTH=(-H "Authorization: Bearer ${TOKEN}"); fi
+
+echo "=================================================================="
+echo "Test 1 (acceptance / origin case): unpaid-sessions envelope"
+echo "  GET ${BASE_URL}/api/service-payments/unpaid-sessions?therapistId=${THERAPIST_ID}&from=${FROM}&to=${TO}"
+echo ""
+echo "  With THERAPIST_ID=23, FROM=2026-05-30, TO=2026-06-12 against the"
+echo "  production dataset, expect (the 2026-07-07 discrepancy case):"
+echo "    - sessions[]: 16 payable rows, Σ remainingProviderAmount = 363.40"
+echo "    - paidInRange.fullyPaidSessionCount = 4"
+echo "    - paidInRange.fullyPaidTotal        = 85.00"
+echo "    - paidInRange.totalApplied          = 85.00"
+echo "    - paidInRange.sessions[]: 4 rows, each remainingProviderAmount = 0.00"
+echo "      with paymentReferences[].referenceNumber = \"PAYROLL-2026-05\""
+echo "    - Invariant: 448.40 (Σ provider) = 363.40 (Σ remaining) + 85.00 (totalApplied)"
+echo "=================================================================="
+curl -sS -w "\nHTTP %{http_code}\n" "${AUTH[@]}" \
+    "${BASE_URL}/api/service-payments/unpaid-sessions?therapistId=${THERAPIST_ID}&from=${FROM}&to=${TO}" | $PRETTY
+echo
+
+echo "=================================================================="
+echo "Test 2: payroll-preview rows carry the new additive paid context"
+echo "  GET ${BASE_URL}/api/service-payments/payroll-preview?from=${FROM}&to=${TO}"
+echo "  Expect: each row includes paidSessionCount (fully-paid count) and"
+echo "          paidTotal (Σ amountApplied across ALL in-range sessions)."
+echo "          For therapist 23 in the origin range: paidSessionCount=4, paidTotal=85.00."
+echo "          Therapists with ONLY paid sessions in range are still skipped."
+echo "=================================================================="
+curl -sS -w "\nHTTP %{http_code}\n" "${AUTH[@]}" \
+    "${BASE_URL}/api/service-payments/payroll-preview?from=${FROM}&to=${TO}" | $PRETTY
+echo
+
+echo "=================================================================="
+echo "Test 3 (validation): to before from -> 400 Bad Request"
+echo "  GET ${BASE_URL}/api/service-payments/unpaid-sessions?therapistId=${THERAPIST_ID}&from=2026-06-12&to=2026-05-30"
+echo "=================================================================="
+curl -sS -w "\nHTTP %{http_code}\n" "${AUTH[@]}" \
+    "${BASE_URL}/api/service-payments/unpaid-sessions?therapistId=${THERAPIST_ID}&from=2026-06-12&to=2026-05-30" | $PRETTY
+echo
+
+echo "=================================================================="
+echo "Test 4 (negative): any secured call with no token should be 401."
+echo "  Unset TOKEN and re-run Test 1; expect HTTP 401."
+echo "=================================================================="
+
+echo "All WP-20B tests complete."

--- a/tests/Core.Tests/ServicePaymentServiceTests.cs
+++ b/tests/Core.Tests/ServicePaymentServiceTests.cs
@@ -410,6 +410,175 @@ public class ServicePaymentServiceTests
         await act.Should().ThrowAsync<ArgumentException>();
     }
 
+    // ---- WP-20: paid-in-range breakdown -------------------------------------
+
+    private static SessionServicePayment Allocation(int id, int servicePaymentId, int sessionId, decimal amountApplied,
+        string? referenceNumber = null, DateTime? paymentDate = null) => new()
+    {
+        Id = id,
+        ServicePaymentId = servicePaymentId,
+        TherapySessionId = sessionId,
+        AmountApplied = amountApplied,
+        ServicePayment = new ServicePayment
+        {
+            Id = servicePaymentId,
+            TherapistId = TherapistId,
+            ReferenceNumber = referenceNumber,
+            PaymentDate = paymentDate ?? new DateTime(2026, 5, 31),
+        },
+    };
+
+    [Fact]
+    public async Task GetProviderSessionsBreakdownAsync_PartitionsPayableAndPaid_AndUpholdsInvariant()
+    {
+        // s1 fully paid (20 of 20) -> paid detail only; s2 partially paid (20 of 60 -> 40 remains)
+        // -> payable list AND paid detail; s3 unpaid (30) -> payable only.
+        var sessions = new List<TherapySession>
+        {
+            Session(1, 20m, date: new DateOnly(2026, 4, 5)),
+            Session(2, 60m, date: new DateOnly(2026, 4, 6)),
+            Session(3, 30m, date: new DateOnly(2026, 4, 7)),
+        };
+        var existing = new List<SessionServicePayment>
+        {
+            Allocation(1, 88, sessionId: 1, amountApplied: 20m, referenceNumber: "PAYROLL-2026-05"),
+            Allocation(2, 88, sessionId: 2, amountApplied: 20m, referenceNumber: "PAYROLL-2026-05"),
+        };
+        var (service, _, _, _) = BuildService(completedSessions: sessions, existingAllocations: existing);
+
+        var result = await service.GetProviderSessionsBreakdownAsync(TherapistId, new DateOnly(2026, 4, 1), new DateOnly(2026, 4, 30));
+
+        // Payable list: s2 (partial) + s3 (unpaid), ordered by date.
+        result.Sessions.Select(s => s.SessionId).Should().Equal(2, 3);
+        result.Sessions.Single(s => s.SessionId == 2).RemainingProviderAmount.Should().Be(40m);
+        result.Sessions.Single(s => s.SessionId == 3).RemainingProviderAmount.Should().Be(30m);
+
+        // Paid detail: s1 (full, remaining clamped to 0) + s2 (partial, remaining 40).
+        result.PaidInRange.Sessions.Select(s => s.SessionId).Should().Equal(1, 2);
+        var full = result.PaidInRange.Sessions.Single(s => s.SessionId == 1);
+        full.AmountApplied.Should().Be(20m);
+        full.RemainingProviderAmount.Should().Be(0m);
+        var partial = result.PaidInRange.Sessions.Single(s => s.SessionId == 2);
+        partial.AmountApplied.Should().Be(20m);
+        partial.RemainingProviderAmount.Should().Be(40m);
+
+        // Fully-paid rollup counts only remaining <= 0; TotalApplied spans ALL sessions.
+        result.PaidInRange.FullyPaidSessionCount.Should().Be(1);
+        result.PaidInRange.FullyPaidTotal.Should().Be(20m);
+        result.PaidInRange.TotalApplied.Should().Be(40m);
+
+        // Reconciliation invariant: ΣProvider = ΣRemaining (payable) + TotalApplied.
+        var totalProvider = sessions.Sum(s => s.ProviderAmount);
+        var totalRemaining = result.Sessions.Sum(s => s.RemainingProviderAmount);
+        (totalRemaining + result.PaidInRange.TotalApplied).Should().Be(totalProvider);
+    }
+
+    [Fact]
+    public async Task GetProviderSessionsBreakdownAsync_ReturnsEmptyEnvelope_WhenNoSessionsInRange()
+    {
+        var (service, _, _, _) = BuildService();
+
+        var result = await service.GetProviderSessionsBreakdownAsync(TherapistId, new DateOnly(2026, 4, 1), new DateOnly(2026, 4, 30));
+
+        result.Sessions.Should().BeEmpty();
+        result.PaidInRange.Sessions.Should().BeEmpty();
+        result.PaidInRange.FullyPaidSessionCount.Should().Be(0);
+        result.PaidInRange.FullyPaidTotal.Should().Be(0m);
+        result.PaidInRange.TotalApplied.Should().Be(0m);
+    }
+
+    [Fact]
+    public async Task GetProviderSessionsBreakdownAsync_PopulatesPaymentReferences_GroupingMultipleAllocationsPerSession()
+    {
+        // One session covered by two service payments (30 + 30 of 60 -> fully paid).
+        var sessions = new List<TherapySession> { Session(1, 60m) };
+        var existing = new List<SessionServicePayment>
+        {
+            Allocation(1, 88, sessionId: 1, amountApplied: 30m, referenceNumber: "PAYROLL-2026-05", paymentDate: new DateTime(2026, 5, 31)),
+            Allocation(2, 91, sessionId: 1, amountApplied: 30m, referenceNumber: null, paymentDate: new DateTime(2026, 6, 15)),
+        };
+        var (service, _, _, _) = BuildService(completedSessions: sessions, existingAllocations: existing);
+
+        var result = await service.GetProviderSessionsBreakdownAsync(TherapistId, new DateOnly(2026, 4, 1), new DateOnly(2026, 6, 30));
+
+        result.PaidInRange.Sessions.Should().HaveCount(1);
+        var detail = result.PaidInRange.Sessions[0];
+        detail.AmountApplied.Should().Be(60m);
+        detail.PaymentReferences.Should().HaveCount(2);
+
+        var ref1 = detail.PaymentReferences.Single(r => r.ServicePaymentId == 88);
+        ref1.ReferenceNumber.Should().Be("PAYROLL-2026-05");
+        ref1.PaymentDate.Should().Be("2026-05-31");
+        ref1.AmountApplied.Should().Be(30m);
+
+        var ref2 = detail.PaymentReferences.Single(r => r.ServicePaymentId == 91);
+        ref2.ReferenceNumber.Should().Be(string.Empty); // null reference -> empty string
+        ref2.PaymentDate.Should().Be("2026-06-15");
+        ref2.AmountApplied.Should().Be(30m);
+    }
+
+    [Fact]
+    public async Task GetUnpaidProviderSessionsAsync_DelegatesToBreakdown_ReturningExactlyThePayableList()
+    {
+        // Guards batch payroll: the legacy method must return exactly the breakdown's payable list.
+        var sessions = new List<TherapySession>
+        {
+            Session(1, 60m, date: new DateOnly(2026, 4, 5)),
+            Session(2, 60m, date: new DateOnly(2026, 4, 6)),
+            Session(3, 30m, date: new DateOnly(2026, 4, 7)),
+        };
+        var existing = new List<SessionServicePayment>
+        {
+            Allocation(1, 99, sessionId: 1, amountApplied: 60m), // fully paid -> excluded
+            Allocation(2, 99, sessionId: 2, amountApplied: 20m), // partial -> included
+        };
+        var (service, _, _, _) = BuildService(completedSessions: sessions, existingAllocations: existing);
+        var from = new DateOnly(2026, 4, 1);
+        var to = new DateOnly(2026, 4, 30);
+
+        var unpaid = (await service.GetUnpaidProviderSessionsAsync(TherapistId, from, to)).ToList();
+        var breakdown = await service.GetProviderSessionsBreakdownAsync(TherapistId, from, to);
+
+        unpaid.Should().BeEquivalentTo(breakdown.Sessions, o => o.WithStrictOrdering());
+        unpaid.Select(s => s.SessionId).Should().Equal(2, 3);
+        unpaid[0].AlreadyApplied.Should().Be(20m);
+        unpaid[0].RemainingProviderAmount.Should().Be(40m);
+    }
+
+    [Fact]
+    public async Task GetPayrollPreviewAsync_PopulatesPaidContext_AndStillSkipsOnlyPaidTherapists()
+    {
+        // 42 Smith: one fully paid (60) + one partially paid (20 of 60 -> 40 owed)
+        //   -> row with PaidSessionCount 1 (fully paid only) and PaidTotal 80 (all applied money).
+        // 43 Jones: single fully-paid session -> still skipped (paid context rides existing rows only).
+        var sessions = new List<TherapySession>
+        {
+            Session(1, 60m, therapistId: 42), Session(2, 60m, therapistId: 42),
+            Session(3, 100m, therapistId: 43),
+        };
+        var existing = new List<SessionServicePayment>
+        {
+            Allocation(1, 99, sessionId: 1, amountApplied: 60m),
+            Allocation(2, 99, sessionId: 2, amountApplied: 20m),
+            Allocation(3, 99, sessionId: 3, amountApplied: 100m),
+        };
+        var therapists = new List<TherapistProfile>
+        {
+            Therapist(42, "Smith, Jane"), Therapist(43, "Jones, Bob"),
+        };
+        var (service, _, _, _) = BuildService(sessions, existing, therapists);
+
+        var preview = (await service.GetPayrollPreviewAsync(new DateOnly(2026, 4, 1), new DateOnly(2026, 4, 30))).ToList();
+
+        preview.Should().HaveCount(1); // Jones (only-paid) skipped
+        var row = preview[0];
+        row.TherapistName.Should().Be("Smith, Jane");
+        row.SessionCount.Should().Be(1);
+        row.TotalRemaining.Should().Be(40m);
+        row.PaidSessionCount.Should().Be(1);   // fully paid sessions only
+        row.PaidTotal.Should().Be(80m);        // Σ applied across ALL in-range sessions (60 + 20)
+    }
+
     // ---- WP-14.5: reversal -------------------------------------------------
 
     private static ServicePayment OriginalPayment(int id = 500, decimal amount = 120m) => new()


### PR DESCRIPTION
## Summary
- `GET /api/service-payments/unpaid-sessions` now returns an envelope `{ sessions, paidInRange }`: the payable list (element shape unchanged) plus a paid-in-range summary — fully-paid count/total, `totalApplied`, and per-session payment references (id, reference number, date, amount).
- Reconciliation invariant now provable from one response: `Σ providerAmount = Σ remainingProviderAmount + paidInRange.totalApplied` over Completed sessions in range.
- `payroll-preview` rows gain additive `paidSessionCount` / `paidTotal`; the only-owed skip rule is unchanged.
- `GetUnpaidProviderSessionsAsync` delegates to the new breakdown method — batch payroll and all other callers keep identical behavior (guarded by a delegation test).
- `SessionServicePaymentRepository.GetBySessionIdsAsync` now includes the `ServicePayment` nav for reference/date.

## ⚠️ Lockstep deploy
**Breaking response-shape change** on `unpaid-sessions` (array → envelope). Merge and deploy together with `patient-care-ui-vue` PR `feature/wp-20c-paid-in-range` in the same window.

## Origin
Therapist-23 reconciliation question (2026-07-07): UI showed 16 sessions/$363.40 vs raw SQL 20/$448.40 — the 4/$85.00 delta was sessions already settled via `PAYROLL-2026-05`. API was correct; the report just couldn't show it.

## Verification
- `dotnet build` clean, `dotnet test` **332/332 green** (5 new Core.Tests: partitioning, invariant, payment-ref grouping, delegation guard, preview paid context).
- Contract updated first: `patient-care-super` `_contracts/service-payments-api.md` (`ac95839`).
- Curl artifact: `test-scripts/wp-20b-paid-in-range.sh` (origin case expectations encoded).
- Owner tested locally against the WP-20C UI — confirmed working.

Plan: `patient-care-super/planning/active/wp-20-paid-in-range-visibility.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
