### PR TITLE
CORS: pin CloudFront origin to the clinic's distribution (no *.cloudf…

### DIFF
--- a/src/Web/Startup.cs
+++ b/src/Web/Startup.cs
@@ -53,7 +53,10 @@ public class Startup(IConfiguration configuration, IWebHostEnvironment environme
 
                         return host.Contains("neurocorp") ||
                             host.Contains("localhost") ||
-                            host.EndsWith(".cloudfront.net");   // ← Allow CloudFront for Swagger UI in dev/staging, but not production (where we use a custom domain).
+                            // Pinned exact host only — never wildcard *.cloudfront.net: any AWS
+                            // account can mint a distribution under that suffix, and this policy
+                            // also sends AllowCredentials.
+                            host == "d26wxxuffdufr.cloudfront.net";
                     })
                     .AllowAnyHeader()
                     .AllowAnyMethod()

--- a/tests/Web.Tests/CorsPolicyTests.cs
+++ b/tests/Web.Tests/CorsPolicyTests.cs
@@ -1,0 +1,49 @@
+using System.Net;
+using FluentAssertions;
+using Neurocorp.Api.Web.Tests.Authorization;
+
+namespace Neurocorp.Api.Web.Tests;
+
+/// <summary>
+/// CORS origin-allowlist regression tests. *.cloudfront.net must NOT be wildcard-allowed:
+/// any AWS account can mint a distribution under that suffix, and the policy also sends
+/// AllowCredentials. Only the clinic's own pinned distribution host may pass.
+/// Exercises the real pipeline via an anonymous endpoint (health) so only CORS is in play.
+/// </summary>
+public class CorsPolicyTests : IClassFixture<AccessControlTestFactory>
+{
+    private readonly AccessControlTestFactory _factory;
+
+    public CorsPolicyTests(AccessControlTestFactory factory) => _factory = factory;
+
+    private async Task<HttpResponseMessage> GetWithOrigin(string origin)
+    {
+        var client = _factory.CreateClient();
+        var request = new HttpRequestMessage(HttpMethod.Get, "/api/health/checks");
+        request.Headers.Add("Origin", origin);
+        return await client.SendAsync(request);
+    }
+
+    [Theory]
+    [InlineData("https://d26wxxuffdufr.cloudfront.net")]  // the clinic's pinned distribution
+    [InlineData("http://localhost:8080")]                  // local dev UI
+    public async Task AllowedOrigin_GetsCorsHeader(string origin)
+    {
+        var response = await GetWithOrigin(origin);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.Should().ContainKey("Access-Control-Allow-Origin")
+            .WhoseValue.Should().ContainSingle().Which.Should().Be(origin);
+    }
+
+    [Theory]
+    [InlineData("https://d1111attacker.cloudfront.net")]  // arbitrary third-party distribution
+    [InlineData("https://evil.example.com")]
+    public async Task ForeignOrigin_GetsNoCorsHeader(string origin)
+    {
+        var response = await GetWithOrigin(origin);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.Contains("Access-Control-Allow-Origin").Should().BeFalse();
+    }
+}


### PR DESCRIPTION
…ront.net wildcard)

EndsWith('.cloudfront.net') admitted every CloudFront distribution on the internet (any AWS account gets one) while the policy also sends AllowCredentials. Red->green: 4 CORS pipeline tests, the attacker-distribution case failed before the fix. Allowed host pinned to d26wxxuffdufr.cloudfront.net.