### PR TITLE
B3: project primary-caretaker name/phone/email on SessionEvent

### DIFF
--- a/docs/session-caretaker-b3-verification.md
+++ b/docs/session-caretaker-b3-verification.md
@@ -1,0 +1,34 @@
+# B3 verification — caretaker contact info on SessionEvent
+
+Every session endpoint now returns `caretakerName`, `caretakerPhone`, `caretakerEmail`
+(primary caretaker; first link as fallback; `null` when the patient has no caretaker).
+Contract: `patient-care-super/_contracts/sessions-api.md`.
+
+```bash
+# Login (MGR) and capture a token
+TOKEN=$(curl -s -X POST http://localhost:5245/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email":"<mgr-email>","password":"<password>"}' | jq -r '.token')
+
+# 1) Day list (feeds the Appointments views + dashboard panel)
+curl -s http://localhost:5245/api/sessions/2026-07-11/all \
+  -H "Authorization: Bearer $TOKEN" \
+  | jq '.[0] | {sessionId, patient, caretakerName, caretakerPhone, caretakerEmail}'
+
+# 2) Proposed/unconfirmed list (feeds the Proposed tab)
+curl -s http://localhost:5245/api/sessions/unconfirmed \
+  -H "Authorization: Bearer $TOKEN" \
+  | jq '.[0] | {sessionId, patient, caretakerName, caretakerPhone, caretakerEmail}'
+
+# 3) Single session
+curl -s http://localhost:5245/api/sessions/1 \
+  -H "Authorization: Bearer $TOKEN" \
+  | jq '{sessionId, caretakerName, caretakerPhone, caretakerEmail}'
+```
+
+Expected:
+- A patient with a primary caretaker → that caretaker's "Last, First" + phone + email.
+- A patient whose links have no `PrimaryCaretaker=1` → the first linked caretaker.
+- A patient with no caretaker links → all three fields `null` (JSON `null`, not omitted).
+- Synthetic legacy placeholders (`<Name>-SH (LEGACY)`) appear by name with `null` email —
+  that is correct data, not a bug.

--- a/src/Core/BusinessObjects/Sessions/SessionEvent.cs
+++ b/src/Core/BusinessObjects/Sessions/SessionEvent.cs
@@ -36,6 +36,12 @@ public class SessionEvent
     public string? SpecialtyName { get; set; }
     public bool? IsDiscovery { get; set; }
 
+    // B3 (2026-07-07 punch list): primary caretaker contact info for the Session Details panel.
+    // Falls back to the first linked caretaker when none is flagged primary; null when unlinked.
+    public string? CaretakerName { get; set; }
+    public string? CaretakerPhone { get; set; }
+    public string? CaretakerEmail { get; set; }
+
     // WP-17 access-control: ProviderAmount (therapist payout) is confidential — matrix grants
     // Appointments.ProviderAmount to MGR/AM only (FrontDesk excluded). ProviderAmountResultFilter
     // sets this to null for callers lacking that claim, and WhenWritingNull omits the property

--- a/src/Infrastructure/Repositories/SessionEventRepository.cs
+++ b/src/Infrastructure/Repositories/SessionEventRepository.cs
@@ -17,6 +17,10 @@ public class SessionEventRepository(ApplicationDbContext dbContext) :
                          (ts.Therapist != null))
             .Include(ts => ts.Patient)
                 .ThenInclude(p => p!.User)
+            .Include(ts => ts.Patient)
+                .ThenInclude(p => p!.Caretakers)
+                    .ThenInclude(pc => pc.Caretaker)
+                        .ThenInclude(c => c!.User)
             .Include(ts => ts.Therapist)
                 .ThenInclude(t => t!.User)
             .Include(ts => ts.AppointmentStatus)
@@ -35,6 +39,10 @@ public class SessionEventRepository(ApplicationDbContext dbContext) :
                          (ts.SessionDate == targetDate))
             .Include(ts => ts.Patient)
                 .ThenInclude(p => p!.User)
+            .Include(ts => ts.Patient)
+                .ThenInclude(p => p!.Caretakers)
+                    .ThenInclude(pc => pc.Caretaker)
+                        .ThenInclude(c => c!.User)
             .Include(ts => ts.Therapist)
                 .ThenInclude(t => t!.User)
             .Include(ts => ts.AppointmentStatus)
@@ -52,6 +60,10 @@ public class SessionEventRepository(ApplicationDbContext dbContext) :
                          (ts.Therapist != null))
             .Include(ts => ts.Patient)
                 .ThenInclude(p => p!.User)
+            .Include(ts => ts.Patient)
+                .ThenInclude(p => p!.Caretakers)
+                    .ThenInclude(pc => pc.Caretaker)
+                        .ThenInclude(c => c!.User)
             .Include(ts => ts.Therapist)
                 .ThenInclude(t => t!.User)
             .Include(ts => ts.AppointmentStatus)
@@ -78,6 +90,10 @@ public class SessionEventRepository(ApplicationDbContext dbContext) :
         var result = await query
             .Include(ts => ts.Patient)
                 .ThenInclude(p => p!.User)
+            .Include(ts => ts.Patient)
+                .ThenInclude(p => p!.Caretakers)
+                    .ThenInclude(pc => pc.Caretaker)
+                        .ThenInclude(c => c!.User)
             .Include(ts => ts.Therapist)
                 .ThenInclude(t => t!.User)
             .Include(ts => ts.AppointmentStatus)
@@ -94,6 +110,10 @@ public class SessionEventRepository(ApplicationDbContext dbContext) :
         .Where(ts => ts.Id == id)
             .Include(ts => ts.Patient)
                 .ThenInclude(p => p!.User)
+            .Include(ts => ts.Patient)
+                .ThenInclude(p => p!.Caretakers)
+                    .ThenInclude(pc => pc.Caretaker)
+                        .ThenInclude(c => c!.User)
             .Include(ts => ts.Therapist)
                 .ThenInclude(t => t!.User)
             .Include(ts => ts.AppointmentStatus)
@@ -115,6 +135,10 @@ public class SessionEventRepository(ApplicationDbContext dbContext) :
         var therapySessionToUpdate = await _dbContext.TherapySessions
             .Include(ts => ts.Patient)
                 .ThenInclude(p => p!.User)
+            .Include(ts => ts.Patient)
+                .ThenInclude(p => p!.Caretakers)
+                    .ThenInclude(pc => pc.Caretaker)
+                        .ThenInclude(c => c!.User)
             .Include(ts => ts.Therapist)
                 .ThenInclude(t => t!.User)
             .Include(ts => ts.AppointmentStatus)
@@ -166,6 +190,12 @@ public class SessionEventRepository(ApplicationDbContext dbContext) :
 
         var statusName = ts.AppointmentStatus?.Name ?? "Completed";
 
+        // B3: surface the primary caretaker's contact info (first link as fallback).
+        var caretakerUser = ts.Patient!.Caretakers?
+            .OrderByDescending(pc => pc.PrimaryCaretaker)
+            .Select(pc => pc.Caretaker?.User)
+            .FirstOrDefault(u => u != null);
+
         return new SessionEvent
         {
             SessionId = ts.Id,
@@ -192,6 +222,9 @@ public class SessionEventRepository(ApplicationDbContext dbContext) :
             SpecialtyAbbreviation = ts.SpecialtyType?.Abbreviation,
             SpecialtyName = ts.SpecialtyType?.Name,
             IsDiscovery = ts.SpecialtyType?.IsDiscovery,
+            CaretakerName = caretakerUser?.GetFullName(),
+            CaretakerPhone = caretakerUser?.PhoneNumber,
+            CaretakerEmail = caretakerUser?.Email,
             ProviderAmount = ts.ProviderAmount,
         };
     }

--- a/tests/Infrastructure.Tests/SessionEventRepositoryTests.cs
+++ b/tests/Infrastructure.Tests/SessionEventRepositoryTests.cs
@@ -97,8 +97,99 @@ public class SessionEventRepositoryTests
             Assert.Contains(result, se => se.Discount == 20);            
             Assert.Contains(result, se => se.AmountPaid == 90);            
             Assert.Contains(result, se => se.AmountDue == 90);            
-            Assert.Contains(result, se => se.Notes == "Another Session Note");            
-            Assert.Contains(result, se => !se.IsPastDue);            
+            Assert.Contains(result, se => se.Notes == "Another Session Note");
+            Assert.Contains(result, se => !se.IsPastDue);
+        }
+    }
+
+    // B3 (2026-07-07 punch list): Session Details must carry the primary caretaker's
+    // name/phone/email so the Proposed > Session Details panel can display them.
+    [Fact]
+    public async Task GetAllByTargetDateAsync_ProjectsPrimaryCaretakerContactInfo()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: "TestDatabase_B3Caretaker")
+            .Options;
+
+        var targetDateTime = DateTime.UtcNow;
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            context.AppointmentStatuses.Add(new AppointmentStatus { Id = 4, Name = "Completed", Description = "Session took place" });
+
+            var patientWithCaretakers = new Patient
+            {
+                Id = 1,
+                User = new User { FirstName = "John", LastName = "Doe" },
+                Caretakers = new List<PatientCaretaker>
+                {
+                    new PatientCaretaker
+                    {
+                        PatientId = 1,
+                        CaretakerId = 1,
+                        PrimaryCaretaker = false,
+                        Caretaker = new Caretaker
+                        {
+                            Id = 1,
+                            User = new User { FirstName = "Backup", LastName = "Uncle", PhoneNumber = "555-0002", Email = "uncle@example.com" },
+                        },
+                    },
+                    new PatientCaretaker
+                    {
+                        PatientId = 1,
+                        CaretakerId = 2,
+                        PrimaryCaretaker = true,
+                        Caretaker = new Caretaker
+                        {
+                            Id = 2,
+                            User = new User { FirstName = "Mary", LastName = "Doe", PhoneNumber = "555-0001", Email = "mary@example.com" },
+                        },
+                    },
+                },
+            };
+
+            context.TherapySessions.Add(new TherapySession
+            {
+                Id = 1,
+                Patient = patientWithCaretakers,
+                Therapist = new Therapist { Id = 1, User = new User { FirstName = "Jane", LastName = "Smith" } },
+                SessionDate = DateOnly.FromDateTime(targetDateTime),
+                SessionTime = TimeOnly.FromDateTime(targetDateTime),
+                Amount = 100,
+                Notes = "With caretakers"
+            });
+            context.TherapySessions.Add(new TherapySession
+            {
+                Id = 2,
+                Patient = new Patient { Id = 2, User = new User { FirstName = "Alice", LastName = "Wonder" } },
+                Therapist = new Therapist { Id = 2, User = new User { FirstName = "Bob", LastName = "Builder" } },
+                SessionDate = DateOnly.FromDateTime(targetDateTime),
+                SessionTime = TimeOnly.FromDateTime(targetDateTime),
+                Amount = 200,
+                Notes = "No caretakers"
+            });
+            await context.SaveChangesAsync();
+        }
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            var repository = new SessionEventRepository(context);
+
+            var result = await repository.GetAllByTargetDateAsync(DateOnly.FromDateTime(targetDateTime));
+
+            Assert.Equal(2, result.Count);
+
+            // The primary caretaker wins over the non-primary link.
+            var withCaretaker = result.Single(se => se.SessionId == 1);
+            Assert.Equal("Doe, Mary", withCaretaker.CaretakerName);
+            Assert.Equal("555-0001", withCaretaker.CaretakerPhone);
+            Assert.Equal("mary@example.com", withCaretaker.CaretakerEmail);
+
+            // No caretaker links -> nulls, not an exception.
+            var withoutCaretaker = result.Single(se => se.SessionId == 2);
+            Assert.Null(withoutCaretaker.CaretakerName);
+            Assert.Null(withoutCaretaker.CaretakerPhone);
+            Assert.Null(withoutCaretaker.CaretakerEmail);
         }
     }
 }


### PR DESCRIPTION
The Proposed > Session Details panel needs the patient's caretaker contact info, but the SessionEvent chain carried none. Adds caretakerName/caretakerPhone/caretakerEmail to the DTO, includes the Patient.Caretakers -> Caretaker -> User walk in every SessionEvent query, and projects the primary caretaker (first link as fallback, nulls when unlinked). Red-to-green repository regression test; suite 352 green. Contract updated in patient-care-super sessions-api.md.