### PR TITLE
B3 follow-up: booking endpoints missed the caretaker (and specialty) …

### DIFF
--- a/src/Infrastructure/Repositories/BookingRepository.cs
+++ b/src/Infrastructure/Repositories/BookingRepository.cs
@@ -39,9 +39,12 @@ public class BookingRepository : IBookingRepository
         return await _dbContext.TherapySessions
             .Where(ts => ts.Id == sessionId)
             .Include(ts => ts.Patient).ThenInclude(p => p!.User)
+            .Include(ts => ts.Patient).ThenInclude(p => p!.Caretakers)
+                .ThenInclude(pc => pc.Caretaker).ThenInclude(c => c!.User)
             .Include(ts => ts.Therapist).ThenInclude(t => t!.User)
             .Include(ts => ts.AppointmentStatus)
             .Include(ts => ts.Site)
+            .Include(ts => ts.SpecialtyType)
             .Select(ts => MapToSessionEvent(ts))
             .FirstOrDefaultAsync();
     }
@@ -50,9 +53,12 @@ public class BookingRepository : IBookingRepository
     {
         var session = await _dbContext.TherapySessions
             .Include(ts => ts.Patient).ThenInclude(p => p!.User)
+            .Include(ts => ts.Patient).ThenInclude(p => p!.Caretakers)
+                .ThenInclude(pc => pc.Caretaker).ThenInclude(c => c!.User)
             .Include(ts => ts.Therapist).ThenInclude(t => t!.User)
             .Include(ts => ts.AppointmentStatus)
             .Include(ts => ts.Site)
+            .Include(ts => ts.SpecialtyType)
             .FirstOrDefaultAsync(ts => ts.Id == sessionId)
             ?? throw new ArgumentException($"Session {sessionId} not found.");
 
@@ -102,9 +108,12 @@ public class BookingRepository : IBookingRepository
                 && ts.SessionDate >= from && ts.SessionDate <= to
                 && ts.Patient != null && ts.Therapist != null)
             .Include(ts => ts.Patient).ThenInclude(p => p!.User)
+            .Include(ts => ts.Patient).ThenInclude(p => p!.Caretakers)
+                .ThenInclude(pc => pc.Caretaker).ThenInclude(c => c!.User)
             .Include(ts => ts.Therapist).ThenInclude(t => t!.User)
             .Include(ts => ts.AppointmentStatus)
             .Include(ts => ts.Site)
+            .Include(ts => ts.SpecialtyType)
             .OrderBy(ts => ts.SessionDate)
             .ThenBy(ts => ts.SessionTime)
             .Select(ts => MapToSessionEvent(ts))
@@ -119,9 +128,12 @@ public class BookingRepository : IBookingRepository
                 && ts.SessionDate >= from && ts.SessionDate <= to
                 && ts.Patient != null && ts.Therapist != null)
             .Include(ts => ts.Patient).ThenInclude(p => p!.User)
+            .Include(ts => ts.Patient).ThenInclude(p => p!.Caretakers)
+                .ThenInclude(pc => pc.Caretaker).ThenInclude(c => c!.User)
             .Include(ts => ts.Therapist).ThenInclude(t => t!.User)
             .Include(ts => ts.AppointmentStatus)
             .Include(ts => ts.Site)
+            .Include(ts => ts.SpecialtyType)
             .OrderBy(ts => ts.SessionDate)
             .ThenBy(ts => ts.SessionTime)
             .Select(ts => MapToSessionEvent(ts))
@@ -149,6 +161,14 @@ public class BookingRepository : IBookingRepository
     private static SessionEvent MapToSessionEvent(TherapySession ts)
     {
         var statusName = ts.AppointmentStatus?.Name ?? "Completed";
+
+        // B3: surface the primary caretaker's contact info (first link as fallback) —
+        // keep in step with SessionEventRepository.ExtractSessionEvent.
+        var caretakerUser = ts.Patient!.Caretakers?
+            .OrderByDescending(pc => pc.PrimaryCaretaker)
+            .Select(pc => pc.Caretaker?.User)
+            .FirstOrDefault(u => u != null);
+
         return new SessionEvent
         {
             SessionId = ts.Id,
@@ -171,6 +191,13 @@ public class BookingRepository : IBookingRepository
             IsConfirmed = ConfirmedStatuses.Contains(ts.AppointmentStatusId),
             SiteId = ts.SiteId,
             SiteName = ts.Site?.SiteName,
+            SpecialtyTypeId = ts.SpecialtyTypeId,
+            SpecialtyAbbreviation = ts.SpecialtyType?.Abbreviation,
+            SpecialtyName = ts.SpecialtyType?.Name,
+            IsDiscovery = ts.SpecialtyType?.IsDiscovery,
+            CaretakerName = caretakerUser?.GetFullName(),
+            CaretakerPhone = caretakerUser?.PhoneNumber,
+            CaretakerEmail = caretakerUser?.Email,
         };
     }
 }

--- a/tests/Infrastructure.Tests/BookingRepositoryTests.cs
+++ b/tests/Infrastructure.Tests/BookingRepositoryTests.cs
@@ -1,0 +1,170 @@
+using Xunit;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Neurocorp.Api.Core.Entities;
+using Neurocorp.Api.Infrastructure.Data;
+using Neurocorp.Api.Infrastructure.Repositories;
+
+namespace Infrastructure.Tests.Repositories;
+
+public class BookingRepositoryTests
+{
+    // B3 follow-up: the booking endpoints (/unconfirmed, /upcoming, confirm/cancel responses)
+    // are served by BookingRepository's own SessionEvent mapper, which had drifted from the
+    // contract — it carried neither the caretaker fields (B3) nor the WP-9B specialty fields.
+    [Fact]
+    public async Task GetByStatusAndDateRangeAsync_ProjectsCaretakerAndSpecialtyFields()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: "TestDatabase_BookingB3")
+            .Options;
+
+        var targetDateTime = DateTime.UtcNow;
+        var targetDate = DateOnly.FromDateTime(targetDateTime);
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            context.AppointmentStatuses.Add(new AppointmentStatus { Id = 1, Name = "Proposed", Description = "Requested, not yet confirmed" });
+            context.SpecialtyTypes.Add(new SpecialtyType { Id = 14, Abbreviation = "NM", Name = "Neuro Motor", IsDiscovery = false });
+
+            var patientWithCaretakers = new Patient
+            {
+                Id = 1,
+                User = new User { FirstName = "John", LastName = "Doe" },
+                Caretakers = new List<PatientCaretaker>
+                {
+                    new PatientCaretaker
+                    {
+                        PatientId = 1,
+                        CaretakerId = 1,
+                        PrimaryCaretaker = false,
+                        Caretaker = new Caretaker
+                        {
+                            Id = 1,
+                            User = new User { FirstName = "Backup", LastName = "Uncle", PhoneNumber = "555-0002", Email = "uncle@example.com" },
+                        },
+                    },
+                    new PatientCaretaker
+                    {
+                        PatientId = 1,
+                        CaretakerId = 2,
+                        PrimaryCaretaker = true,
+                        Caretaker = new Caretaker
+                        {
+                            Id = 2,
+                            User = new User { FirstName = "Mary", LastName = "Doe", PhoneNumber = "555-0001", Email = "mary@example.com" },
+                        },
+                    },
+                },
+            };
+
+            context.TherapySessions.Add(new TherapySession
+            {
+                Id = 1,
+                Patient = patientWithCaretakers,
+                Therapist = new Therapist { Id = 1, User = new User { FirstName = "Jane", LastName = "Smith" } },
+                SessionDate = targetDate,
+                SessionTime = TimeOnly.FromDateTime(targetDateTime),
+                AppointmentStatusId = 1,
+                SpecialtyTypeId = 14,
+                Amount = 100,
+                Notes = "Proposed with caretakers"
+            });
+            context.TherapySessions.Add(new TherapySession
+            {
+                Id = 2,
+                Patient = new Patient { Id = 2, User = new User { FirstName = "Alice", LastName = "Wonder" } },
+                Therapist = new Therapist { Id = 2, User = new User { FirstName = "Bob", LastName = "Builder" } },
+                SessionDate = targetDate,
+                SessionTime = TimeOnly.FromDateTime(targetDateTime),
+                AppointmentStatusId = 1,
+                Amount = 200,
+                Notes = "Proposed without caretakers"
+            });
+            await context.SaveChangesAsync();
+        }
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            var repository = new BookingRepository(context);
+
+            var result = (await repository.GetByStatusAndDateRangeAsync(1, targetDate, targetDate)).ToList();
+
+            Assert.Equal(2, result.Count);
+
+            var withCaretaker = result.Single(se => se.SessionId == 1);
+            Assert.Equal("Doe, Mary", withCaretaker.CaretakerName);
+            Assert.Equal("555-0001", withCaretaker.CaretakerPhone);
+            Assert.Equal("mary@example.com", withCaretaker.CaretakerEmail);
+            Assert.Equal(14, withCaretaker.SpecialtyTypeId);
+            Assert.Equal("NM", withCaretaker.SpecialtyAbbreviation);
+            Assert.Equal("Neuro Motor", withCaretaker.SpecialtyName);
+            Assert.False(withCaretaker.IsDiscovery);
+
+            var withoutCaretaker = result.Single(se => se.SessionId == 2);
+            Assert.Null(withoutCaretaker.CaretakerName);
+            Assert.Null(withoutCaretaker.CaretakerPhone);
+            Assert.Null(withoutCaretaker.CaretakerEmail);
+        }
+    }
+
+    [Fact]
+    public async Task GetSessionEventByIdAsync_ProjectsCaretakerFields()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: "TestDatabase_BookingB3_ById")
+            .Options;
+
+        var targetDateTime = DateTime.UtcNow;
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            context.AppointmentStatuses.Add(new AppointmentStatus { Id = 1, Name = "Proposed", Description = "Requested" });
+            context.TherapySessions.Add(new TherapySession
+            {
+                Id = 5,
+                Patient = new Patient
+                {
+                    Id = 1,
+                    User = new User { FirstName = "John", LastName = "Doe" },
+                    Caretakers = new List<PatientCaretaker>
+                    {
+                        new PatientCaretaker
+                        {
+                            PatientId = 1,
+                            CaretakerId = 1,
+                            PrimaryCaretaker = true,
+                            Caretaker = new Caretaker
+                            {
+                                Id = 1,
+                                User = new User { FirstName = "Mary", LastName = "Doe", PhoneNumber = "555-0001", Email = "mary@example.com" },
+                            },
+                        },
+                    },
+                },
+                Therapist = new Therapist { Id = 1, User = new User { FirstName = "Jane", LastName = "Smith" } },
+                SessionDate = DateOnly.FromDateTime(targetDateTime),
+                SessionTime = TimeOnly.FromDateTime(targetDateTime),
+                AppointmentStatusId = 1,
+                Amount = 100,
+                Notes = ""
+            });
+            await context.SaveChangesAsync();
+        }
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            var repository = new BookingRepository(context);
+
+            var result = await repository.GetSessionEventByIdAsync(5);
+
+            Assert.NotNull(result);
+            Assert.Equal("Doe, Mary", result!.CaretakerName);
+            Assert.Equal("555-0001", result.CaretakerPhone);
+            Assert.Equal("mary@example.com", result.CaretakerEmail);
+        }
+    }
+}


### PR DESCRIPTION
…projection

/api/sessions/unconfirmed, /upcoming, and the confirm/cancel responses are served by BookingRepository's own SessionEvent mapper, which the B3 change (#103) did not touch — caretaker fields came back null there (found by the B3 curl verification), and the mapper had also never carried the WP-9B specialty fields (contract drift). Adds the Patient.Caretakers->Caretaker->User and SpecialtyType includes to all four query sites and projects both field groups, matching SessionEventRepository.ExtractSessionEvent. Red-to-green BookingRepositoryTests (2 tests); suite 354 green.