### PR TITLE
H2: stamp compile-time build date into the assembly, expose buildTime…

### DIFF
--- a/docs/health-build-date-h2-verification.md
+++ b/docs/health-build-date-h2-verification.md
@@ -1,0 +1,57 @@
+# H2 — API build date on `/api/health/checks` — curl verification
+
+Punch-list item H2 (2026-07-07 meeting): Admin › About › Build Info was missing the REST API
+build date. The Web assembly is now stamped at compile time with an ISO-8601 UTC timestamp
+(MSBuild `AssemblyMetadata`, key `BuildTimestampUtc`, in `src/Web/Web.csproj`), exposed as
+`buildTimeUtc` on the existing anonymous health endpoint. Contract: `health-api.md`.
+
+## 1. Field present and parseable
+
+```bash
+API=http://localhost:5245   # or the deployed base URL
+
+curl -s "$API/api/health/checks" | jq '{version, buildTimeUtc}'
+```
+
+**Expect:** both fields non-null, e.g.
+
+```json
+{
+  "version": "121.0.0.0",
+  "buildTimeUtc": "2026-07-11T18:24:03.1234567Z"
+}
+```
+
+- `buildTimeUtc` parses as ISO-8601 (`date -d` / `DateTimeOffset.Parse` round-trip).
+- `"unknown"` would mean the assembly was built without the csproj metadata (should never
+  happen once this change is in — the stamp needs no CI/build-arg wiring).
+
+## 2. No auth required (unchanged)
+
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" "$API/api/health/checks"
+```
+
+**Expect:** `200` with no Authorization header (HealthController is `[AllowAnonymous]`, K8s probes).
+
+## 3. Sanity: build date coheres with the deployed version
+
+After the next deploy, the timestamp should match the CI run that produced the image tag:
+
+```bash
+curl -s "$API/api/health/checks" | jq -r '.buildTimeUtc'
+# compare against the GitHub Actions run timestamp for the deployed build number
+```
+
+## Rollout note
+
+Older deployed builds (≤ v120) omit `buildTimeUtc` entirely; the UI About panel renders "—"
+for the API-built row until the API is redeployed with this change.
+
+## Automated coverage
+
+- `Web.Tests/HealthControllerTests.cs`
+  - `BuildInfo_TimestampIsStampedAndParseableIso8601Utc` — assembly stamp exists and parses.
+  - `GetHealthChecks_IncludesVersionAndBuildTimeUtc` — controller payload carries it.
+  - `HealthChecksEndpointTests.GetHealthChecks_SerializesBuildTimeUtcInCamelCase` — wire-level
+    JSON through the real host (`AccessControlTestFactory`): camelCase `buildTimeUtc`.

--- a/src/Web/BuildInfo.cs
+++ b/src/Web/BuildInfo.cs
@@ -1,0 +1,17 @@
+using System.Reflection;
+
+namespace Neurocorp.Api.Web;
+
+/// <summary>
+/// Exposes the compile-time build timestamp stamped into the Web assembly by MSBuild
+/// (AssemblyMetadata key "BuildTimestampUtc" in Web.csproj).
+/// </summary>
+public static class BuildInfo
+{
+    public const string MetadataKey = "BuildTimestampUtc";
+
+    public static string BuildTimestampUtc { get; } =
+        typeof(BuildInfo).Assembly
+            .GetCustomAttributes<AssemblyMetadataAttribute>()
+            .FirstOrDefault(a => a.Key == MetadataKey)?.Value ?? "unknown";
+}

--- a/src/Web/Controllers/HealthController.cs
+++ b/src/Web/Controllers/HealthController.cs
@@ -79,6 +79,7 @@ public class HealthController : ControllerBase
         var result = new
         {
             Version = version,
+            BuildTimeUtc = BuildInfo.BuildTimestampUtc,
             Statuses = healthStatuses
         };
 

--- a/src/Web/Web.csproj
+++ b/src/Web/Web.csproj
@@ -7,6 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- H2: compile-time build timestamp, surfaced via /api/health/checks (see BuildInfo.cs).
+         Evaluated when the compiler runs, so an incremental no-op build keeps the prior stamp. -->
+    <AssemblyMetadata Include="BuildTimestampUtc" Value="$([System.DateTime]::UtcNow.ToString('o'))" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.11" />

--- a/tests/Web.Tests/HealthControllerTests.cs
+++ b/tests/Web.Tests/HealthControllerTests.cs
@@ -1,0 +1,87 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Moq;
+using Neurocorp.Api.Web;
+using Neurocorp.Api.Web.Controllers;
+using Neurocorp.Api.Web.Middleware.HealthChecks;
+using Neurocorp.Api.Web.Tests.Authorization;
+
+namespace Web.Tests;
+
+public class HealthControllerTests
+{
+    [Fact]
+    public void BuildInfo_TimestampIsStampedAndParseableIso8601Utc()
+    {
+        // H2: the assembly must carry a compile-time build timestamp
+        // (AssemblyMetadata "BuildTimestampUtc" in Web.csproj).
+        Assert.NotEqual("unknown", BuildInfo.BuildTimestampUtc);
+
+        var parsed = DateTimeOffset.TryParse(
+            BuildInfo.BuildTimestampUtc,
+            System.Globalization.CultureInfo.InvariantCulture,
+            System.Globalization.DateTimeStyles.RoundtripKind,
+            out var timestamp);
+
+        Assert.True(parsed, $"BuildTimestampUtc '{BuildInfo.BuildTimestampUtc}' is not a parseable ISO-8601 timestamp");
+        Assert.Equal(TimeSpan.Zero, timestamp.Offset);
+    }
+
+    [Fact]
+    public async Task GetHealthChecks_IncludesVersionAndBuildTimeUtc()
+    {
+        var healthCheckService = new Mock<HealthCheckService>();
+        healthCheckService
+            .Setup(s => s.CheckHealthAsync(
+                It.IsAny<Func<HealthCheckRegistration, bool>?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new HealthReport(
+                new Dictionary<string, HealthReportEntry>(),
+                TimeSpan.Zero));
+
+        var controller = new HealthController(new StartupHealthCheck(), healthCheckService.Object);
+
+        var response = await controller.GetHealthChecks();
+
+        var ok = Assert.IsType<OkObjectResult>(response);
+        Assert.NotNull(ok.Value);
+        var payloadType = ok.Value!.GetType();
+
+        var version = payloadType.GetProperty("Version")?.GetValue(ok.Value) as string;
+        Assert.False(string.IsNullOrEmpty(version));
+
+        var buildTime = payloadType.GetProperty("BuildTimeUtc")?.GetValue(ok.Value) as string;
+        Assert.Equal(BuildInfo.BuildTimestampUtc, buildTime);
+    }
+}
+
+/// <summary>
+/// Wire-level check through the real host: the UI reads camelCase `buildTimeUtc` off
+/// GET /api/health/checks (contract health-api.md), so assert the serialized JSON, not the
+/// controller's anonymous object.
+/// </summary>
+public class HealthChecksEndpointTests : IClassFixture<AccessControlTestFactory>
+{
+    private readonly AccessControlTestFactory _factory;
+
+    public HealthChecksEndpointTests(AccessControlTestFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task GetHealthChecks_SerializesBuildTimeUtcInCamelCase()
+    {
+        var client = _factory.CreateClient();
+
+        var response = await client.GetAsync("/api/health/checks");
+
+        Assert.Equal(System.Net.HttpStatusCode.OK, response.StatusCode);
+        using var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+
+        Assert.True(json.RootElement.TryGetProperty("version", out _));
+        Assert.True(json.RootElement.TryGetProperty("buildTimeUtc", out var buildTime));
+        Assert.Equal(BuildInfo.BuildTimestampUtc, buildTime.GetString());
+    }
+}


### PR DESCRIPTION
…Utc on /api/health/checks

MSBuild AssemblyMetadata (BuildTimestampUtc) in Web.csproj — no CI/build-arg wiring needed; the Docker publish recompiles and picks it up. BuildInfo.cs reads the attribute; HealthController adds buildTimeUtc next to version. Contract updated (health-api.md). Consumers must tolerate the field being absent from older deployed builds.

Tests: 2 unit + 1 wire-level through AccessControlTestFactory (camelCase
serialization). Suite 356 green. Curls: docs/health-build-date-h2-verification.md