### PR TITLE
WP-21B (F1): paged patient session-history endpoints on Patients.View

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -13,6 +13,8 @@
 | GET | `/api/patients` | List all patients | — | `PatientProfile[]` |
 | GET | `/api/patients/{id}` | Get patient by ID | — | `PatientProfile` |
 | GET | `/api/patients/{id}/pastdue` | Past-due billing summary for a patient | — | `PatientPastDueInfo` |
+| GET | `/api/patients/session-history` | Paged patient summaries by most-recent-session (WP-21; `?search=&page=&pageSize=30`) | — | `PagedResult<PatientSessionHistorySummary>` |
+| GET | `/api/patients/{id}/sessions` | Paged session history, newest first (WP-21; `?page=&pageSize=25&isDiscovery=&status=`; **breaking**: was a bare `SessionEvent[]` — no consumers) | — | `PagedResult<SessionEvent>` |
 | POST | `/api/patients` | Create a new patient | `PatientProfileRequest` | `PatientProfile` (201) |
 | PUT | `/api/patients/{id}` | Update an existing patient | `PatientProfileUpdateRequest` | 204 No Content |
 

--- a/docs/patient-session-history-wp21-verification.md
+++ b/docs/patient-session-history-wp21-verification.md
@@ -1,0 +1,67 @@
+# WP-21B verification — patient session-history endpoints
+
+Both endpoints are gated by `Patients.View` (ACCT/AM/FD/MGR/OWN + SYSADMIN wildcard) and return
+the WP-21 `PagedResult<T>` envelope `{ items, page, pageSize, totalCount }`. Contract:
+`patient-care-super/_contracts/patients-api.md`.
+
+## Setup — mint a token (MGR or SYSADMIN via owner login)
+
+```bash
+BASE=http://localhost:5245            # deployed: http://neurocorp.k3s:30000
+TOKEN=$(curl -s -X POST $BASE/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"username":"<owner-user>","password":"<password>"}' | jq -r '.accessToken')
+# NB: the field is .accessToken (NOT .token — see fix b3-verification-doc-token-field).
+```
+
+## 1. Summary list — paged, most-recent-session first
+
+```bash
+# Default page (30 rows, newest activity first; zero-session patients sort last)
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BASE/api/patients/session-history" | jq '{totalCount, page, pageSize, first: .items[0]}'
+
+# Page 2, and search by name/MRN (case-insensitive)
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BASE/api/patients/session-history?page=2&pageSize=30" | jq '.items | length'
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BASE/api/patients/session-history?search=bennet" | jq '.items[] | {patientName, lastSessionDate, totalSessions}'
+```
+
+**VERIFY:** `totalCount` ≈ the live patient census (866+); `items[0].lastSessionDate` is the most
+recent session date in the DB; a searched patient's `totalSessions` matches
+`SELECT COUNT(*) FROM TherapySession WHERE PatientID = <id>`.
+
+## 2. Per-patient sessions — paged, newest first
+
+```bash
+PID=<patientId from step 1>
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BASE/api/patients/$PID/sessions" | jq '{totalCount, page, count: (.items|length), newest: .items[0].sessionDate, oldest: .items[-1].sessionDate}'
+
+# Page 2 + the pre-existing filters still compose
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BASE/api/patients/$PID/sessions?page=2&pageSize=25" | jq '.items | length'
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BASE/api/patients/$PID/sessions?status=Completed&pageSize=5" | jq '.items[].statusName'
+```
+
+**VERIFY:** items are `sessionDate DESC` (ties broken by `sessionTime`/`sessionId` DESC);
+`totalCount` equals the patient's session count (or the filtered count when `status`/`isDiscovery`
+is supplied); page beyond the end → `items: []` with the real `totalCount`.
+
+## 3. Access control + ProviderAmount shaping
+
+```bash
+# No token → 401
+curl -s -o /dev/null -w "%{http_code}\n" "$BASE/api/patients/session-history"
+
+# MGR/OWN token → providerAmount present on items; FD/ACCT token → the key is absent entirely
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BASE/api/patients/$PID/sessions?pageSize=1" | jq '.items[0] | has("providerAmount")'
+```
+
+**VERIFY:** 401 without a token. With an FD or ACCT token, `has("providerAmount")` is `false`
+(field-shaped by `ProviderAmountResultFilter`, which unwraps the paged envelope); with MGR/OWN it
+is `true`. ACCT/OWN role coverage is proven by integration tests
+(`SensitiveCellAuthorizationTests`) since no ACCT/OWN users exist yet.

--- a/src/Core/BusinessObjects/Common/PagedResult.cs
+++ b/src/Core/BusinessObjects/Common/PagedResult.cs
@@ -1,0 +1,16 @@
+namespace Neurocorp.Api.Core.BusinessObjects.Common;
+
+/// <summary>
+/// Shared pagination envelope — <c>{ items, page, pageSize, totalCount }</c> (WP-21, the
+/// platform's first paged-response convention; reuse for future paged endpoints).
+/// <see cref="Page"/> is 1-based; <see cref="TotalCount"/> is the size of the full filtered set,
+/// not the page. <see cref="Items"/> is deliberately settable so response filters
+/// (e.g. ProviderAmountResultFilter) can swap in a materialized, shaped list.
+/// </summary>
+public class PagedResult<T>
+{
+    public IReadOnlyList<T> Items { get; set; } = [];
+    public int Page { get; set; }
+    public int PageSize { get; set; }
+    public int TotalCount { get; set; }
+}

--- a/src/Core/BusinessObjects/Patients/PatientSessionHistorySummary.cs
+++ b/src/Core/BusinessObjects/Patients/PatientSessionHistorySummary.cs
@@ -1,0 +1,15 @@
+namespace Neurocorp.Api.Core.BusinessObjects.Patients;
+
+/// <summary>
+/// WP-21 (F1): one row of the Patients → Session History tab's patient list — patient identity
+/// plus session-recency aggregates. <see cref="LastSessionDate"/> null with
+/// <see cref="TotalSessions"/> 0 means the patient has never had a session (such rows sort last).
+/// </summary>
+public class PatientSessionHistorySummary
+{
+    public int PatientId { get; set; }
+    public string PatientName { get; set; } = string.Empty;
+    public string? MedicalRecordNumber { get; set; }
+    public DateOnly? LastSessionDate { get; set; }
+    public int TotalSessions { get; set; }
+}

--- a/src/Core/BusinessObjects/Sessions/SessionEvent.cs
+++ b/src/Core/BusinessObjects/Sessions/SessionEvent.cs
@@ -43,7 +43,7 @@ public class SessionEvent
     public string? CaretakerEmail { get; set; }
 
     // WP-17 access-control: ProviderAmount (therapist payout) is confidential — matrix grants
-    // Appointments.ProviderAmount to MGR/AM only (FrontDesk excluded). ProviderAmountResultFilter
+    // Appointments.ProviderAmount to AM/MGR/OWN only (FrontDesk/Accountant excluded). ProviderAmountResultFilter
     // sets this to null for callers lacking that claim, and WhenWritingNull omits the property
     // entirely from the JSON so FD never receives the figure (not just a zeroed value).
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/src/Core/Interfaces/Repositories/IPatientProfileRepository.cs
+++ b/src/Core/Interfaces/Repositories/IPatientProfileRepository.cs
@@ -1,3 +1,4 @@
+using Neurocorp.Api.Core.BusinessObjects.Common;
 using Neurocorp.Api.Core.BusinessObjects.Patients;
 
 namespace Neurocorp.Api.Core.Interfaces.Repositories;
@@ -5,4 +6,7 @@ namespace Neurocorp.Api.Core.Interfaces.Repositories;
 public interface IPatientProfileRepository : IRepository<PatientProfile>
 {
     public Task<PatientProfile> UpdateAsync(int patientId, int userId, PatientProfileUpdateRequest updateRequest);
+    // WP-21 (F1): paged patient summaries ordered most-recent-session first; optional
+    // case-insensitive search on first/last name and MRN.
+    public Task<PagedResult<PatientSessionHistorySummary>> GetSessionHistoryAsync(string? search, int page, int pageSize);
 }

--- a/src/Core/Interfaces/Repositories/ISessionEventRepository.cs
+++ b/src/Core/Interfaces/Repositories/ISessionEventRepository.cs
@@ -1,3 +1,4 @@
+using Neurocorp.Api.Core.BusinessObjects.Common;
 using Neurocorp.Api.Core.BusinessObjects.Sessions;
 using Neurocorp.Api.Core.BusinessObjects.Therapists;
 
@@ -7,6 +8,7 @@ public interface ISessionEventRepository : IRepository<SessionEvent>
 {
     public Task<IReadOnlyList<SessionEvent>> GetAllByTargetDateAsync(DateOnly targetDate);
     public Task<IReadOnlyList<SessionEvent>> GetAllPastDueAsync();
-    public Task<IReadOnlyList<SessionEvent>> GetByPatientIdAsync(int patientId, bool? isDiscovery = null, string? status = null);
+    // WP-21 (F1): paged, newest first (SessionDate/SessionTime/SessionID DESC).
+    public Task<PagedResult<SessionEvent>> GetByPatientIdAsync(int patientId, int page, int pageSize, bool? isDiscovery = null, string? status = null);
     public Task<SessionEvent> UpdateAsync(int therapySessionId, SessionEventUpdateRequest updateRequest);
 }

--- a/src/Core/Interfaces/Services/IPatientProfileService.cs
+++ b/src/Core/Interfaces/Services/IPatientProfileService.cs
@@ -1,3 +1,4 @@
+using Neurocorp.Api.Core.BusinessObjects.Common;
 using Neurocorp.Api.Core.BusinessObjects.Patients;
 
 namespace Neurocorp.Api.Core.Interfaces.Services;
@@ -9,4 +10,6 @@ public interface IPatientProfileService : IService<PatientProfile>
     public Task<bool> UpdateAsync(int patientId, PatientProfileUpdateRequest request);
     public Task<bool> VerifyRequestAsync(int patientAggId);
     Task<IEnumerable<PatientCaretakerSummary>> GetCaretakersForPatientAsync(int patientId);
+    // WP-21 (F1): backs the Patients → Session History tab's paged patient list.
+    Task<PagedResult<PatientSessionHistorySummary>> GetSessionHistoryAsync(string? search, int page, int pageSize);
 }

--- a/src/Core/Services/PatientProfileService.cs
+++ b/src/Core/Services/PatientProfileService.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using Neurocorp.Api.Core.BusinessObjects.Common;
 using Neurocorp.Api.Core.BusinessObjects.Patients;
 using Neurocorp.Api.Core.Entities;
 using Neurocorp.Api.Core.Interfaces;
@@ -147,6 +148,13 @@ public class PatientProfileService : IPatientProfileService
             return true;
         }
         return false;
+    }
+
+    public async Task<PagedResult<PatientSessionHistorySummary>> GetSessionHistoryAsync(string? search, int page, int pageSize)
+    {
+        _logger.LogInformation("Getting patient session-history summaries (search: {Search}, page: {Page}, pageSize: {PageSize}).",
+            search, page, pageSize);
+        return await _repository.GetSessionHistoryAsync(search, page, pageSize);
     }
 
     public async Task<IEnumerable<PatientCaretakerSummary>> GetCaretakersForPatientAsync(int patientId)

--- a/src/Infrastructure/Repositories/PatientProfileRepository.cs
+++ b/src/Infrastructure/Repositories/PatientProfileRepository.cs
@@ -1,4 +1,5 @@
 using Neurocorp.Api.Core.Entities;
+using Neurocorp.Api.Core.BusinessObjects.Common;
 using Neurocorp.Api.Core.BusinessObjects.Patients;
 using Neurocorp.Api.Core.Interfaces.Repositories;
 using Neurocorp.Api.Infrastructure.Data;
@@ -47,6 +48,69 @@ public class PatientProfileRepository(ApplicationDbContext dbContext) :
     public override async Task<PatientProfile> UpdateAsync(PatientProfile entity)
     {
         return await Task.FromException<PatientProfile>(new NotImplementedException());
+    }
+
+    // WP-21 (F1): paged patient summaries for the Session History tab, ordered by
+    // most-recent-session first. Recency/count come from correlated scalar subqueries — they
+    // translate to SQL on every provider (incl. the InMemory test provider), and at this table's
+    // scale (~1k patients / ~11k sessions) they're as good as a grouped join.
+    public async Task<PagedResult<PatientSessionHistorySummary>> GetSessionHistoryAsync(string? search, int page, int pageSize)
+    {
+        var patients = _dbContext.Patients.Where(p => p.User != null);
+
+        if (!string.IsNullOrWhiteSpace(search))
+        {
+            // Explicit ToLower(): MySQL columns are already _ci-collated; this keeps the
+            // InMemory provider (LINQ-to-objects, case-sensitive Contains) behaving identically.
+            var term = search.Trim().ToLower();
+            patients = patients.Where(p =>
+                p.User!.FirstName.ToLower().Contains(term) ||
+                p.User!.LastName.ToLower().Contains(term) ||
+                (p.MedicalRecordNumber != null && p.MedicalRecordNumber.ToLower().Contains(term)));
+        }
+
+        var totalCount = await patients.CountAsync();
+
+        var rows = await patients
+            .Select(p => new
+            {
+                p.Id,
+                p.User!.FirstName,
+                p.User!.LastName,
+                p.User!.MiddleName,
+                p.MedicalRecordNumber,
+                LastSessionDate = _dbContext.TherapySessions
+                    .Where(ts => ts.PatientId == p.Id)
+                    .Max(ts => (DateOnly?)ts.SessionDate),
+                TotalSessions = _dbContext.TherapySessions
+                    .Count(ts => ts.PatientId == p.Id),
+            })
+            // MySQL puts NULLs last under ORDER BY ... DESC, matching .NET's comparer — patients
+            // who never had a session deliberately sort to the end on both providers.
+            .OrderByDescending(x => x.LastSessionDate)
+            .ThenBy(x => x.LastName)
+            .ThenBy(x => x.FirstName)
+            .ThenBy(x => x.Id)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync();
+
+        var items = rows.Select(r => new PatientSessionHistorySummary
+        {
+            PatientId = r.Id,
+            PatientName = $"{r.LastName}, {r.FirstName} {r.MiddleName}".Trim(),
+            MedicalRecordNumber = r.MedicalRecordNumber,
+            LastSessionDate = r.LastSessionDate,
+            TotalSessions = r.TotalSessions,
+        }).ToList();
+
+        return new PagedResult<PatientSessionHistorySummary>
+        {
+            Items = items,
+            Page = page,
+            PageSize = pageSize,
+            TotalCount = totalCount
+        };
     }
 
     public async Task<PatientProfile> UpdateAsync(int patientId, int userId, PatientProfileUpdateRequest updateRequest)

--- a/src/Infrastructure/Repositories/SessionEventRepository.cs
+++ b/src/Infrastructure/Repositories/SessionEventRepository.cs
@@ -1,3 +1,4 @@
+using Neurocorp.Api.Core.BusinessObjects.Common;
 using Neurocorp.Api.Core.BusinessObjects.Sessions;
 using Neurocorp.Api.Core.Interfaces.Repositories;
 using Neurocorp.Api.Infrastructure.Data;
@@ -74,7 +75,7 @@ public class SessionEventRepository(ApplicationDbContext dbContext) :
         return result;
     }
 
-    public async Task<IReadOnlyList<SessionEvent>> GetByPatientIdAsync(int patientId, bool? isDiscovery = null, string? status = null)
+    public async Task<PagedResult<SessionEvent>> GetByPatientIdAsync(int patientId, int page, int pageSize, bool? isDiscovery = null, string? status = null)
     {
         var query = _dbContext.TherapySessions
             .Where(ts => ts.PatientId == patientId &&
@@ -87,7 +88,18 @@ public class SessionEventRepository(ApplicationDbContext dbContext) :
         if (!string.IsNullOrEmpty(status))
             query = query.Where(ts => ts.AppointmentStatus != null && ts.AppointmentStatus.Name == status);
 
-        var result = await query
+        // COUNT(*) over the filters only — no Includes, so no join amplification.
+        var totalCount = await query.CountAsync();
+
+        // WP-21: newest first with deterministic tiebreaks so pages are stable. Ordering and
+        // Skip/Take sit on TherapySession columns and run in SQL; ExtractSessionEvent below is
+        // client-evaluated, so paging MUST stay ahead of that projection.
+        var items = await query
+            .OrderByDescending(ts => ts.SessionDate)
+            .ThenByDescending(ts => ts.SessionTime)
+            .ThenByDescending(ts => ts.Id)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
             .Include(ts => ts.Patient)
                 .ThenInclude(p => p!.User)
             .Include(ts => ts.Patient)
@@ -101,7 +113,14 @@ public class SessionEventRepository(ApplicationDbContext dbContext) :
             .Include(ts => ts.SpecialtyType)
             .Select(ts => ExtractSessionEvent(ts))
             .ToListAsync();
-        return result;
+
+        return new PagedResult<SessionEvent>
+        {
+            Items = items,
+            Page = page,
+            PageSize = pageSize,
+            TotalCount = totalCount
+        };
     }
 
     public override async Task<SessionEvent?> GetByIdAsync(int id)

--- a/src/Web/Authorization/ProviderAmountResultFilter.cs
+++ b/src/Web/Authorization/ProviderAmountResultFilter.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
+using Neurocorp.Api.Core.BusinessObjects.Common;
 using Neurocorp.Api.Core.BusinessObjects.Sessions;
 
 namespace Neurocorp.Api.Web.Authorization;
@@ -10,14 +11,16 @@ namespace Neurocorp.Api.Web.Authorization;
 /// <summary>
 /// WP-17 field-level confidentiality. Strips <see cref="SessionEvent.ProviderAmount"/> (the therapist
 /// payout) from responses when the caller lacks <c>Appointments.ProviderAmount</c> — the access-control
-/// matrix grants that claim to MGR/AM only, so FrontDesk must never receive the figure. Setting the
-/// field to <c>null</c> omits it from the JSON entirely (SessionEvent marks it
+/// matrix grants that claim to AM/MGR/OWN only, so FrontDesk (and Accountant) must never receive the
+/// figure. Setting the field to <c>null</c> omits it from the JSON entirely (SessionEvent marks it
 /// <c>[JsonIgnore(WhenWritingNull)]</c>), making the confidentiality real rather than UI-cosmetic.
 ///
 /// Registered globally (Startup), so it covers every SessionEvent-returning endpoint today and any
-/// added later. All current SessionEvent endpoints are appointments-context, so the governing claim is
-/// <c>Appointments.ProviderAmount</c>. (<c>Dashboard.ProviderAmount</c> is a reserved/future claim with
-/// no endpoint yet; a future dashboard DTO would get its own shaping keyed on that claim.)
+/// added later — including WP-21's <see cref="PagedResult{T}"/>-of-SessionEvent envelope. Note that
+/// endpoint-level gating and this field-level shaping are keyed on different claims: WP-21's
+/// patient-context session reads are reachable via <c>Patients.View</c>, which is exactly why ACCT/FD
+/// get redacted rows there rather than a 403. (<c>Dashboard.ProviderAmount</c> is a reserved/future
+/// claim with no endpoint yet; a future dashboard DTO would get its own shaping keyed on that claim.)
 /// </summary>
 public class ProviderAmountResultFilter : IAsyncResultFilter
 {
@@ -34,7 +37,7 @@ public class ProviderAmountResultFilter : IAsyncResultFilter
     }
 
     private static bool IsSessionEventPayload(object value) =>
-        value is SessionEvent || value is IEnumerable<SessionEvent>;
+        value is SessionEvent || value is IEnumerable<SessionEvent> || value is PagedResult<SessionEvent>;
 
     private static object Redact(object value)
     {
@@ -43,6 +46,16 @@ public class ProviderAmountResultFilter : IAsyncResultFilter
             case SessionEvent single:
                 single.ProviderAmount = null;
                 return single;
+            case PagedResult<SessionEvent> paged:
+                // WP-21: unwrap the paged envelope — a closed type-match (not reflection over
+                // "anything with Items") so the shaped surface stays enumerable and testable.
+                var shapedItems = paged.Items.ToList();
+                foreach (var sessionEvent in shapedItems)
+                {
+                    sessionEvent.ProviderAmount = null;
+                }
+                paged.Items = shapedItems;
+                return paged;
             case IEnumerable<SessionEvent> many:
                 // Materialize so a lazy sequence isn't re-enumerated (unshaped) at serialization time.
                 var list = many.ToList();

--- a/src/Web/Controllers/PatientsController.cs
+++ b/src/Web/Controllers/PatientsController.cs
@@ -88,19 +88,46 @@ public class PatientsController : ControllerBase
         return Ok(caretakers);
     }
 
-    // WP-17 (D-8): cross-resource read gated by the data's own domain claim (Appointments.View) —
-    // these are the patient's session/appointment rows. AM/FD/MGR.
-    [HttpGet("{patientId}/sessions")]
-    [Authorize(Policy = AuthPolicy.PermissionPrefix + Permissions.AppointmentsView)]
-    [ProducesResponseType(typeof(IEnumerable<SessionEvent>), StatusCodes.Status200OK)]
+    // WP-21 (F1): paged patient summaries ordered by most-recent-session first — backs the
+    // Patients → Session History tab's patient list.
+    [HttpGet("session-history")]
+    [Authorize(Policy = AuthPolicy.PermissionPrefix + Permissions.PatientsView)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(PagedResult<PatientSessionHistorySummary>))]
+    public async Task<IActionResult> GetPatientSessionHistory(
+        [FromQuery] string? search = null,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 30)
+    {
+        var (safePage, safeSize) = ClampPaging(page, pageSize, defaultPageSize: 30);
+        var result = await _patientProfileService.GetSessionHistoryAsync(search, safePage, safeSize);
+        return Ok(result);
+    }
+
+    // WP-21 (F1 ruling — supersedes WP-17 D-8 for patient-context session reads): gated by the
+    // PATIENT domain claim (Patients.View: ACCT/AM/FD/MGR/OWN) so the Session History tab's whole
+    // audience can read a patient's sessions; Appointments.View would exclude ACCT. ProviderAmount
+    // confidentiality stays field-level — ProviderAmountResultFilter shapes the paged envelope too.
+    [HttpGet("{patientId:int}/sessions")]
+    [Authorize(Policy = AuthPolicy.PermissionPrefix + Permissions.PatientsView)]
+    [ProducesResponseType(typeof(PagedResult<SessionEvent>), StatusCodes.Status200OK)]
     public async Task<IActionResult> GetPatientSessions(
         int patientId,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 25,
         [FromQuery] bool? isDiscovery = null,
         [FromQuery] string? status = null)
     {
-        var sessions = await _sessionEventRepository.GetByPatientIdAsync(patientId, isDiscovery, status);
+        var (safePage, safeSize) = ClampPaging(page, pageSize, defaultPageSize: 25);
+        var sessions = await _sessionEventRepository.GetByPatientIdAsync(patientId, safePage, safeSize, isDiscovery, status);
         return Ok(sessions);
     }
+
+    private const int MaxPageSize = 100;
+
+    // Lenient clamping (silent, not 400) matches the API's existing query-param style; the
+    // pageSize ceiling keeps "?pageSize=100000" from re-creating the unpaged endpoint.
+    private static (int Page, int PageSize) ClampPaging(int page, int pageSize, int defaultPageSize) =>
+        (Math.Max(1, page), pageSize < 1 ? defaultPageSize : Math.Min(pageSize, MaxPageSize));
 
     [HttpPost]
     [Authorize(Policy = AuthPolicy.PermissionPrefix + Permissions.PatientsEdit)]

--- a/tests/Infrastructure.Tests/PatientSessionHistoryRepositoryTests.cs
+++ b/tests/Infrastructure.Tests/PatientSessionHistoryRepositoryTests.cs
@@ -1,0 +1,141 @@
+using Xunit;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Neurocorp.Api.Core.Entities;
+using Neurocorp.Api.Infrastructure.Data;
+using Neurocorp.Api.Infrastructure.Repositories;
+
+namespace Infrastructure.Tests.Repositories;
+
+/// <summary>
+/// WP-21 (F1): PatientProfileRepository.GetSessionHistoryAsync — the paged patient-summary query
+/// behind the Session History tab's patient list. The InMemory provider validates the
+/// shape/ordering/search logic; the SQL translation itself is exercised against real MySQL via
+/// the curl verification doc (correlated scalar subqueries translate on both providers).
+/// </summary>
+public class PatientSessionHistoryRepositoryTests
+{
+    private static DbContextOptions<ApplicationDbContext> Options(string name) =>
+        new DbContextOptionsBuilder<ApplicationDbContext>().UseInMemoryDatabase(databaseName: name).Options;
+
+    private static Patient NewPatient(int id, string first, string last, string? mrn = null) =>
+        new() { Id = id, MedicalRecordNumber = mrn, User = new User { FirstName = first, LastName = last } };
+
+    private static TherapySession NewSession(int id, int patientId, DateOnly date) => new()
+    {
+        Id = id,
+        PatientId = patientId,
+        TherapistId = 1,
+        SessionDate = date,
+        SessionTime = new TimeOnly(9, 0),
+        Amount = 100,
+    };
+
+    private static async Task Seed(DbContextOptions<ApplicationDbContext> options)
+    {
+        using var context = new ApplicationDbContext(options);
+        context.AppointmentStatuses.Add(new AppointmentStatus { Id = 4, Name = "Completed", Description = "Session took place" });
+
+        // ANDERSON: 3 sessions, newest 2026-07-01 (most recent overall).
+        // BENNET:   1 session on 2026-06-15.
+        // CORONADO: 2 sessions, newest 2026-06-15 — ties BENNET on date, breaks on last name.
+        // DOE:      zero sessions — must sort last with null date / 0 count.
+        context.Patients.AddRange(
+            NewPatient(1, "Amy", "Anderson", "L24-0001"),
+            NewPatient(2, "Neya", "Bennet", "L25-0034"),
+            NewPatient(3, "Luis", "Coronado", "L24-0201"),
+            NewPatient(4, "Jane", "Doe", "TEMP-4"));
+        context.TherapySessions.AddRange(
+            NewSession(1, 1, new DateOnly(2026, 3, 1)),
+            NewSession(2, 1, new DateOnly(2026, 7, 1)),
+            NewSession(3, 1, new DateOnly(2026, 5, 1)),
+            NewSession(4, 2, new DateOnly(2026, 6, 15)),
+            NewSession(5, 3, new DateOnly(2026, 6, 15)),
+            NewSession(6, 3, new DateOnly(2026, 1, 10)));
+        await context.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task OrdersByRecency_ZeroSessionPatientsLast_WithAggregates()
+    {
+        var options = Options("Wp21Summary_Ordering");
+        await Seed(options);
+
+        using var context = new ApplicationDbContext(options);
+        var repository = new PatientProfileRepository(context);
+
+        var result = await repository.GetSessionHistoryAsync(search: null, page: 1, pageSize: 30);
+
+        Assert.Equal(4, result.TotalCount);
+        Assert.Equal(
+            new[] { "Anderson, Amy", "Bennet, Neya", "Coronado, Luis", "Doe, Jane" },
+            result.Items.Select(r => r.PatientName).ToArray());
+
+        var anderson = result.Items[0];
+        Assert.Equal(1, anderson.PatientId);
+        Assert.Equal("L24-0001", anderson.MedicalRecordNumber);
+        Assert.Equal(new DateOnly(2026, 7, 1), anderson.LastSessionDate);
+        Assert.Equal(3, anderson.TotalSessions);
+
+        var doe = result.Items[3];
+        Assert.Null(doe.LastSessionDate);
+        Assert.Equal(0, doe.TotalSessions);
+    }
+
+    [Fact]
+    public async Task Paging_IsStable_AndTotalCountConstant()
+    {
+        var options = Options("Wp21Summary_Paging");
+        await Seed(options);
+
+        using var context = new ApplicationDbContext(options);
+        var repository = new PatientProfileRepository(context);
+
+        var page1 = await repository.GetSessionHistoryAsync(null, page: 1, pageSize: 2);
+        var page2 = await repository.GetSessionHistoryAsync(null, page: 2, pageSize: 2);
+
+        Assert.Equal(4, page1.TotalCount);
+        Assert.Equal(4, page2.TotalCount);
+        Assert.Equal(new[] { 1, 2 }, page1.Items.Select(r => r.PatientId).ToArray());
+        Assert.Equal(new[] { 3, 4 }, page2.Items.Select(r => r.PatientId).ToArray());
+
+        var beyond = await repository.GetSessionHistoryAsync(null, page: 9, pageSize: 2);
+        Assert.Empty(beyond.Items);
+        Assert.Equal(4, beyond.TotalCount);
+    }
+
+    [Theory]
+    [InlineData("neya", 2)]        // first name, case-insensitive
+    [InlineData("BENNET", 2)]      // last name, case-insensitive
+    [InlineData("l25-0034", 2)]    // MRN, case-insensitive
+    public async Task Search_MatchesNameAndMrn_CaseInsensitively(string term, int expectedPatientId)
+    {
+        var options = Options($"Wp21Summary_Search_{term}");
+        await Seed(options);
+
+        using var context = new ApplicationDbContext(options);
+        var repository = new PatientProfileRepository(context);
+
+        var result = await repository.GetSessionHistoryAsync(term, page: 1, pageSize: 30);
+
+        Assert.Equal(1, result.TotalCount);
+        Assert.Equal(expectedPatientId, Assert.Single(result.Items).PatientId);
+    }
+
+    [Fact]
+    public async Task Search_NoMatch_ReturnsEmptyWithZeroCount()
+    {
+        var options = Options("Wp21Summary_SearchEmpty");
+        await Seed(options);
+
+        using var context = new ApplicationDbContext(options);
+        var repository = new PatientProfileRepository(context);
+
+        var result = await repository.GetSessionHistoryAsync("zzz-no-such-patient", page: 1, pageSize: 30);
+
+        Assert.Empty(result.Items);
+        Assert.Equal(0, result.TotalCount);
+    }
+}

--- a/tests/Infrastructure.Tests/SessionEventRepositoryTests.cs
+++ b/tests/Infrastructure.Tests/SessionEventRepositoryTests.cs
@@ -102,6 +102,134 @@ public class SessionEventRepositoryTests
         }
     }
 
+    // ── WP-21 (F1): GetByPatientIdAsync paging ───────────────────────────────────────
+
+    private static TherapySession Session(int id, int patientId, Patient patient, Therapist therapist,
+        DateOnly date, TimeOnly time, decimal amount = 100) => new()
+    {
+        Id = id,
+        PatientId = patientId,
+        Patient = patient,
+        Therapist = therapist,
+        SessionDate = date,
+        SessionTime = time,
+        Amount = amount,
+    };
+
+    [Fact]
+    public async Task GetByPatientIdAsync_PagesNewestFirst_WithStableTiebreaks()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: "TestDatabase_Wp21Paging")
+            .Options;
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            context.AppointmentStatuses.Add(new AppointmentStatus { Id = 4, Name = "Completed", Description = "Session took place" });
+            var patient = new Patient { Id = 1, User = new User { FirstName = "John", LastName = "Doe" } };
+            var therapist = new Therapist { Id = 1, User = new User { FirstName = "Jane", LastName = "Smith" } };
+
+            // Three dates + a same-date/different-time pair + a same-date/same-time id tie.
+            context.TherapySessions.AddRange(
+                Session(1, 1, patient, therapist, new DateOnly(2026, 5, 1), new TimeOnly(9, 0)),
+                Session(2, 1, patient, therapist, new DateOnly(2026, 7, 1), new TimeOnly(9, 0)),
+                Session(3, 1, patient, therapist, new DateOnly(2026, 7, 1), new TimeOnly(14, 0)),
+                Session(4, 1, patient, therapist, new DateOnly(2026, 6, 1), new TimeOnly(9, 0)),
+                Session(5, 1, patient, therapist, new DateOnly(2026, 7, 1), new TimeOnly(14, 0)));
+            await context.SaveChangesAsync();
+        }
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            var repository = new SessionEventRepository(context);
+
+            // Newest first: date DESC, time DESC, id DESC → 5, 3, 2, 4, 1.
+            var page1 = await repository.GetByPatientIdAsync(1, page: 1, pageSize: 2);
+            Assert.Equal(5, page1.TotalCount);
+            Assert.Equal(1, page1.Page);
+            Assert.Equal(2, page1.PageSize);
+            Assert.Equal(new[] { 5, 3 }, page1.Items.Select(se => se.SessionId).ToArray());
+
+            var page2 = await repository.GetByPatientIdAsync(1, page: 2, pageSize: 2);
+            Assert.Equal(5, page2.TotalCount);
+            Assert.Equal(new[] { 2, 4 }, page2.Items.Select(se => se.SessionId).ToArray());
+
+            var page3 = await repository.GetByPatientIdAsync(1, page: 3, pageSize: 2);
+            Assert.Equal(new[] { 1 }, page3.Items.Select(se => se.SessionId).ToArray());
+        }
+    }
+
+    [Fact]
+    public async Task GetByPatientIdAsync_FiltersAndTotalCountAgree()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: "TestDatabase_Wp21Filters")
+            .Options;
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            context.AppointmentStatuses.AddRange(
+                new AppointmentStatus { Id = 4, Name = "Completed", Description = "Session took place" },
+                new AppointmentStatus { Id = 8, Name = "Cancelled", Description = "Session cancelled" });
+            var patient = new Patient { Id = 1, User = new User { FirstName = "John", LastName = "Doe" } };
+            var therapist = new Therapist { Id = 1, User = new User { FirstName = "Jane", LastName = "Smith" } };
+
+            var completed = Session(1, 1, patient, therapist, new DateOnly(2026, 7, 1), new TimeOnly(9, 0));
+            completed.AppointmentStatusId = 4;
+            var cancelled = Session(2, 1, patient, therapist, new DateOnly(2026, 7, 2), new TimeOnly(9, 0));
+            cancelled.AppointmentStatusId = 8;
+            var otherPatientSession = Session(3, 2,
+                new Patient { Id = 2, User = new User { FirstName = "Alice", LastName = "Wonder" } },
+                therapist, new DateOnly(2026, 7, 3), new TimeOnly(9, 0));
+            otherPatientSession.AppointmentStatusId = 4;
+
+            context.TherapySessions.AddRange(completed, cancelled, otherPatientSession);
+            await context.SaveChangesAsync();
+        }
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            var repository = new SessionEventRepository(context);
+
+            // status filter narrows both the items AND the totalCount (not the patient's full set).
+            var filtered = await repository.GetByPatientIdAsync(1, page: 1, pageSize: 25, status: "Completed");
+            Assert.Equal(1, filtered.TotalCount);
+            Assert.Equal(1, Assert.Single(filtered.Items).SessionId);
+
+            var unfiltered = await repository.GetByPatientIdAsync(1, page: 1, pageSize: 25);
+            Assert.Equal(2, unfiltered.TotalCount);
+        }
+    }
+
+    [Fact]
+    public async Task GetByPatientIdAsync_PageBeyondEnd_ReturnsEmptyItemsWithTotalCount()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: "TestDatabase_Wp21BeyondEnd")
+            .Options;
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            context.AppointmentStatuses.Add(new AppointmentStatus { Id = 4, Name = "Completed", Description = "Session took place" });
+            context.TherapySessions.Add(Session(1, 1,
+                new Patient { Id = 1, User = new User { FirstName = "John", LastName = "Doe" } },
+                new Therapist { Id = 1, User = new User { FirstName = "Jane", LastName = "Smith" } },
+                new DateOnly(2026, 7, 1), new TimeOnly(9, 0)));
+            await context.SaveChangesAsync();
+        }
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            var repository = new SessionEventRepository(context);
+
+            var result = await repository.GetByPatientIdAsync(1, page: 5, pageSize: 25);
+
+            Assert.Empty(result.Items);
+            Assert.Equal(1, result.TotalCount);
+            Assert.Equal(5, result.Page);
+        }
+    }
+
     // B3 (2026-07-07 punch list): Session Details must carry the primary caretaker's
     // name/phone/email so the Proposed > Session Details panel can display them.
     [Fact]

--- a/tests/Web.Tests/Authorization/ProviderAmountShapingTests.cs
+++ b/tests/Web.Tests/Authorization/ProviderAmountShapingTests.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Routing;
 using Neurocorp.Api.Core.Authorization;
+using Neurocorp.Api.Core.BusinessObjects.Common;
 using Neurocorp.Api.Core.BusinessObjects.Sessions;
 using Neurocorp.Api.Web.Authorization;
 using Xunit;
@@ -117,6 +118,70 @@ public class ProviderAmountShapingTests
         var payload = new { Secret = "keep-me" };
         var result = await RunFilter(FrontDesk(), payload);
         result.Value.Should().BeSameAs(payload);
+    }
+
+    // ── WP-21: the PagedResult<SessionEvent> envelope must be shaped too ─────────────
+    // The WP-21 endpoints are reachable via Patients.View, so principals like ACCT/FD hit them
+    // WITHOUT Appointments.ProviderAmount — the envelope arm is what keeps the payout confidential.
+
+    private static PagedResult<SessionEvent> Envelope(params decimal?[] providerAmounts) => new()
+    {
+        Items = providerAmounts.Select(pa => new SessionEvent { ProviderAmount = pa }).ToList(),
+        Page = 2,
+        PageSize = 25,
+        TotalCount = 132,
+    };
+
+    // ACCT-shaped principal: holds Patients.View (reaches the WP-21 endpoints) but no ProviderAmount claim.
+    private static ClaimsPrincipal PatientsViewOnly() =>
+        Principal(new Claim(SystemClaims.PermissionClaimType, "Patients.View"));
+
+    [Fact]
+    public async Task FrontDesk_paged_envelope_items_are_redacted()
+    {
+        var result = await RunFilter(FrontDesk(), Envelope(10m, 20m));
+        ((PagedResult<SessionEvent>)result.Value!).Items.Should().OnlyContain(e => e.ProviderAmount == null);
+    }
+
+    [Fact]
+    public async Task PatientsView_only_principal_paged_envelope_is_redacted()
+    {
+        var result = await RunFilter(PatientsViewOnly(), Envelope(50m));
+        ((PagedResult<SessionEvent>)result.Value!).Items.Should().OnlyContain(e => e.ProviderAmount == null);
+    }
+
+    [Fact]
+    public async Task Manager_paged_envelope_keeps_ProviderAmount()
+    {
+        var result = await RunFilter(Manager(), Envelope(99m));
+        ((PagedResult<SessionEvent>)result.Value!).Items.Single().ProviderAmount.Should().Be(99m);
+    }
+
+    [Fact]
+    public async Task Wildcard_paged_envelope_keeps_ProviderAmount()
+    {
+        var result = await RunFilter(Wildcard(), Envelope(99m));
+        ((PagedResult<SessionEvent>)result.Value!).Items.Single().ProviderAmount.Should().Be(99m);
+    }
+
+    [Fact]
+    public async Task Paged_envelope_metadata_survives_redaction()
+    {
+        var result = await RunFilter(FrontDesk(), Envelope(10m, 20m));
+        var paged = (PagedResult<SessionEvent>)result.Value!;
+        paged.Page.Should().Be(2);
+        paged.PageSize.Should().Be(25);
+        paged.TotalCount.Should().Be(132);
+        paged.Items.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task Paged_envelope_of_other_type_is_untouched()
+    {
+        var payload = new PagedResult<string> { Items = ["keep-me"], Page = 1, PageSize = 30, TotalCount = 1 };
+        var result = await RunFilter(FrontDesk(), payload);
+        result.Value.Should().BeSameAs(payload);
+        ((PagedResult<string>)result.Value!).Items.Single().Should().Be("keep-me");
     }
 
     // ── serialization: null ⇒ property omitted entirely ──────────────────────────────

--- a/tests/Web.Tests/Authorization/SensitiveCellAuthorizationTests.cs
+++ b/tests/Web.Tests/Authorization/SensitiveCellAuthorizationTests.cs
@@ -36,6 +36,11 @@ namespace Neurocorp.Api.Web.Tests.Authorization;
 ///   TreatmentPlans.Edit   [AM,MGR]      PUT  /api/treatment-plans/{id} (content edit; FD denied)
 ///   TreatmentPlans.Book   [AM,FD,MGR]   POST /api/treatment-plans, POST …/{id}/schedule,
 ///                                       PUT …/{id}/activate|complete|cancel (FD retains setup)
+///
+/// WP-21 (F1) — patient session history rides Patients.View (supersedes D-8 for these reads):
+///   Patients.View [ACCT,AM,FD,MGR,OWN]  GET /api/patients/session-history,
+///                                       GET /api/patients/{id}/sessions
+///   (the ACCT rows are the F1 proof — ACCT lacks Appointments.View, the endpoint's old gate)
 /// </summary>
 public class SensitiveCellAuthorizationTests : IClassFixture<AccessControlTestFactory>
 {
@@ -76,6 +81,9 @@ public class SensitiveCellAuthorizationTests : IClassFixture<AccessControlTestFa
     // ServicePayments.Adjust [MGR] (WP-14.5) — reversing a disbursement is MGR-only; AM (view-only) and FD denied.
     [InlineData("POST", "/api/service-payments/1/reverse", "AM")]
     [InlineData("POST", "/api/service-payments/1/reverse", "FD")]
+    // Patients.View (WP-21, F1) — restricted roles hold no granular claims ⇒ locked out.
+    [InlineData("GET", "/api/patients/session-history", "CARETAKER")]
+    [InlineData("GET", "/api/patients/1/sessions", "CARETAKER")]
     public async Task RoleWithoutClaim_Is403(string method, string route, string role)
     {
         var response = await SendAsync(method, route, TokenFor(role));
@@ -124,6 +132,14 @@ public class SensitiveCellAuthorizationTests : IClassFixture<AccessControlTestFa
     // ServicePayments.Adjust [MGR] (WP-14.5) — MGR may reverse; SYSADMIN via wildcard.
     [InlineData("POST", "/api/service-payments/1/reverse", "MGR")]
     [InlineData("POST", "/api/service-payments/1/reverse", "SYSADMIN")]
+    // Patients.View (WP-21, F1) — the whole Session History audience gets through; the ACCT rows
+    // would have failed under the endpoint's pre-WP-21 gate (Appointments.View, which ACCT lacks).
+    [InlineData("GET", "/api/patients/session-history", "ACCT")]
+    [InlineData("GET", "/api/patients/session-history", "FD")]
+    [InlineData("GET", "/api/patients/session-history", "OWN")]
+    [InlineData("GET", "/api/patients/session-history", "SYSADMIN")]
+    [InlineData("GET", "/api/patients/1/sessions", "ACCT")]
+    [InlineData("GET", "/api/patients/1/sessions", "FD")]
     public async Task RoleWithClaim_IsNotBlocked(string method, string route, string role)
     {
         var response = await SendAsync(method, route, TokenFor(role));
@@ -139,6 +155,7 @@ public class SensitiveCellAuthorizationTests : IClassFixture<AccessControlTestFa
     [InlineData("POST", "/api/sites")]
     [InlineData("GET", "/api/caretakers/1/statement")]
     [InlineData("GET", "/api/patients/pastdue")]
+    [InlineData("GET", "/api/patients/session-history")]
     public async Task NoToken_Is401(string method, string route)
     {
         var response = await SendAsync(method, route, token: null);

--- a/tests/Web.Tests/PatientsControllerTests.cs
+++ b/tests/Web.Tests/PatientsControllerTests.cs
@@ -6,6 +6,7 @@ using Neurocorp.Api.Core.Interfaces.Services;
 using Neurocorp.Api.Web.Controllers;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Neurocorp.Api.Core.BusinessObjects.Common;
 using Neurocorp.Api.Core.BusinessObjects.Sessions;
 using Neurocorp.Api.Core.Interfaces.Repositories;
 using FluentAssertions;
@@ -49,6 +50,79 @@ public class PatientsControllerTests
         var okResult = Assert.IsType<OkObjectResult>(result);
         var returnedPatients = Assert.IsType<List<PatientProfile>>(okResult.Value);
         Assert.Equal(mockPatients.Count, returnedPatients.Count);
+    }
+
+    // ── WP-21 (F1): paged session-history endpoints ──────────────────────────────────
+
+    [Fact]
+    public async Task GetPatientSessionHistory_ReturnsOk_WithPagedResult()
+    {
+        var envelope = new PagedResult<PatientSessionHistorySummary>
+        {
+            Items = new List<PatientSessionHistorySummary> { new() { PatientId = 7 } },
+            Page = 1,
+            PageSize = 30,
+            TotalCount = 1,
+        };
+        _mockPatientProfileService
+            .Setup(s => s.GetSessionHistoryAsync("doe", 1, 30))
+            .ReturnsAsync(envelope);
+
+        var result = await _controller.GetPatientSessionHistory("doe", 1, 30);
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var returned = Assert.IsType<PagedResult<PatientSessionHistorySummary>>(okResult.Value);
+        returned.Should().BeSameAs(envelope);
+        _mockPatientProfileService.Verify(s => s.GetSessionHistoryAsync("doe", 1, 30), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetPatientSessionHistory_ClampsPagingParams()
+    {
+        _mockPatientProfileService
+            .Setup(s => s.GetSessionHistoryAsync(null, It.IsAny<int>(), It.IsAny<int>()))
+            .ReturnsAsync(new PagedResult<PatientSessionHistorySummary>());
+
+        // page 0 → 1; pageSize 9999 → the 100 ceiling; pageSize 0 → the 30 default.
+        await _controller.GetPatientSessionHistory(null, page: 0, pageSize: 9999);
+        _mockPatientProfileService.Verify(s => s.GetSessionHistoryAsync(null, 1, 100), Times.Once);
+
+        await _controller.GetPatientSessionHistory(null, page: 3, pageSize: 0);
+        _mockPatientProfileService.Verify(s => s.GetSessionHistoryAsync(null, 3, 30), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetPatientSessions_ReturnsOk_WithPagedResult()
+    {
+        var envelope = new PagedResult<SessionEvent>
+        {
+            Items = new List<SessionEvent> { new() { SessionId = 42 } },
+            Page = 2,
+            PageSize = 25,
+            TotalCount = 132,
+        };
+        _mockSessionEventRepository
+            .Setup(r => r.GetByPatientIdAsync(7, 2, 25, null, null))
+            .ReturnsAsync(envelope);
+
+        var result = await _controller.GetPatientSessions(7, page: 2, pageSize: 25);
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var returned = Assert.IsType<PagedResult<SessionEvent>>(okResult.Value);
+        returned.Should().BeSameAs(envelope);
+        _mockSessionEventRepository.Verify(r => r.GetByPatientIdAsync(7, 2, 25, null, null), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetPatientSessions_ClampsPagingParams_AndForwardsFilters()
+    {
+        _mockSessionEventRepository
+            .Setup(r => r.GetByPatientIdAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<bool?>(), It.IsAny<string?>()))
+            .ReturnsAsync(new PagedResult<SessionEvent>());
+
+        await _controller.GetPatientSessions(7, page: -5, pageSize: 400, isDiscovery: true, status: "Completed");
+
+        _mockSessionEventRepository.Verify(r => r.GetByPatientIdAsync(7, 1, 100, true, "Completed"), Times.Once);
     }
 
     [Fact]


### PR DESCRIPTION
- GET /api/patients/session-history: paged patient summaries (search, 30/page) ordered by most-recent-session first; zero-session patients sort last.
- GET /api/patients/{id}/sessions: converted to PagedResult<SessionEvent>
  (25/page, newest first w/ time+id tiebreaks); claim retargeted Appointments.View -> Patients.View per the F1 ruling (supersedes WP-17 D-8 for patient-context session reads) so ACCT can reach it. Breaking envelope change; endpoint had zero consumers.
- New PagedResult<T> envelope (first pagination convention in the platform).
- ProviderAmountResultFilter gains a PagedResult<SessionEvent> arm so the envelope cannot leak ProviderAmount to FD/ACCT; stale MGR/AM-only doc fixed.
- Tests: 385 green (was 357) incl. ACCT/OWN/FD/CARETAKER access rows and envelope-shaping cases. Curl doc: docs/patient-session-history-wp21-verification.md