### PR TITLE
WP-22B: duplicate-patient merge endpoints (Patients.Merge, SYSADMIN-o…

### DIFF
--- a/docs/access-control-matrix.json
+++ b/docs/access-control-matrix.json
@@ -1,9 +1,9 @@
 {
   "_meta": {
-    "generatedAt": "2026-07-11T15:16:15-05:00",
+    "generatedAt": "2026-07-11T20:33:41-05:00",
     "generator": "tools/generate-access-manifest.sh",
     "hashScope": "sha256 (first 12 hex) of canonical JSON {claims:[{claim,grants}]}, claims+grants sorted; wildcard/restricted cells and all metadata excluded",
-    "semanticHash": "776a7665d67b",
+    "semanticHash": "6c42b5362fbc",
     "source": "access-control-matrix.md"
   },
   "claims": [
@@ -188,6 +188,10 @@
         "FD",
         "MGR"
       ]
+    },
+    {
+      "claim": "Patients.Merge",
+      "grants": []
     },
     {
       "claim": "Patients.StartDiscovery",

--- a/docs/patient-merge-wp22-verification.md
+++ b/docs/patient-merge-wp22-verification.md
@@ -1,0 +1,125 @@
+# WP-22B verification — duplicate-patient merge endpoints
+
+Both endpoints are gated by `Patients.Merge` — an **empty-grants** matrix row (hash
+`6c42b5362fbc`): only the SYSADMIN `System/FullAccess` wildcard satisfies it, so **every**
+granular role (MGR/AM/FD/OWN/ACCT) gets 403. Contract:
+`patient-care-super/_contracts/patients-api.md` § WP-22.
+
+⚠️ **These curls are the primary proof for the two `ExecuteUpdateAsync` bulk repoints**
+(TherapySession / TreatmentPlan `PatientID`) — the InMemory test provider cannot execute them,
+so they have no unit-test coverage by design. Run the full sequence against a **rehearsal DB
+(prod dump in a `mysql:8` container)** first, exactly like the WP-19 promotion rehearsals.
+
+## Setup — mint a SYSADMIN token
+
+```bash
+BASE=http://localhost:5245            # deployed: http://neurocorp.k3s:30000
+TOKEN=$(curl -s -X POST $BASE/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"username":"<sysadmin-user>","password":"<password>"}' | jq -r '.accessToken')
+# NB: the field is .accessToken (NOT .token).
+```
+
+Pick a real duplicate pair (see `patient-care-db tools/legacy-import/caretaker-backfill-2024.md`
+§3 — e.g. MATHIAS BULTRON PID 359 survives, MATIAS BULTRON PID 360 eliminated), or create two
+throwaway patients via `POST /api/patients` on the rehearsal DB.
+
+```bash
+SURVIVOR=<survivorPatientId>
+ELIMINATED=<eliminatedPatientId>
+```
+
+## 1. Access control
+
+```bash
+# No token → 401
+curl -s -o /dev/null -w "%{http_code}\n" -X POST "$BASE/api/patients/merge/preview" \
+  -H "Content-Type: application/json" -d "{\"survivorPatientId\":$SURVIVOR,\"eliminatedPatientId\":$ELIMINATED}"
+
+# MGR token → 403 on BOTH routes (mint MGR_TOKEN via an MGR login)
+curl -s -o /dev/null -w "%{http_code}\n" -X POST "$BASE/api/patients/merge/preview" \
+  -H "Authorization: Bearer $MGR_TOKEN" -H "Content-Type: application/json" \
+  -d "{\"survivorPatientId\":$SURVIVOR,\"eliminatedPatientId\":$ELIMINATED}"
+curl -s -o /dev/null -w "%{http_code}\n" -X POST "$BASE/api/patients/merge" \
+  -H "Authorization: Bearer $MGR_TOKEN" -H "Content-Type: application/json" \
+  -d "{\"survivorPatientId\":$SURVIVOR,\"eliminatedPatientId\":$ELIMINATED}"
+```
+
+**VERIFY:** 401 / 403 / 403.
+
+## 2. Validation errors
+
+```bash
+# Same IDs → 400
+curl -s -X POST "$BASE/api/patients/merge/preview" -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" -d "{\"survivorPatientId\":$SURVIVOR,\"eliminatedPatientId\":$SURVIVOR}" | jq '{status, detail}'
+
+# Missing patient → 404 (message names which side)
+curl -s -X POST "$BASE/api/patients/merge/preview" -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" -d "{\"survivorPatientId\":$SURVIVOR,\"eliminatedPatientId\":999999}" | jq '{status, detail}'
+```
+
+## 3. Preview (side-effect-free)
+
+```bash
+curl -s -X POST "$BASE/api/patients/merge/preview" -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{\"survivorPatientId\":$SURVIVOR,\"eliminatedPatientId\":$ELIMINATED}" | jq .
+```
+
+**VERIFY:**
+- `counts.sessionsToRemap` == `SELECT COUNT(*) FROM TherapySession WHERE PatientID = $ELIMINATED;`
+- `counts.plansToRemap` == the same count on `TreatmentPlan`.
+- `caretakers[]` dispositions make sense (synthetic `-SH (LEGACY)` → `retire-synthetic` when the
+  survivor keeps a caretaker; shared caretaker → `dedupe-delete`).
+- `blockers` is `[]` for a clean pair.
+- Re-running the preview changes **nothing** (row counts identical before/after).
+
+## 4. Execute — pre/post SQL proof of the ExecuteUpdate repoints
+
+```sql
+-- PRE (record these)
+SELECT COUNT(*) FROM TherapySession WHERE PatientID = <ELIMINATED>;   -- expect N > 0
+SELECT COUNT(*) FROM TherapySession WHERE PatientID = <SURVIVOR>;     -- expect M
+SELECT COUNT(*) FROM TherapySession;                                  -- expect T (conservation)
+SELECT COUNT(*) FROM TreatmentPlan  WHERE PatientID IN (<SURVIVOR>,<ELIMINATED>);
+SELECT COUNT(*) FROM PatientMergeLog;                                 -- expect L
+```
+
+```bash
+curl -s -X POST "$BASE/api/patients/merge" -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{\"survivorPatientId\":$SURVIVOR,\"eliminatedPatientId\":$ELIMINATED}" | jq .
+```
+
+```sql
+-- POST
+SELECT COUNT(*) FROM TherapySession WHERE PatientID = <ELIMINATED>;   -- expect 0
+SELECT COUNT(*) FROM TherapySession WHERE PatientID = <SURVIVOR>;     -- expect M + N
+SELECT COUNT(*) FROM TherapySession;                                  -- expect T (unchanged)
+SELECT * FROM Patient    WHERE PatientID = <ELIMINATED>;              -- expect empty (hard-deleted)
+SELECT * FROM SystemUser WHERE UserID   = <eliminated UserID>;        -- expect empty (retired)
+SELECT * FROM UserRole   WHERE UserID   = <eliminated UserID>;        -- expect empty
+SELECT COUNT(*) FROM PatientMergeLog;                                 -- expect L + 1
+SELECT * FROM PatientMergeLog ORDER BY PatientMergeLogID DESC LIMIT 1;
+  -- expect: counts == the curl result, Eliminated* snapshot populated, MergedByUserId = your user
+SELECT Notes FROM Patient WHERE PatientID = <SURVIVOR>;               -- expect a [MERGED: ...] marker
+-- Audit columns stamped by the bulk repoint (ExecuteUpdate sets them explicitly):
+SELECT LastUpdatedByUserId, COUNT(*) FROM TherapySession
+WHERE  PatientID = <SURVIVOR> AND LastUpdatedByUserId = <your UserID> GROUP BY 1;
+```
+
+## 5. API-level post-checks
+
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" -H "Authorization: Bearer $TOKEN" "$BASE/api/patients/$ELIMINATED"   # 404
+curl -s -H "Authorization: Bearer $TOKEN" "$BASE/api/patients/$SURVIVOR" | jq '{patientId, patientName, cedula, dateOfBirth}'
+curl -s -H "Authorization: Bearer $TOKEN" "$BASE/api/patients/$SURVIVOR/sessions" | jq '.totalCount'   # M + N
+curl -s -H "Authorization: Bearer $TOKEN" "$BASE/api/patients/$SURVIVOR/caretakers" | jq 'length'      # per preview
+```
+
+## 6. Blocker path (409)
+
+On the rehearsal DB, give the eliminated patient's SystemUser an extra role
+(`INSERT INTO UserRole (UserID, RoleID) VALUES (<eliminated UserID>, 3);`) and re-run preview →
+`blockers` non-empty; execute → **409** with the same message. Remove the row afterwards.

--- a/src/Core/BusinessObjects/Patients/PatientMergePreview.cs
+++ b/src/Core/BusinessObjects/Patients/PatientMergePreview.cs
@@ -1,0 +1,64 @@
+namespace Neurocorp.Api.Core.BusinessObjects.Patients;
+
+/// <summary>
+/// Dry-run result of a duplicate-patient merge (WP-22): identity summaries of both records,
+/// exactly what would move/be deleted, which blank survivor fields would be filled, plus
+/// warnings (informational) and blockers (execute would 409). Computed by the same plan step
+/// the execute path runs, so preview and result counts always agree.
+/// </summary>
+public class PatientMergePreview
+{
+    public PatientMergeIdentity Survivor { get; set; } = new();
+    public PatientMergeIdentity Eliminated { get; set; } = new();
+    public PatientMergePlannedCounts Counts { get; set; } = new();
+    public IReadOnlyList<PatientMergeCaretakerDisposition> Caretakers { get; set; } = [];
+    public IReadOnlyList<PatientMergeFieldFill> FieldFills { get; set; } = [];
+    public IReadOnlyList<string> Warnings { get; set; } = [];
+    public IReadOnlyList<string> Blockers { get; set; } = [];
+}
+
+/// <summary>Identity card for one side of the merge, as shown in the confirmation UI.</summary>
+public class PatientMergeIdentity
+{
+    public int PatientId { get; set; }
+    public int UserId { get; set; }
+    public string PatientName { get; set; } = string.Empty;
+    public string? MedicalRecordNumber { get; set; }
+    public string? Cedula { get; set; }
+    public DateTime? DateOfBirth { get; set; }
+    public string? Gender { get; set; }
+    public bool IsActive { get; set; }
+    public int SessionCount { get; set; }
+    public int PlanCount { get; set; }
+    public int CaretakerCount { get; set; }
+}
+
+public class PatientMergePlannedCounts
+{
+    public int SessionsToRemap { get; set; }
+    public int PlansToRemap { get; set; }
+    public int CaretakerLinksToRemap { get; set; }
+    public int CaretakerLinksToDedupe { get; set; }
+    public int SyntheticCaretakersToDelete { get; set; }
+}
+
+/// <summary>What the merge does with one of the eliminated record's caretaker links.</summary>
+public class PatientMergeCaretakerDisposition
+{
+    public const string Remap = "remap";
+    public const string DedupeDelete = "dedupe-delete";
+    public const string RetireSynthetic = "retire-synthetic";
+
+    public int CaretakerId { get; set; }
+    public string CaretakerName { get; set; } = string.Empty;
+    public bool IsSynthetic { get; set; }
+    public string Disposition { get; set; } = Remap;
+    public bool PrimaryFlagDropped { get; set; }
+}
+
+/// <summary>A blank survivor field that inherits the eliminated record's value.</summary>
+public class PatientMergeFieldFill
+{
+    public string Field { get; set; } = string.Empty;
+    public string Value { get; set; } = string.Empty;
+}

--- a/src/Core/BusinessObjects/Patients/PatientMergeRequest.cs
+++ b/src/Core/BusinessObjects/Patients/PatientMergeRequest.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Neurocorp.Api.Core.BusinessObjects.Patients;
+
+/// <summary>Request body for both merge endpoints (WP-22): preview and execute.</summary>
+public class PatientMergeRequest
+{
+    [Range(1, int.MaxValue)]
+    public int SurvivorPatientId { get; set; }
+
+    [Range(1, int.MaxValue)]
+    public int EliminatedPatientId { get; set; }
+}

--- a/src/Core/BusinessObjects/Patients/PatientMergeResult.cs
+++ b/src/Core/BusinessObjects/Patients/PatientMergeResult.cs
@@ -1,0 +1,21 @@
+namespace Neurocorp.Api.Core.BusinessObjects.Patients;
+
+/// <summary>Outcome of an executed duplicate-patient merge (WP-22) — actual counts.</summary>
+public class PatientMergeResult
+{
+    public int SurvivorPatientId { get; set; }
+    public int EliminatedPatientId { get; set; }
+    public int MergeLogId { get; set; }
+    public PatientMergeExecutedCounts Counts { get; set; } = new();
+    public IReadOnlyList<string> FieldsFilled { get; set; } = [];
+    public DateTime MergedAtUtc { get; set; }
+}
+
+public class PatientMergeExecutedCounts
+{
+    public int SessionsRemapped { get; set; }
+    public int PlansRemapped { get; set; }
+    public int CaretakerLinksRemapped { get; set; }
+    public int CaretakerLinksDeduped { get; set; }
+    public int SyntheticCaretakersDeleted { get; set; }
+}

--- a/src/Core/Configurations/Dependencies.cs
+++ b/src/Core/Configurations/Dependencies.cs
@@ -28,6 +28,7 @@ public static class NeurocorpConfigurationExtensions
         services.AddScoped<ITreatmentPlanService, TreatmentPlanService>();
         services.AddScoped<IBulkSchedulingService, BulkSchedulingService>();
         services.AddScoped<IScheduleMatrixService, ScheduleMatrixService>();
+        services.AddScoped<IPatientMergeService, PatientMergeService>();
 
         // Authentication / authorization (Chunk 1B). Token + current-user
         // implementations live in the Web layer (composition root) because they

--- a/src/Core/Entities/PatientMergeLog.cs
+++ b/src/Core/Entities/PatientMergeLog.cs
@@ -1,0 +1,26 @@
+namespace Neurocorp.Api.Core.Entities;
+
+/// <summary>
+/// Append-only audit row for a duplicate-patient merge (WP-22). The eliminated patient's
+/// Patient and SystemUser rows are hard-deleted in the same transaction that writes this row,
+/// so the Eliminated* columns are identity snapshots with deliberately no FK. Maps to the
+/// <c>PatientMergeLog</c> table created in migration V025.
+/// </summary>
+public class PatientMergeLog : AuditableEntityBase
+{
+    public int SurvivorPatientId { get; set; }
+    public int EliminatedPatientId { get; set; }
+    public int EliminatedUserId { get; set; }
+    public string EliminatedName { get; set; } = string.Empty;
+    public string? EliminatedMrn { get; set; }
+    public string? EliminatedCedula { get; set; }
+    public DateTime? EliminatedDateOfBirth { get; set; }
+    public string? EliminatedNotes { get; set; }
+    public int SessionsRemapped { get; set; }
+    public int PlansRemapped { get; set; }
+    public int CaretakerLinksRemapped { get; set; }
+    public int CaretakerLinksDeduped { get; set; }
+    public int SyntheticCaretakersDeleted { get; set; }
+    public string? FieldsFilled { get; set; }
+    public int MergedByUserId { get; set; }
+}

--- a/src/Core/Exceptions/ConflictException.cs
+++ b/src/Core/Exceptions/ConflictException.cs
@@ -1,0 +1,12 @@
+namespace Neurocorp.Api.Core.Exceptions;
+
+/// <summary>
+/// Thrown by the domain/service layer when a request is well-formed and the resources exist,
+/// but domain state forbids the operation (e.g. merging a patient whose SystemUser holds
+/// non-Patient roles). The global exception handler maps this to a 409 ProblemDetails —
+/// the domain-driven sibling of the DbUpdateException/1062 duplicate-key 409.
+/// </summary>
+public class ConflictException : Exception
+{
+    public ConflictException(string message) : base(message) { }
+}

--- a/src/Core/Interfaces/Repositories/IPatientMergeRepository.cs
+++ b/src/Core/Interfaces/Repositories/IPatientMergeRepository.cs
@@ -1,0 +1,35 @@
+using Neurocorp.Api.Core.Entities;
+
+namespace Neurocorp.Api.Core.Interfaces.Repositories;
+
+/// <summary>
+/// Data access for the duplicate-patient merge (WP-22). Deliberately its own interface: the
+/// merge needs by-user reads (roles, claims, therapist/caretaker identity checks) and bulk FK
+/// repoints that no existing repository exposes. All mutating members are called inside the
+/// merge's single IUnitOfWork transaction.
+/// </summary>
+public interface IPatientMergeRepository
+{
+    Task<Patient?> GetPatientWithUserAsync(int patientId);
+    Task<IReadOnlyList<UserRole>> GetUserRolesAsync(int userId);
+    Task<bool> IsTherapistUserAsync(int userId);
+    Task<bool> IsCaretakerUserAsync(int userId);
+    /// <summary>Caretaker links for a patient, with Caretaker.User and Caretaker.Notes loaded.</summary>
+    Task<IReadOnlyList<PatientCaretaker>> GetCaretakerLinksAsync(int patientId);
+    Task<int> CountSessionsAsync(int patientId);
+    Task<int> CountTreatmentPlansAsync(int patientId);
+
+    /// <summary>Bulk-repoints TherapySession.PatientID (ExecuteUpdate — MySQL only, not InMemory).</summary>
+    Task<int> ReassignSessionsAsync(int fromPatientId, int toPatientId, int mergedByUserId);
+    /// <summary>Bulk-repoints TreatmentPlan.PatientID (ExecuteUpdate — MySQL only, not InMemory).</summary>
+    Task<int> ReassignTreatmentPlansAsync(int fromPatientId, int toPatientId, int mergedByUserId);
+
+    Task UpdateCaretakerLinkAsync(PatientCaretaker link);
+    Task DeleteCaretakerLinkAsync(PatientCaretaker link);
+    Task DeleteCaretakerAsync(Caretaker caretaker);
+    Task UpdatePatientAsync(Patient patient);
+    Task DeletePatientAsync(Patient patient);
+    /// <summary>Retires a SystemUser: deletes its UserRole rows, then UserClaim rows, then the user.</summary>
+    Task DeleteUserIdentityAsync(int userId);
+    Task<PatientMergeLog> AddMergeLogAsync(PatientMergeLog log);
+}

--- a/src/Core/Interfaces/Services/IPatientMergeService.cs
+++ b/src/Core/Interfaces/Services/IPatientMergeService.cs
@@ -1,0 +1,17 @@
+using Neurocorp.Api.Core.BusinessObjects.Patients;
+
+namespace Neurocorp.Api.Core.Interfaces.Services;
+
+/// <summary>
+/// Duplicate-patient merge (WP-22, SYSADMIN-only): remap every relationship from the
+/// eliminated record onto the survivor, enrich the survivor's blank fields, write the audit
+/// trail, and hard-delete the eliminated Patient + SystemUser.
+/// </summary>
+public interface IPatientMergeService
+{
+    /// <summary>Side-effect-free dry-run; blockers non-empty means Merge would throw ConflictException.</summary>
+    Task<PatientMergePreview> PreviewAsync(PatientMergeRequest request);
+
+    /// <summary>Executes the merge in one transaction. Throws ConflictException on any blocker.</summary>
+    Task<PatientMergeResult> MergeAsync(PatientMergeRequest request);
+}

--- a/src/Core/Services/PatientMergeService.cs
+++ b/src/Core/Services/PatientMergeService.cs
@@ -1,0 +1,339 @@
+using Microsoft.Extensions.Logging;
+using Neurocorp.Api.Core.BusinessObjects.Patients;
+using Neurocorp.Api.Core.Entities;
+using Neurocorp.Api.Core.Exceptions;
+using Neurocorp.Api.Core.Interfaces;
+using Neurocorp.Api.Core.Interfaces.Repositories;
+using Neurocorp.Api.Core.Interfaces.Services;
+
+namespace Neurocorp.Api.Core.Services;
+
+/// <summary>
+/// Duplicate-patient merge (WP-22, SYSADMIN-only). Preview and execute share one plan step so
+/// their counts always agree; execute runs the whole remap + hard-delete inside a single
+/// IUnitOfWork transaction — any failure rolls everything back.
+/// </summary>
+public class PatientMergeService : IPatientMergeService
+{
+    // Greppable prefix on Caretaker.Notes identifying WP-19 placeholder caretakers
+    // (see patient-care-db tools/legacy-import/importer/caretaker_backfill.py).
+    private const string SyntheticCaretakerNotesPrefix = "SYNTHETIC placeholder";
+    private const int PatientRoleId = 2;
+
+    private readonly IPatientMergeRepository _repository;
+    private readonly ICurrentUserService _currentUser;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly ILogger<PatientMergeService> _logger;
+
+    public PatientMergeService(
+        ILogger<PatientMergeService> logger,
+        IPatientMergeRepository repository,
+        ICurrentUserService currentUser,
+        IUnitOfWork unitOfWork)
+    {
+        _logger = logger;
+        _repository = repository;
+        _currentUser = currentUser;
+        _unitOfWork = unitOfWork;
+    }
+
+    public async Task<PatientMergePreview> PreviewAsync(PatientMergeRequest request)
+    {
+        var (survivor, eliminated) = await LoadPairAsync(request);
+        return await BuildPlanAsync(survivor, eliminated);
+    }
+
+    public async Task<PatientMergeResult> MergeAsync(PatientMergeRequest request)
+    {
+        var mergedByUserId = _currentUser.UserId ?? 0;
+
+        var (result, logId) = await _unitOfWork.ExecuteAsync(async () =>
+        {
+            // Load + plan INSIDE the transaction so validation and mutation see one snapshot.
+            var (survivor, eliminated) = await LoadPairAsync(request);
+            var plan = await BuildPlanAsync(survivor, eliminated);
+            if (plan.Blockers.Count > 0)
+            {
+                throw new ConflictException(string.Join(" ", plan.Blockers));
+            }
+
+            // 1. Caretaker link surgery — deletes first (frees the (PatientID, CaretakerID)
+            //    unique key), then remaps; synthetic retirements queue their identity.
+            var eliminatedLinks = await _repository.GetCaretakerLinksAsync(eliminated.Id);
+            var survivorLinks = await _repository.GetCaretakerLinksAsync(survivor.Id);
+            var survivorHasPrimary = survivorLinks.Any(l => l.PrimaryCaretaker);
+            var identitiesToRetire = new List<int>();
+            int remapped = 0, deduped = 0, syntheticsDeleted = 0;
+
+            var dispositionByLinkId = plan.Caretakers.ToDictionary(c => c.CaretakerId, c => c);
+            foreach (var link in eliminatedLinks)
+            {
+                var disposition = dispositionByLinkId[link.CaretakerId].Disposition;
+                if (disposition == PatientMergeCaretakerDisposition.DedupeDelete)
+                {
+                    await _repository.DeleteCaretakerLinkAsync(link);
+                    deduped++;
+                }
+                else if (disposition == PatientMergeCaretakerDisposition.RetireSynthetic)
+                {
+                    await _repository.DeleteCaretakerLinkAsync(link);
+                    if (link.Caretaker is not null)
+                    {
+                        if (link.Caretaker.User is not null) identitiesToRetire.Add(link.Caretaker.User.Id);
+                        await _repository.DeleteCaretakerAsync(link.Caretaker);
+                    }
+                    syntheticsDeleted++;
+                }
+                else
+                {
+                    link.PatientId = survivor.Id;
+                    if (link.PrimaryCaretaker && survivorHasPrimary)
+                    {
+                        link.PrimaryCaretaker = false; // survivor's designation wins
+                    }
+                    survivorHasPrimary |= link.PrimaryCaretaker;
+                    await _repository.UpdateCaretakerLinkAsync(link);
+                    remapped++;
+                }
+            }
+
+            // 2 + 3. Bulk FK repoints (row counts are the audit-log figures).
+            var sessionsRemapped = await _repository.ReassignSessionsAsync(eliminated.Id, survivor.Id, mergedByUserId);
+            var plansRemapped = await _repository.ReassignTreatmentPlansAsync(eliminated.Id, survivor.Id, mergedByUserId);
+
+            // 4. Snapshot, then hard-delete the eliminated Patient row. Deleting BEFORE the
+            //    survivor enrichment frees uq_patient_cedula for a Cedula fill.
+            var snapshot = new PatientMergeLog
+            {
+                SurvivorPatientId = survivor.Id,
+                EliminatedPatientId = eliminated.Id,
+                EliminatedUserId = eliminated.User!.Id,
+                EliminatedName = eliminated.User.GetFullName(),
+                EliminatedMrn = eliminated.MedicalRecordNumber,
+                EliminatedCedula = eliminated.Cedula,
+                EliminatedDateOfBirth = eliminated.DateOfBirth,
+                EliminatedNotes = eliminated.Notes,
+                MergedByUserId = mergedByUserId,
+            };
+            await _repository.DeletePatientAsync(eliminated);
+
+            // 5. Enrich the survivor (fill-blanks) + append the Notes audit marker.
+            var fieldsFilled = plan.FieldFills.Select(f => f.Field).ToList();
+            foreach (var fill in plan.FieldFills)
+            {
+                switch (fill.Field)
+                {
+                    case nameof(Patient.DateOfBirth): survivor.DateOfBirth = snapshot.EliminatedDateOfBirth; break;
+                    case nameof(Patient.Cedula): survivor.Cedula = snapshot.EliminatedCedula; break;
+                    case nameof(Patient.Gender): survivor.Gender = eliminated.Gender; break;
+                    case nameof(Patient.Notes): survivor.Notes = snapshot.EliminatedNotes; break;
+                }
+            }
+            var marker = BuildMergedMarker(snapshot, sessionsRemapped, plansRemapped,
+                remapped, deduped, syntheticsDeleted, fieldsFilled);
+            survivor.Notes = string.IsNullOrWhiteSpace(survivor.Notes) ? marker : $"{survivor.Notes}\n{marker}";
+            await _repository.UpdatePatientAsync(survivor);
+
+            // 6. Audit row (actual counts).
+            snapshot.SessionsRemapped = sessionsRemapped;
+            snapshot.PlansRemapped = plansRemapped;
+            snapshot.CaretakerLinksRemapped = remapped;
+            snapshot.CaretakerLinksDeduped = deduped;
+            snapshot.SyntheticCaretakersDeleted = syntheticsDeleted;
+            snapshot.FieldsFilled = fieldsFilled.Count > 0 ? string.Join(",", fieldsFilled) : null;
+            var log = await _repository.AddMergeLogAsync(snapshot);
+
+            // 7. Retire identities: the eliminated patient's SystemUser + every deleted
+            //    synthetic caretaker's SystemUser (roles → claims → user; fix-b1 order).
+            await _repository.DeleteUserIdentityAsync(snapshot.EliminatedUserId);
+            foreach (var userId in identitiesToRetire)
+            {
+                await _repository.DeleteUserIdentityAsync(userId);
+            }
+
+            var mergeResult = new PatientMergeResult
+            {
+                SurvivorPatientId = survivor.Id,
+                EliminatedPatientId = snapshot.EliminatedPatientId,
+                Counts = new PatientMergeExecutedCounts
+                {
+                    SessionsRemapped = sessionsRemapped,
+                    PlansRemapped = plansRemapped,
+                    CaretakerLinksRemapped = remapped,
+                    CaretakerLinksDeduped = deduped,
+                    SyntheticCaretakersDeleted = syntheticsDeleted,
+                },
+                FieldsFilled = fieldsFilled,
+                MergedAtUtc = DateTime.UtcNow,
+            };
+            return (mergeResult, log.Id);
+        });
+
+        result.MergeLogId = logId;
+        _logger.LogInformation(
+            "Patient merge executed: survivor {SurvivorId} absorbed {EliminatedId} " +
+            "(sessions {Sessions}, plans {Plans}, links remapped {Remapped}/deduped {Deduped}/synthetic {Synthetic}) by user {UserId}, log {LogId}",
+            result.SurvivorPatientId, result.EliminatedPatientId, result.Counts.SessionsRemapped,
+            result.Counts.PlansRemapped, result.Counts.CaretakerLinksRemapped, result.Counts.CaretakerLinksDeduped,
+            result.Counts.SyntheticCaretakersDeleted, mergedByUserId, logId);
+        return result;
+    }
+
+    private async Task<(Patient Survivor, Patient Eliminated)> LoadPairAsync(PatientMergeRequest request)
+    {
+        if (request.SurvivorPatientId == request.EliminatedPatientId)
+        {
+            throw new ArgumentException("Survivor and eliminated patient must be different records.");
+        }
+        var survivor = await _repository.GetPatientWithUserAsync(request.SurvivorPatientId)
+            ?? throw new NotFoundException("Survivor patient", request.SurvivorPatientId);
+        var eliminated = await _repository.GetPatientWithUserAsync(request.EliminatedPatientId)
+            ?? throw new NotFoundException("Eliminated patient", request.EliminatedPatientId);
+        return (survivor, eliminated);
+    }
+
+    /// <summary>Read-only plan shared by preview and execute — performs no writes.</summary>
+    private async Task<PatientMergePreview> BuildPlanAsync(Patient survivor, Patient eliminated)
+    {
+        var warnings = new List<string>();
+        var blockers = new List<string>();
+
+        // Blockers: the eliminated identity must be a pure Patient — anything else is a
+        // hand-curated situation the hard-delete must not steamroll.
+        var eliminatedRoles = await _repository.GetUserRolesAsync(eliminated.User!.Id);
+        if (eliminatedRoles.Any(r => r.RoleId != PatientRoleId))
+        {
+            blockers.Add($"Eliminated patient's user {eliminated.User.Id} holds non-Patient roles; resolve manually before merging.");
+        }
+        if (await _repository.IsTherapistUserAsync(eliminated.User.Id))
+        {
+            blockers.Add($"Eliminated patient's user {eliminated.User.Id} is also a Therapist identity; resolve manually before merging.");
+        }
+        if (await _repository.IsCaretakerUserAsync(eliminated.User.Id))
+        {
+            blockers.Add($"Eliminated patient's user {eliminated.User.Id} is also a Caretaker identity; resolve manually before merging.");
+        }
+
+        // Caretaker link classification.
+        var survivorLinks = await _repository.GetCaretakerLinksAsync(survivor.Id);
+        var eliminatedLinks = await _repository.GetCaretakerLinksAsync(eliminated.Id);
+        var survivorCaretakerIds = survivorLinks.Select(l => l.CaretakerId).ToHashSet();
+        var survivorHasPrimary = survivorLinks.Any(l => l.PrimaryCaretaker);
+
+        var dispositions = new List<PatientMergeCaretakerDisposition>();
+        var nonSyntheticRemaps = eliminatedLinks.Count(l =>
+            !survivorCaretakerIds.Contains(l.CaretakerId) && !IsSynthetic(l.Caretaker));
+        var survivorKeepsACaretaker = survivorLinks.Count + nonSyntheticRemaps > 0;
+
+        foreach (var link in eliminatedLinks)
+        {
+            var isSynthetic = IsSynthetic(link.Caretaker);
+            var d = new PatientMergeCaretakerDisposition
+            {
+                CaretakerId = link.CaretakerId,
+                CaretakerName = link.Caretaker?.User?.GetFullName() ?? $"Caretaker #{link.CaretakerId}",
+                IsSynthetic = isSynthetic,
+            };
+            if (survivorCaretakerIds.Contains(link.CaretakerId))
+            {
+                d.Disposition = PatientMergeCaretakerDisposition.DedupeDelete;
+                var survivorDup = survivorLinks.First(l => l.CaretakerId == link.CaretakerId);
+                if (link.PrimaryCaretaker && !survivorDup.PrimaryCaretaker)
+                {
+                    d.PrimaryFlagDropped = true;
+                    warnings.Add($"Caretaker '{d.CaretakerName}' was primary on the eliminated record; the survivor's existing (non-primary) link is kept as-is.");
+                }
+            }
+            else if (isSynthetic && survivorKeepsACaretaker)
+            {
+                // Standing rule: retire the WP-19 placeholder when the survivor keeps a
+                // caretaker; if it would leave the survivor caretaker-less, remap instead.
+                d.Disposition = PatientMergeCaretakerDisposition.RetireSynthetic;
+            }
+            else
+            {
+                d.Disposition = PatientMergeCaretakerDisposition.Remap;
+                if (link.PrimaryCaretaker && survivorHasPrimary)
+                {
+                    d.PrimaryFlagDropped = true;
+                    warnings.Add($"Caretaker '{d.CaretakerName}' arrives non-primary — the survivor already has a primary caretaker.");
+                }
+                survivorHasPrimary |= link.PrimaryCaretaker && !d.PrimaryFlagDropped;
+            }
+            dispositions.Add(d);
+        }
+
+        // Fill-blanks: survivor inherits where its own field is empty. MRN is NEVER merged.
+        var fills = new List<PatientMergeFieldFill>();
+        if (survivor.DateOfBirth is null && eliminated.DateOfBirth is not null)
+            fills.Add(new() { Field = nameof(Patient.DateOfBirth), Value = eliminated.DateOfBirth.Value.ToString("yyyy-MM-dd") });
+        if (string.IsNullOrWhiteSpace(survivor.Cedula) && !string.IsNullOrWhiteSpace(eliminated.Cedula))
+            fills.Add(new() { Field = nameof(Patient.Cedula), Value = eliminated.Cedula! });
+        if (string.IsNullOrWhiteSpace(survivor.Gender) && !string.IsNullOrWhiteSpace(eliminated.Gender))
+            fills.Add(new() { Field = nameof(Patient.Gender), Value = eliminated.Gender! });
+        if (string.IsNullOrWhiteSpace(survivor.Notes) && !string.IsNullOrWhiteSpace(eliminated.Notes))
+            fills.Add(new() { Field = nameof(Patient.Notes), Value = Truncate(eliminated.Notes!, 200) });
+
+        if (survivor.HasTemporaryMrn() && !eliminated.HasTemporaryMrn())
+        {
+            warnings.Add($"Survivor has a temporary MRN while the eliminated record's MRN is '{eliminated.MedicalRecordNumber}' — MRN is never merged; the eliminated MRN is preserved in the merge log.");
+        }
+        if (!string.IsNullOrWhiteSpace(survivor.Cedula) && !string.IsNullOrWhiteSpace(eliminated.Cedula)
+            && !string.Equals(survivor.Cedula, eliminated.Cedula, StringComparison.OrdinalIgnoreCase))
+        {
+            warnings.Add($"Both records carry a Cedula (survivor '{survivor.Cedula}', eliminated '{eliminated.Cedula}') — the survivor keeps its own; the eliminated value is preserved in the merge log.");
+        }
+        if (!(survivor.User!.ActiveStatus))
+        {
+            warnings.Add("The survivor patient is currently inactive.");
+        }
+
+        return new PatientMergePreview
+        {
+            Survivor = await BuildIdentityAsync(survivor, survivorLinks.Count),
+            Eliminated = await BuildIdentityAsync(eliminated, eliminatedLinks.Count),
+            Counts = new PatientMergePlannedCounts
+            {
+                SessionsToRemap = await _repository.CountSessionsAsync(eliminated.Id),
+                PlansToRemap = await _repository.CountTreatmentPlansAsync(eliminated.Id),
+                CaretakerLinksToRemap = dispositions.Count(d => d.Disposition == PatientMergeCaretakerDisposition.Remap),
+                CaretakerLinksToDedupe = dispositions.Count(d => d.Disposition == PatientMergeCaretakerDisposition.DedupeDelete),
+                SyntheticCaretakersToDelete = dispositions.Count(d => d.Disposition == PatientMergeCaretakerDisposition.RetireSynthetic),
+            },
+            Caretakers = dispositions,
+            FieldFills = fills,
+            Warnings = warnings,
+            Blockers = blockers,
+        };
+    }
+
+    private async Task<PatientMergeIdentity> BuildIdentityAsync(Patient patient, int caretakerCount) => new()
+    {
+        PatientId = patient.Id,
+        UserId = patient.User!.Id,
+        PatientName = patient.User.GetFullName(),
+        MedicalRecordNumber = patient.MedicalRecordNumber,
+        Cedula = patient.Cedula,
+        DateOfBirth = patient.DateOfBirth,
+        Gender = patient.Gender,
+        IsActive = patient.User.ActiveStatus,
+        SessionCount = await _repository.CountSessionsAsync(patient.Id),
+        PlanCount = await _repository.CountTreatmentPlansAsync(patient.Id),
+        CaretakerCount = caretakerCount,
+    };
+
+    private static bool IsSynthetic(Caretaker? caretaker) =>
+        caretaker?.Notes?.StartsWith(SyntheticCaretakerNotesPrefix, StringComparison.OrdinalIgnoreCase) == true;
+
+    private static string BuildMergedMarker(PatientMergeLog snapshot, int sessions, int plans,
+        int remapped, int deduped, int syntheticsDeleted, IReadOnlyList<string> fieldsFilled) =>
+        $"[MERGED: absorbed Patient #{snapshot.EliminatedPatientId}" +
+        $" MRN {snapshot.EliminatedMrn ?? "—"} Cedula {snapshot.EliminatedCedula ?? "—"}" +
+        $" \"{snapshot.EliminatedName}\" on {DateTime.UtcNow:yyyy-MM-dd} by user {snapshot.MergedByUserId};" +
+        $" sessions {sessions}, plans {plans}," +
+        $" caretakerLinks remapped {remapped}/deduped {deduped}/syntheticDeleted {syntheticsDeleted};" +
+        $" filled {(fieldsFilled.Count > 0 ? string.Join(",", fieldsFilled) : "none")}]";
+
+    private static string Truncate(string value, int max) =>
+        value.Length <= max ? value : value[..max] + "…";
+}

--- a/src/Infrastructure/Configurations/Dependencies.cs
+++ b/src/Infrastructure/Configurations/Dependencies.cs
@@ -52,6 +52,7 @@ public static class NeurocorpConfigurationExtensions
         services.AddScoped<IUnitOfWork, EfUnitOfWork>();
         services.AddScoped(typeof(IRepository<>), typeof(EfRepository<>));
         services.AddScoped<IPatientRepository, PatientRepository>();
+        services.AddScoped<IPatientMergeRepository, PatientMergeRepository>();
         services.AddScoped<IPatientProfileRepository, PatientProfileRepository>();
         services.AddScoped<ICaretakerProfileRepository, CaretakerProfileRepository>();
         services.AddScoped<ITherapistProfileRepository, TherapistProfileRepository>();

--- a/src/Infrastructure/Data/ApplicationDbContext.cs
+++ b/src/Infrastructure/Data/ApplicationDbContext.cs
@@ -41,6 +41,7 @@ public class ApplicationDbContext : DbContext
     public DbSet<TherapistSpecialty> TherapistSpecialties { get; set; }
     public DbSet<TreatmentPlan> TreatmentPlans { get; set; }
     public DbSet<TreatmentPlanLine> TreatmentPlanLines { get; set; }
+    public DbSet<PatientMergeLog> PatientMergeLogs { get; set; }
 
     public override int SaveChanges()
     {

--- a/src/Infrastructure/Data/Configurations/MergeConfigurations.cs
+++ b/src/Infrastructure/Data/Configurations/MergeConfigurations.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Neurocorp.Api.Core.Entities;
+
+namespace Neurocorp.Api.Infrastructure.Data.Configurations;
+
+// EF Core mapping for the duplicate-patient merge audit trail (WP-22 / DB migration V025).
+
+public class PatientMergeLogConfiguration : IEntityTypeConfiguration<PatientMergeLog>
+{
+    public void Configure(EntityTypeBuilder<PatientMergeLog> builder)
+    {
+        builder.ToTable("PatientMergeLog");
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.Id).HasColumnName("PatientMergeLogID");
+        builder.Property(e => e.SurvivorPatientId).HasColumnName("SurvivorPatientID");
+        builder.Property(e => e.EliminatedPatientId).HasColumnName("EliminatedPatientID");
+        builder.Property(e => e.EliminatedUserId).HasColumnName("EliminatedUserID");
+        builder.Property(e => e.EliminatedName).HasMaxLength(200);
+        builder.Property(e => e.EliminatedMrn).HasMaxLength(50);
+        builder.Property(e => e.EliminatedCedula).HasMaxLength(50);
+        builder.Property(e => e.EliminatedNotes).IsRequired(false);
+        builder.Property(e => e.FieldsFilled).HasMaxLength(200).IsRequired(false);
+        // Survivor FK exists in the DB (fk_patientmergelog_survivor) but no navigation is
+        // mapped — the log is written/read by id only. Eliminated* columns have NO FK by
+        // design: their rows are hard-deleted in the same transaction.
+    }
+}

--- a/src/Infrastructure/Repositories/PatientMergeRepository.cs
+++ b/src/Infrastructure/Repositories/PatientMergeRepository.cs
@@ -1,0 +1,144 @@
+using Neurocorp.Api.Core.Entities;
+using Neurocorp.Api.Core.Interfaces.Repositories;
+using Neurocorp.Api.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace Neurocorp.Api.Infrastructure.Repositories;
+
+/// <summary>
+/// Data access for the duplicate-patient merge (WP-22). All members run on the ambient
+/// DbContext so the service's IUnitOfWork transaction covers every statement — including the
+/// two ExecuteUpdate bulk repoints (relational providers only; the InMemory test provider
+/// throws on them, so those two members are verified against real MySQL via
+/// docs/patient-merge-wp22-verification.md and the batch invariant queries).
+/// </summary>
+public class PatientMergeRepository : IPatientMergeRepository
+{
+    private readonly ApplicationDbContext _dbContext;
+
+    public PatientMergeRepository(ApplicationDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<Patient?> GetPatientWithUserAsync(int patientId)
+    {
+        return await _dbContext.Patients
+            .Include(p => p.User)
+            .FirstOrDefaultAsync(p => p.Id == patientId);
+    }
+
+    public async Task<IReadOnlyList<UserRole>> GetUserRolesAsync(int userId)
+    {
+        return await _dbContext.Set<UserRole>()
+            .Where(r => r.UserId == userId)
+            .ToListAsync();
+    }
+
+    public async Task<bool> IsTherapistUserAsync(int userId)
+    {
+        return await _dbContext.Therapists.AnyAsync(t => t.User!.Id == userId);
+    }
+
+    public async Task<bool> IsCaretakerUserAsync(int userId)
+    {
+        return await _dbContext.Caretakers.AnyAsync(c => c.User!.Id == userId);
+    }
+
+    public async Task<IReadOnlyList<PatientCaretaker>> GetCaretakerLinksAsync(int patientId)
+    {
+        return await _dbContext.Set<PatientCaretaker>()
+            .Where(pc => pc.PatientId == patientId)
+            .Include(pc => pc.Caretaker)
+                .ThenInclude(c => c!.User)
+            .ToListAsync();
+    }
+
+    public async Task<int> CountSessionsAsync(int patientId)
+    {
+        return await _dbContext.TherapySessions.CountAsync(s => s.PatientId == patientId);
+    }
+
+    public async Task<int> CountTreatmentPlansAsync(int patientId)
+    {
+        return await _dbContext.TreatmentPlans.CountAsync(p => p.PatientId == patientId);
+    }
+
+    // ExecuteUpdate bypasses SaveChanges interception, so the audit columns are stamped
+    // explicitly in the SET clause.
+    public async Task<int> ReassignSessionsAsync(int fromPatientId, int toPatientId, int mergedByUserId)
+    {
+        return await _dbContext.TherapySessions
+            .Where(s => s.PatientId == fromPatientId)
+            .ExecuteUpdateAsync(set => set
+                .SetProperty(s => s.PatientId, toPatientId)
+                .SetProperty(s => s.LastUpdatedTimestamp, DateTime.UtcNow)
+                .SetProperty(s => s.LastUpdatedByUserId, mergedByUserId));
+    }
+
+    public async Task<int> ReassignTreatmentPlansAsync(int fromPatientId, int toPatientId, int mergedByUserId)
+    {
+        return await _dbContext.TreatmentPlans
+            .Where(p => p.PatientId == fromPatientId)
+            .ExecuteUpdateAsync(set => set
+                .SetProperty(p => p.PatientId, toPatientId)
+                .SetProperty(p => p.LastUpdatedTimestamp, DateTime.UtcNow)
+                .SetProperty(p => p.LastUpdatedByUserId, mergedByUserId));
+    }
+
+    public async Task UpdateCaretakerLinkAsync(PatientCaretaker link)
+    {
+        _dbContext.Entry(link).State = EntityState.Modified;
+        await _dbContext.SaveChangesAsync();
+    }
+
+    public async Task DeleteCaretakerLinkAsync(PatientCaretaker link)
+    {
+        _dbContext.Set<PatientCaretaker>().Remove(link);
+        await _dbContext.SaveChangesAsync();
+    }
+
+    public async Task DeleteCaretakerAsync(Caretaker caretaker)
+    {
+        _dbContext.Caretakers.Remove(caretaker);
+        await _dbContext.SaveChangesAsync();
+    }
+
+    public async Task UpdatePatientAsync(Patient patient)
+    {
+        _dbContext.Entry(patient).State = EntityState.Modified;
+        await _dbContext.SaveChangesAsync();
+    }
+
+    public async Task DeletePatientAsync(Patient patient)
+    {
+        _dbContext.Patients.Remove(patient);
+        await _dbContext.SaveChangesAsync();
+    }
+
+    // Fix-b1 retirement order: role rows, then claim rows, then the SystemUser itself.
+    public async Task DeleteUserIdentityAsync(int userId)
+    {
+        var roles = await _dbContext.Set<UserRole>().Where(r => r.UserId == userId).ToListAsync();
+        _dbContext.Set<UserRole>().RemoveRange(roles);
+        await _dbContext.SaveChangesAsync();
+
+        var claims = await _dbContext.UserClaims.Where(c => c.UserId == userId).ToListAsync();
+        _dbContext.UserClaims.RemoveRange(claims);
+        await _dbContext.SaveChangesAsync();
+
+        var user = await _dbContext.Users.FindAsync(userId);
+        if (user is not null)
+        {
+            _dbContext.Users.Remove(user);
+            await _dbContext.SaveChangesAsync();
+        }
+    }
+
+    public async Task<PatientMergeLog> AddMergeLogAsync(PatientMergeLog log)
+    {
+        await _dbContext.PatientMergeLogs.AddAsync(log);
+        await _dbContext.SaveChangesAsync();
+        return log;
+    }
+}

--- a/src/Web/Authorization/AccessControlManifest.cs
+++ b/src/Web/Authorization/AccessControlManifest.cs
@@ -18,5 +18,5 @@ namespace Neurocorp.Api.Web.Authorization;
 public static class AccessControlManifest
 {
     /// <summary>First 12 hex chars of SHA-256 over the manifest's canonical grant tuples.</summary>
-    public const string SemanticHash = "776a7665d67b";
+    public const string SemanticHash = "6c42b5362fbc";
 }

--- a/src/Web/Authorization/Permissions.g.cs
+++ b/src/Web/Authorization/Permissions.g.cs
@@ -7,7 +7,7 @@
 //   (patient-care-super/tools/generate-access-manifest.sh), re-vendor
 //   docs/access-control-matrix.json, then re-run tools/generate-permissions.sh.
 //
-//   Access-control manifest semantic hash: 776a7665d67b
+//   Access-control manifest semantic hash: 6c42b5362fbc
 // </auto-generated>
 
 namespace Neurocorp.Api.Web.Authorization;
@@ -48,6 +48,7 @@ public static class Permissions
     public const string PatientsDelinquentView = "Patients.Delinquent.View";
     public const string PatientsEdit = "Patients.Edit";
     public const string PatientsLinkCaretaker = "Patients.LinkCaretaker";
+    public const string PatientsMerge = "Patients.Merge";
     public const string PatientsStartDiscovery = "Patients.StartDiscovery";
     public const string PatientsView = "Patients.View";
     public const string PaymentsAdjust = "Payments.Adjust";

--- a/src/Web/Controllers/PatientsController.cs
+++ b/src/Web/Controllers/PatientsController.cs
@@ -19,15 +19,19 @@ public class PatientsController : ControllerBase
     private readonly ISessionEventRepository _sessionEventRepository;
     private readonly ILogger<PatientsController> _logger;
 
+    private readonly IPatientMergeService _patientMergeService;
+
     public PatientsController(
         ILogger<PatientsController> logger,
         IPatientProfileService patientProfileService,
         IHandleSessionEvent sessionEventHandler,
-        ISessionEventRepository sessionEventRepository)
+        ISessionEventRepository sessionEventRepository,
+        IPatientMergeService patientMergeService)
     {
         _patientProfileService = patientProfileService;
         _sessionEventHandler = sessionEventHandler;
         _sessionEventRepository = sessionEventRepository;
+        _patientMergeService = patientMergeService;
         _logger = logger;
     }
 
@@ -167,6 +171,35 @@ public class PatientsController : ControllerBase
             // InvalidOperationException to 500, not 400).
             return Problem(statusCode: StatusCodes.Status400BadRequest, detail: ex.Message, title: "Bad Request");
         }
+    }
+
+    // WP-22 (F2): duplicate-patient merge — SYSADMIN-only by customer ruling. Patients.Merge
+    // has an EMPTY grants row in the matrix (hash 6c42b5362fbc); only the System/FullAccess
+    // wildcard satisfies it, so no RoleClaim was seeded. Preview is side-effect-free; execute
+    // remaps sessions/plans/caretaker-links, fills survivor blanks, writes PatientMergeLog +
+    // a [MERGED: ...] Notes marker, and hard-deletes the eliminated Patient + SystemUser.
+
+    [HttpPost("merge/preview")]
+    [Authorize(Policy = AuthPolicy.PermissionPrefix + Permissions.PatientsMerge)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(PatientMergePreview))]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> PreviewPatientMerge([FromBody] PatientMergeRequest request)
+    {
+        var preview = await _patientMergeService.PreviewAsync(request);
+        return Ok(preview);
+    }
+
+    [HttpPost("merge")]
+    [Authorize(Policy = AuthPolicy.PermissionPrefix + Permissions.PatientsMerge)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(PatientMergeResult))]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    public async Task<IActionResult> MergePatients([FromBody] PatientMergeRequest request)
+    {
+        var result = await _patientMergeService.MergeAsync(request);
+        return Ok(result);
     }
 
     private async Task<PatientPastDueInfo> PackagePastDueInfoAsync(int patientId)

--- a/src/Web/Middleware/GlobalExceptionHandler.cs
+++ b/src/Web/Middleware/GlobalExceptionHandler.cs
@@ -64,6 +64,10 @@ public sealed class GlobalExceptionHandler : IExceptionHandler
     {
         NotFoundException => (StatusCodes.Status404NotFound, "Not Found", exception.Message),
 
+        // Domain-state conflicts (e.g. WP-22 merge blockers) — the domain-driven sibling of
+        // the duplicate-key 409 below.
+        ConflictException => (StatusCodes.Status409Conflict, "Conflict", exception.Message),
+
         // Covers ArgumentNullException / ArgumentOutOfRangeException too (both derive from ArgumentException).
         ArgumentException => (StatusCodes.Status400BadRequest, "Bad Request", exception.Message),
 

--- a/tests/Core.Tests/PatientMergeServiceTests.cs
+++ b/tests/Core.Tests/PatientMergeServiceTests.cs
@@ -1,0 +1,430 @@
+using Moq;
+using Microsoft.Extensions.Logging;
+using Neurocorp.Api.Core.BusinessObjects.Patients;
+using Neurocorp.Api.Core.Entities;
+using Neurocorp.Api.Core.Exceptions;
+using Neurocorp.Api.Core.Interfaces;
+using Neurocorp.Api.Core.Interfaces.Repositories;
+using Neurocorp.Api.Core.Interfaces.Services;
+using Neurocorp.Api.Core.Services;
+using FluentAssertions;
+
+namespace Core.Tests;
+
+public class PatientMergeServiceTests
+{
+    private readonly Mock<IPatientMergeRepository> _repo = new();
+    private readonly Mock<ICurrentUserService> _currentUser = new();
+
+    private PatientMergeService CreateService()
+    {
+        var uow = new Mock<IUnitOfWork>();
+        uow.Setup(u => u.ExecuteAsync(It.IsAny<Func<Task<(PatientMergeResult, int)>>>()))
+           .Returns((Func<Task<(PatientMergeResult, int)>> op) => op());
+        _currentUser.SetupGet(c => c.UserId).Returns(7);
+        return new PatientMergeService(
+            Mock.Of<ILogger<PatientMergeService>>(), _repo.Object, _currentUser.Object, uow.Object);
+    }
+
+    private static Patient MakePatient(int patientId, int userId, string first, string last,
+        string? mrn = null, string? cedula = null, DateTime? dob = null, string? gender = null,
+        string? notes = null, bool active = true)
+    {
+        return new Patient
+        {
+            Id = patientId,
+            User = new User { Id = userId, FirstName = first, LastName = last, ActiveStatus = active },
+            MedicalRecordNumber = mrn,
+            Cedula = cedula,
+            DateOfBirth = dob,
+            Gender = gender,
+            Notes = notes,
+        };
+    }
+
+    private static PatientCaretaker MakeLink(int patientId, int caretakerId, bool primary = false,
+        bool synthetic = false, int caretakerUserId = 0)
+    {
+        return new PatientCaretaker
+        {
+            Id = patientId * 1000 + caretakerId,
+            PatientId = patientId,
+            CaretakerId = caretakerId,
+            PrimaryCaretaker = primary,
+            Caretaker = new Caretaker
+            {
+                Id = caretakerId,
+                Notes = synthetic ? "SYNTHETIC placeholder caretaker (legacy-import backfill 2026-07) for patient L24-0001" : string.Empty,
+                User = new User { Id = caretakerUserId == 0 ? 9000 + caretakerId : caretakerUserId, FirstName = "CT", LastName = $"Caretaker{caretakerId}" },
+            },
+        };
+    }
+
+    /// <summary>Happy-path repo defaults: both patients exist, clean roles, no links/sessions/plans.</summary>
+    private void SetupCleanPair(Patient survivor, Patient eliminated)
+    {
+        _repo.Setup(r => r.GetPatientWithUserAsync(survivor.Id)).ReturnsAsync(survivor);
+        _repo.Setup(r => r.GetPatientWithUserAsync(eliminated.Id)).ReturnsAsync(eliminated);
+        _repo.Setup(r => r.GetUserRolesAsync(It.IsAny<int>()))
+             .ReturnsAsync([new UserRole { RoleId = 2, UserId = eliminated.User!.Id }]);
+        _repo.Setup(r => r.IsTherapistUserAsync(It.IsAny<int>())).ReturnsAsync(false);
+        _repo.Setup(r => r.IsCaretakerUserAsync(It.IsAny<int>())).ReturnsAsync(false);
+        _repo.Setup(r => r.GetCaretakerLinksAsync(It.IsAny<int>())).ReturnsAsync([]);
+        _repo.Setup(r => r.CountSessionsAsync(It.IsAny<int>())).ReturnsAsync(0);
+        _repo.Setup(r => r.CountTreatmentPlansAsync(It.IsAny<int>())).ReturnsAsync(0);
+        _repo.Setup(r => r.ReassignSessionsAsync(eliminated.Id, survivor.Id, It.IsAny<int>())).ReturnsAsync(0);
+        _repo.Setup(r => r.ReassignTreatmentPlansAsync(eliminated.Id, survivor.Id, It.IsAny<int>())).ReturnsAsync(0);
+        _repo.Setup(r => r.AddMergeLogAsync(It.IsAny<PatientMergeLog>()))
+             .ReturnsAsync((PatientMergeLog log) => { log.Id = 42; return log; });
+    }
+
+    // ── Validation guards ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Preview_SameIds_ThrowsArgumentException()
+    {
+        var svc = CreateService();
+        var act = () => svc.PreviewAsync(new PatientMergeRequest { SurvivorPatientId = 5, EliminatedPatientId = 5 });
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task Merge_SameIds_ThrowsArgumentException()
+    {
+        var svc = CreateService();
+        var act = () => svc.MergeAsync(new PatientMergeRequest { SurvivorPatientId = 5, EliminatedPatientId = 5 });
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task Preview_SurvivorMissing_ThrowsNotFound()
+    {
+        var svc = CreateService();
+        _repo.Setup(r => r.GetPatientWithUserAsync(1)).ReturnsAsync((Patient?)null);
+        var act = () => svc.PreviewAsync(new PatientMergeRequest { SurvivorPatientId = 1, EliminatedPatientId = 2 });
+        (await act.Should().ThrowAsync<NotFoundException>()).WithMessage("*Survivor*1*");
+    }
+
+    [Fact]
+    public async Task Preview_EliminatedMissing_ThrowsNotFound()
+    {
+        var svc = CreateService();
+        _repo.Setup(r => r.GetPatientWithUserAsync(1)).ReturnsAsync(MakePatient(1, 10, "A", "B"));
+        _repo.Setup(r => r.GetPatientWithUserAsync(2)).ReturnsAsync((Patient?)null);
+        var act = () => svc.PreviewAsync(new PatientMergeRequest { SurvivorPatientId = 1, EliminatedPatientId = 2 });
+        (await act.Should().ThrowAsync<NotFoundException>()).WithMessage("*Eliminated*2*");
+    }
+
+    [Fact]
+    public async Task Preview_EliminatedUserWithNonPatientRole_ReportsBlocker()
+    {
+        var svc = CreateService();
+        var survivor = MakePatient(1, 10, "Juan", "Perez");
+        var eliminated = MakePatient(2, 20, "Jaun", "Perez");
+        SetupCleanPair(survivor, eliminated);
+        _repo.Setup(r => r.GetUserRolesAsync(20))
+             .ReturnsAsync([new UserRole { RoleId = 2, UserId = 20 }, new UserRole { RoleId = 1, UserId = 20 }]);
+
+        var preview = await svc.PreviewAsync(new PatientMergeRequest { SurvivorPatientId = 1, EliminatedPatientId = 2 });
+
+        preview.Blockers.Should().ContainSingle(b => b.Contains("non-Patient roles"));
+    }
+
+    [Theory]
+    [InlineData(true, false, "Therapist")]
+    [InlineData(false, true, "Caretaker")]
+    public async Task Preview_EliminatedUserDoublingAsOtherIdentity_ReportsBlocker(
+        bool isTherapist, bool isCaretaker, string expected)
+    {
+        var svc = CreateService();
+        var survivor = MakePatient(1, 10, "Juan", "Perez");
+        var eliminated = MakePatient(2, 20, "Jaun", "Perez");
+        SetupCleanPair(survivor, eliminated);
+        _repo.Setup(r => r.IsTherapistUserAsync(20)).ReturnsAsync(isTherapist);
+        _repo.Setup(r => r.IsCaretakerUserAsync(20)).ReturnsAsync(isCaretaker);
+
+        var preview = await svc.PreviewAsync(new PatientMergeRequest { SurvivorPatientId = 1, EliminatedPatientId = 2 });
+
+        preview.Blockers.Should().ContainSingle(b => b.Contains(expected));
+    }
+
+    [Fact]
+    public async Task Merge_WithBlocker_ThrowsConflictAndWritesNothing()
+    {
+        var svc = CreateService();
+        var survivor = MakePatient(1, 10, "Juan", "Perez");
+        var eliminated = MakePatient(2, 20, "Jaun", "Perez");
+        SetupCleanPair(survivor, eliminated);
+        _repo.Setup(r => r.IsTherapistUserAsync(20)).ReturnsAsync(true);
+
+        var act = () => svc.MergeAsync(new PatientMergeRequest { SurvivorPatientId = 1, EliminatedPatientId = 2 });
+
+        await act.Should().ThrowAsync<ConflictException>();
+        _repo.Verify(r => r.ReassignSessionsAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()), Times.Never);
+        _repo.Verify(r => r.DeletePatientAsync(It.IsAny<Patient>()), Times.Never);
+        _repo.Verify(r => r.DeleteUserIdentityAsync(It.IsAny<int>()), Times.Never);
+    }
+
+    // ── Preview purity ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Preview_PerformsNoWrites()
+    {
+        var svc = CreateService();
+        var survivor = MakePatient(1, 10, "Juan", "Perez");
+        var eliminated = MakePatient(2, 20, "Jaun", "Perez", mrn: "L24-0313");
+        SetupCleanPair(survivor, eliminated);
+        _repo.Setup(r => r.GetCaretakerLinksAsync(2)).ReturnsAsync([MakeLink(2, 55, primary: true, synthetic: true)]);
+
+        await svc.PreviewAsync(new PatientMergeRequest { SurvivorPatientId = 1, EliminatedPatientId = 2 });
+
+        _repo.Verify(r => r.ReassignSessionsAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()), Times.Never);
+        _repo.Verify(r => r.ReassignTreatmentPlansAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()), Times.Never);
+        _repo.Verify(r => r.UpdateCaretakerLinkAsync(It.IsAny<PatientCaretaker>()), Times.Never);
+        _repo.Verify(r => r.DeleteCaretakerLinkAsync(It.IsAny<PatientCaretaker>()), Times.Never);
+        _repo.Verify(r => r.DeleteCaretakerAsync(It.IsAny<Caretaker>()), Times.Never);
+        _repo.Verify(r => r.UpdatePatientAsync(It.IsAny<Patient>()), Times.Never);
+        _repo.Verify(r => r.DeletePatientAsync(It.IsAny<Patient>()), Times.Never);
+        _repo.Verify(r => r.DeleteUserIdentityAsync(It.IsAny<int>()), Times.Never);
+        _repo.Verify(r => r.AddMergeLogAsync(It.IsAny<PatientMergeLog>()), Times.Never);
+    }
+
+    // ── Caretaker link classification ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task Preview_SharedCaretaker_ClassifiedDedupeDelete_SurvivorPrimaryWins()
+    {
+        var svc = CreateService();
+        var survivor = MakePatient(1, 10, "Juan", "Perez");
+        var eliminated = MakePatient(2, 20, "Jaun", "Perez");
+        SetupCleanPair(survivor, eliminated);
+        _repo.Setup(r => r.GetCaretakerLinksAsync(1)).ReturnsAsync([MakeLink(1, 55, primary: false)]);
+        _repo.Setup(r => r.GetCaretakerLinksAsync(2)).ReturnsAsync([MakeLink(2, 55, primary: true)]);
+
+        var preview = await svc.PreviewAsync(new PatientMergeRequest { SurvivorPatientId = 1, EliminatedPatientId = 2 });
+
+        var d = preview.Caretakers.Should().ContainSingle().Subject;
+        d.Disposition.Should().Be(PatientMergeCaretakerDisposition.DedupeDelete);
+        d.PrimaryFlagDropped.Should().BeTrue();
+        preview.Counts.CaretakerLinksToDedupe.Should().Be(1);
+        preview.Warnings.Should().Contain(w => w.Contains("primary"));
+    }
+
+    [Fact]
+    public async Task Preview_SyntheticWithSurvivorCaretaker_ClassifiedRetireSynthetic()
+    {
+        var svc = CreateService();
+        var survivor = MakePatient(1, 10, "Juan", "Perez");
+        var eliminated = MakePatient(2, 20, "Jaun", "Perez");
+        SetupCleanPair(survivor, eliminated);
+        _repo.Setup(r => r.GetCaretakerLinksAsync(1)).ReturnsAsync([MakeLink(1, 40)]);
+        _repo.Setup(r => r.GetCaretakerLinksAsync(2)).ReturnsAsync([MakeLink(2, 55, primary: true, synthetic: true)]);
+
+        var preview = await svc.PreviewAsync(new PatientMergeRequest { SurvivorPatientId = 1, EliminatedPatientId = 2 });
+
+        var d = preview.Caretakers.Should().ContainSingle().Subject;
+        d.IsSynthetic.Should().BeTrue();
+        d.Disposition.Should().Be(PatientMergeCaretakerDisposition.RetireSynthetic);
+        preview.Counts.SyntheticCaretakersToDelete.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Preview_SyntheticButSurvivorWouldEndCaretakerless_RemapsInstead()
+    {
+        var svc = CreateService();
+        var survivor = MakePatient(1, 10, "Juan", "Perez");
+        var eliminated = MakePatient(2, 20, "Jaun", "Perez");
+        SetupCleanPair(survivor, eliminated);
+        // Survivor has NO caretakers; eliminated's only link is the synthetic placeholder.
+        _repo.Setup(r => r.GetCaretakerLinksAsync(2)).ReturnsAsync([MakeLink(2, 55, primary: true, synthetic: true)]);
+
+        var preview = await svc.PreviewAsync(new PatientMergeRequest { SurvivorPatientId = 1, EliminatedPatientId = 2 });
+
+        preview.Caretakers.Should().ContainSingle()
+            .Which.Disposition.Should().Be(PatientMergeCaretakerDisposition.Remap);
+        preview.Counts.CaretakerLinksToRemap.Should().Be(1);
+        preview.Counts.SyntheticCaretakersToDelete.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Preview_RemappedPrimaryDemoted_WhenSurvivorAlreadyHasPrimary()
+    {
+        var svc = CreateService();
+        var survivor = MakePatient(1, 10, "Juan", "Perez");
+        var eliminated = MakePatient(2, 20, "Jaun", "Perez");
+        SetupCleanPair(survivor, eliminated);
+        _repo.Setup(r => r.GetCaretakerLinksAsync(1)).ReturnsAsync([MakeLink(1, 40, primary: true)]);
+        _repo.Setup(r => r.GetCaretakerLinksAsync(2)).ReturnsAsync([MakeLink(2, 55, primary: true)]);
+
+        var preview = await svc.PreviewAsync(new PatientMergeRequest { SurvivorPatientId = 1, EliminatedPatientId = 2 });
+
+        var d = preview.Caretakers.Should().ContainSingle().Subject;
+        d.Disposition.Should().Be(PatientMergeCaretakerDisposition.Remap);
+        d.PrimaryFlagDropped.Should().BeTrue();
+        preview.Warnings.Should().Contain(w => w.Contains("already has a primary"));
+    }
+
+    // ── Fill-blanks ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Preview_FillBlanks_OnlyWhereSurvivorEmpty_AndNeverMrn()
+    {
+        var svc = CreateService();
+        var survivor = MakePatient(1, 10, "Juan", "Perez", mrn: "TEMP-1", cedula: null, dob: null, gender: null, notes: null);
+        var eliminated = MakePatient(2, 20, "Jaun", "Perez", mrn: "L24-0313", cedula: "8-123-456",
+            dob: new DateTime(2018, 5, 4), gender: "Male", notes: "[LEGACY-IMPORT: roster]");
+        SetupCleanPair(survivor, eliminated);
+
+        var preview = await svc.PreviewAsync(new PatientMergeRequest { SurvivorPatientId = 1, EliminatedPatientId = 2 });
+
+        preview.FieldFills.Select(f => f.Field).Should().BeEquivalentTo(
+            ["DateOfBirth", "Cedula", "Gender", "Notes"]);
+        preview.FieldFills.Should().NotContain(f => f.Field == "MedicalRecordNumber");
+        preview.Warnings.Should().Contain(w => w.Contains("temporary MRN"));
+    }
+
+    [Fact]
+    public async Task Preview_NoFills_WhenSurvivorFieldsPopulated_AndCedulaConflictWarned()
+    {
+        var svc = CreateService();
+        var survivor = MakePatient(1, 10, "Juan", "Perez", mrn: "L24-0312", cedula: "8-111-111",
+            dob: new DateTime(2018, 1, 1), gender: "Male", notes: "existing");
+        var eliminated = MakePatient(2, 20, "Jaun", "Perez", mrn: "L24-0313", cedula: "8-222-222",
+            dob: new DateTime(2018, 5, 4), gender: "Female", notes: "other");
+        SetupCleanPair(survivor, eliminated);
+
+        var preview = await svc.PreviewAsync(new PatientMergeRequest { SurvivorPatientId = 1, EliminatedPatientId = 2 });
+
+        preview.FieldFills.Should().BeEmpty();
+        preview.Warnings.Should().Contain(w => w.Contains("Both records carry a Cedula"));
+    }
+
+    // ── Execution ───────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Merge_HappyPath_CountsFlowFromRepo_AndLogWritten()
+    {
+        var svc = CreateService();
+        var survivor = MakePatient(1, 10, "Juan", "Perez", mrn: "L24-0312");
+        var eliminated = MakePatient(2, 20, "Jaun", "Perez", mrn: "L24-0313", cedula: "8-123-456",
+            dob: new DateTime(2018, 5, 4), notes: "[LEGACY-IMPORT: roster]");
+        SetupCleanPair(survivor, eliminated);
+        _repo.Setup(r => r.ReassignSessionsAsync(2, 1, 7)).ReturnsAsync(12);
+        _repo.Setup(r => r.ReassignTreatmentPlansAsync(2, 1, 7)).ReturnsAsync(3);
+        PatientMergeLog? written = null;
+        _repo.Setup(r => r.AddMergeLogAsync(It.IsAny<PatientMergeLog>()))
+             .ReturnsAsync((PatientMergeLog log) => { written = log; log.Id = 42; return log; });
+
+        var result = await svc.MergeAsync(new PatientMergeRequest { SurvivorPatientId = 1, EliminatedPatientId = 2 });
+
+        result.MergeLogId.Should().Be(42);
+        result.Counts.SessionsRemapped.Should().Be(12);
+        result.Counts.PlansRemapped.Should().Be(3);
+        result.SurvivorPatientId.Should().Be(1);
+        result.EliminatedPatientId.Should().Be(2);
+        written.Should().NotBeNull();
+        written!.EliminatedName.Should().Be("Perez, Jaun");
+        written.EliminatedMrn.Should().Be("L24-0313");
+        written.EliminatedCedula.Should().Be("8-123-456");
+        written.EliminatedNotes.Should().Be("[LEGACY-IMPORT: roster]");
+        written.SessionsRemapped.Should().Be(12);
+        written.PlansRemapped.Should().Be(3);
+        written.MergedByUserId.Should().Be(7);
+        _repo.Verify(r => r.DeletePatientAsync(eliminated), Times.Once);
+        _repo.Verify(r => r.DeleteUserIdentityAsync(20), Times.Once);
+    }
+
+    [Fact]
+    public async Task Merge_DeletesEliminatedPatient_BeforeSurvivorEnrichment()
+    {
+        // The Cedula fill relies on the eliminated row being gone (uq_patient_cedula).
+        var svc = CreateService();
+        var survivor = MakePatient(1, 10, "Juan", "Perez", mrn: "L24-0312");
+        var eliminated = MakePatient(2, 20, "Jaun", "Perez", cedula: "8-123-456");
+        SetupCleanPair(survivor, eliminated);
+        var callOrder = new List<string>();
+        _repo.Setup(r => r.DeletePatientAsync(It.IsAny<Patient>()))
+             .Callback(() => callOrder.Add("delete")).Returns(Task.CompletedTask);
+        _repo.Setup(r => r.UpdatePatientAsync(It.IsAny<Patient>()))
+             .Callback(() => callOrder.Add("update")).Returns(Task.CompletedTask);
+        _repo.Setup(r => r.DeleteUserIdentityAsync(It.IsAny<int>()))
+             .Callback(() => callOrder.Add("retire")).Returns(Task.CompletedTask);
+
+        await svc.MergeAsync(new PatientMergeRequest { SurvivorPatientId = 1, EliminatedPatientId = 2 });
+
+        callOrder.Should().Equal("delete", "update", "retire");
+        survivor.Cedula.Should().Be("8-123-456");
+    }
+
+    [Fact]
+    public async Task Merge_AppendsMergedMarker_ToExistingSurvivorNotes()
+    {
+        var svc = CreateService();
+        var survivor = MakePatient(1, 10, "Juan", "Perez", mrn: "L24-0312", notes: "pre-existing note");
+        var eliminated = MakePatient(2, 20, "Jaun", "Perez", mrn: "L24-0313");
+        SetupCleanPair(survivor, eliminated);
+
+        await svc.MergeAsync(new PatientMergeRequest { SurvivorPatientId = 1, EliminatedPatientId = 2 });
+
+        survivor.Notes.Should().StartWith("pre-existing note\n[MERGED: absorbed Patient #2 MRN L24-0313");
+        survivor.Notes.Should().Contain("\"Perez, Jaun\"").And.Contain("by user 7");
+    }
+
+    [Fact]
+    public async Task Merge_SyntheticRetirement_DeletesLinkCaretakerAndIdentity()
+    {
+        var svc = CreateService();
+        var survivor = MakePatient(1, 10, "Juan", "Perez", mrn: "L24-0312");
+        var eliminated = MakePatient(2, 20, "Jaun", "Perez");
+        SetupCleanPair(survivor, eliminated);
+        var syntheticLink = MakeLink(2, 55, primary: true, synthetic: true, caretakerUserId: 900);
+        _repo.Setup(r => r.GetCaretakerLinksAsync(1)).ReturnsAsync([MakeLink(1, 40, primary: true)]);
+        _repo.Setup(r => r.GetCaretakerLinksAsync(2)).ReturnsAsync([syntheticLink]);
+
+        var result = await svc.MergeAsync(new PatientMergeRequest { SurvivorPatientId = 1, EliminatedPatientId = 2 });
+
+        result.Counts.SyntheticCaretakersDeleted.Should().Be(1);
+        _repo.Verify(r => r.DeleteCaretakerLinkAsync(syntheticLink), Times.Once);
+        _repo.Verify(r => r.DeleteCaretakerAsync(syntheticLink.Caretaker!), Times.Once);
+        _repo.Verify(r => r.DeleteUserIdentityAsync(900), Times.Once);  // synthetic's SystemUser
+        _repo.Verify(r => r.DeleteUserIdentityAsync(20), Times.Once);   // eliminated patient's SystemUser
+    }
+
+    [Fact]
+    public async Task Merge_RemappedLink_RepointedToSurvivor_AndDemotedWhenSurvivorHasPrimary()
+    {
+        var svc = CreateService();
+        var survivor = MakePatient(1, 10, "Juan", "Perez", mrn: "L24-0312");
+        var eliminated = MakePatient(2, 20, "Jaun", "Perez");
+        SetupCleanPair(survivor, eliminated);
+        var link = MakeLink(2, 55, primary: true);
+        _repo.Setup(r => r.GetCaretakerLinksAsync(1)).ReturnsAsync([MakeLink(1, 40, primary: true)]);
+        _repo.Setup(r => r.GetCaretakerLinksAsync(2)).ReturnsAsync([link]);
+
+        var result = await svc.MergeAsync(new PatientMergeRequest { SurvivorPatientId = 1, EliminatedPatientId = 2 });
+
+        result.Counts.CaretakerLinksRemapped.Should().Be(1);
+        link.PatientId.Should().Be(1);
+        link.PrimaryCaretaker.Should().BeFalse();
+        _repo.Verify(r => r.UpdateCaretakerLinkAsync(link), Times.Once);
+    }
+
+    [Fact]
+    public async Task Merge_DedupedLink_DeletedNotRemapped()
+    {
+        var svc = CreateService();
+        var survivor = MakePatient(1, 10, "Juan", "Perez", mrn: "L24-0312");
+        var eliminated = MakePatient(2, 20, "Jaun", "Perez");
+        SetupCleanPair(survivor, eliminated);
+        var dupLink = MakeLink(2, 55);
+        _repo.Setup(r => r.GetCaretakerLinksAsync(1)).ReturnsAsync([MakeLink(1, 55, primary: true)]);
+        _repo.Setup(r => r.GetCaretakerLinksAsync(2)).ReturnsAsync([dupLink]);
+
+        var result = await svc.MergeAsync(new PatientMergeRequest { SurvivorPatientId = 1, EliminatedPatientId = 2 });
+
+        result.Counts.CaretakerLinksDeduped.Should().Be(1);
+        _repo.Verify(r => r.DeleteCaretakerLinkAsync(dupLink), Times.Once);
+        _repo.Verify(r => r.UpdateCaretakerLinkAsync(It.IsAny<PatientCaretaker>()), Times.Never);
+        _repo.Verify(r => r.DeleteCaretakerAsync(It.IsAny<Caretaker>()), Times.Never);
+    }
+}

--- a/tests/Infrastructure.Tests/PatientMergeRepositoryTests.cs
+++ b/tests/Infrastructure.Tests/PatientMergeRepositoryTests.cs
@@ -1,0 +1,214 @@
+using Xunit;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Neurocorp.Api.Core.Entities;
+using Neurocorp.Api.Infrastructure.Data;
+using Neurocorp.Api.Infrastructure.Repositories;
+
+namespace Infrastructure.Tests.Repositories;
+
+/// <summary>
+/// WP-22 (F2): PatientMergeRepository — reads, deletes, identity retirement, and the merge-log
+/// insert on the InMemory provider. The two ExecuteUpdate bulk repoints (ReassignSessionsAsync /
+/// ReassignTreatmentPlansAsync) are NOT covered here — the InMemory provider does not support
+/// ExecuteUpdate — and are verified against real MySQL via docs/patient-merge-wp22-verification.md
+/// plus the batch runbook's invariant queries (same trade-off as WP-21's correlated subqueries).
+/// </summary>
+public class PatientMergeRepositoryTests
+{
+    private static DbContextOptions<ApplicationDbContext> Options(string name) =>
+        new DbContextOptionsBuilder<ApplicationDbContext>().UseInMemoryDatabase(databaseName: name).Options;
+
+    private static async Task Seed(DbContextOptions<ApplicationDbContext> options)
+    {
+        using var context = new ApplicationDbContext(options);
+        // Patient 1 (user 10): the survivor — real caretaker 40 (user 400), 1 session, 1 plan.
+        // Patient 2 (user 20): the duplicate — synthetic caretaker 55 (user 500), 2 sessions.
+        context.Patients.AddRange(
+            new Patient { Id = 1, MedicalRecordNumber = "L24-0312", User = new User { Id = 10, FirstName = "Juan", LastName = "Perez" } },
+            new Patient { Id = 2, MedicalRecordNumber = "L24-0313", User = new User { Id = 20, FirstName = "Jaun", LastName = "Perez" } });
+        context.Caretakers.AddRange(
+            new Caretaker { Id = 40, Notes = string.Empty, User = new User { Id = 400, FirstName = "Maria", LastName = "Perez" } },
+            new Caretaker { Id = 55, Notes = "SYNTHETIC placeholder caretaker (legacy-import backfill 2026-07) for patient L24-0313", User = new User { Id = 500, FirstName = "Jaun", LastName = "Perez-SH (LEGACY)" } });
+        context.Set<PatientCaretaker>().AddRange(
+            new PatientCaretaker { Id = 1040, PatientId = 1, CaretakerId = 40, PrimaryCaretaker = true },
+            new PatientCaretaker { Id = 2055, PatientId = 2, CaretakerId = 55, PrimaryCaretaker = true });
+        context.Set<UserRole>().AddRange(
+            new UserRole { Id = 1, UserId = 20, RoleId = 2 },
+            new UserRole { Id = 2, UserId = 500, RoleId = 4 });
+        context.UserClaims.Add(new UserClaim { Id = 1, UserId = 20, ClaimType = "Permission", ClaimValue = "X" });
+        context.TherapySessions.AddRange(
+            new TherapySession { Id = 1, PatientId = 1, TherapistId = 1, SessionDate = new DateOnly(2026, 6, 1), SessionTime = new TimeOnly(9, 0) },
+            new TherapySession { Id = 2, PatientId = 2, TherapistId = 1, SessionDate = new DateOnly(2026, 6, 2), SessionTime = new TimeOnly(9, 0) },
+            new TherapySession { Id = 3, PatientId = 2, TherapistId = 1, SessionDate = new DateOnly(2026, 6, 3), SessionTime = new TimeOnly(9, 0) });
+        context.TreatmentPlans.Add(new TreatmentPlan { Id = 1, PatientId = 1, DiscoverySessionId = 1, CreatedByTherapistId = 1 });
+        await context.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task GetPatientWithUserAsync_LoadsUser_AndNullForMissing()
+    {
+        var options = Options("Wp22_GetPatient");
+        await Seed(options);
+        using var context = new ApplicationDbContext(options);
+        var repo = new PatientMergeRepository(context);
+
+        var patient = await repo.GetPatientWithUserAsync(2);
+        var missing = await repo.GetPatientWithUserAsync(999);
+
+        Assert.NotNull(patient);
+        Assert.NotNull(patient!.User);
+        Assert.Equal(20, patient.User!.Id);
+        Assert.Equal("Perez, Jaun", patient.User.GetFullName());
+        Assert.Null(missing);
+    }
+
+    [Fact]
+    public async Task GetCaretakerLinksAsync_IncludesCaretakerUserAndNotes()
+    {
+        var options = Options("Wp22_Links");
+        await Seed(options);
+        using var context = new ApplicationDbContext(options);
+        var repo = new PatientMergeRepository(context);
+
+        var links = await repo.GetCaretakerLinksAsync(2);
+
+        var link = Assert.Single(links);
+        Assert.NotNull(link.Caretaker);
+        Assert.StartsWith("SYNTHETIC placeholder", link.Caretaker!.Notes);
+        Assert.NotNull(link.Caretaker.User);
+        Assert.Equal(500, link.Caretaker.User!.Id);
+    }
+
+    [Fact]
+    public async Task Counts_RolesAndIdentityChecks_ReadCorrectly()
+    {
+        var options = Options("Wp22_Counts");
+        await Seed(options);
+        using var context = new ApplicationDbContext(options);
+        var repo = new PatientMergeRepository(context);
+
+        Assert.Equal(2, await repo.CountSessionsAsync(2));
+        Assert.Equal(1, await repo.CountSessionsAsync(1));
+        Assert.Equal(1, await repo.CountTreatmentPlansAsync(1));
+        Assert.Equal(0, await repo.CountTreatmentPlansAsync(2));
+
+        var roles = await repo.GetUserRolesAsync(20);
+        Assert.Single(roles);
+        Assert.Equal(2, roles[0].RoleId);
+
+        Assert.False(await repo.IsTherapistUserAsync(20));
+        Assert.False(await repo.IsCaretakerUserAsync(20));
+        Assert.True(await repo.IsCaretakerUserAsync(500)); // the synthetic caretaker's user
+    }
+
+    [Fact]
+    public async Task DeleteUserIdentityAsync_RemovesRolesClaimsAndUser()
+    {
+        var options = Options("Wp22_Retire");
+        await Seed(options);
+        using (var context = new ApplicationDbContext(options))
+        {
+            var repo = new PatientMergeRepository(context);
+            await repo.DeleteUserIdentityAsync(20);
+        }
+
+        using var verify = new ApplicationDbContext(options);
+        Assert.Empty(verify.Set<UserRole>().Where(r => r.UserId == 20));
+        Assert.Empty(verify.UserClaims.Where(c => c.UserId == 20));
+        Assert.Null(await verify.Users.FindAsync(20));
+        // Other identities untouched.
+        Assert.NotNull(await verify.Users.FindAsync(10));
+        Assert.Single(verify.Set<UserRole>().Where(r => r.UserId == 500));
+    }
+
+    [Fact]
+    public async Task DeleteUserIdentityAsync_MissingUser_IsNoOp()
+    {
+        var options = Options("Wp22_RetireMissing");
+        await Seed(options);
+        using var context = new ApplicationDbContext(options);
+        var repo = new PatientMergeRepository(context);
+
+        await repo.DeleteUserIdentityAsync(9999); // must not throw
+    }
+
+    [Fact]
+    public async Task DeletePatient_CaretakerAndLink_Work()
+    {
+        var options = Options("Wp22_Deletes");
+        await Seed(options);
+        using (var context = new ApplicationDbContext(options))
+        {
+            var repo = new PatientMergeRepository(context);
+            var links = await repo.GetCaretakerLinksAsync(2);
+            await repo.DeleteCaretakerLinkAsync(links[0]);
+            await repo.DeleteCaretakerAsync(links[0].Caretaker!);
+            var patient = await repo.GetPatientWithUserAsync(2);
+            await repo.DeletePatientAsync(patient!);
+        }
+
+        using var verify = new ApplicationDbContext(options);
+        Assert.Empty(verify.Set<PatientCaretaker>().Where(pc => pc.PatientId == 2));
+        Assert.Null(await verify.Caretakers.FindAsync(55));
+        Assert.Null(await verify.Patients.FindAsync(2));
+        Assert.NotNull(await verify.Patients.FindAsync(1)); // survivor untouched
+    }
+
+    [Fact]
+    public async Task AddMergeLogAsync_PersistsRow_WithGeneratedId()
+    {
+        var options = Options("Wp22_Log");
+        await Seed(options);
+        int logId;
+        using (var context = new ApplicationDbContext(options))
+        {
+            var repo = new PatientMergeRepository(context);
+            var log = await repo.AddMergeLogAsync(new PatientMergeLog
+            {
+                SurvivorPatientId = 1,
+                EliminatedPatientId = 2,
+                EliminatedUserId = 20,
+                EliminatedName = "Perez, Jaun",
+                EliminatedMrn = "L24-0313",
+                SessionsRemapped = 2,
+                CaretakerLinksDeduped = 0,
+                SyntheticCaretakersDeleted = 1,
+                FieldsFilled = "DateOfBirth",
+                MergedByUserId = 7,
+            });
+            logId = log.Id;
+        }
+
+        Assert.True(logId > 0);
+        using var verify = new ApplicationDbContext(options);
+        var saved = await verify.PatientMergeLogs.FindAsync(logId);
+        Assert.NotNull(saved);
+        Assert.Equal(2, saved!.EliminatedPatientId);
+        Assert.Equal("Perez, Jaun", saved.EliminatedName);
+        Assert.Equal(2, saved.SessionsRemapped);
+        Assert.Equal(1, saved.SyntheticCaretakersDeleted);
+    }
+
+    [Fact]
+    public async Task UpdateCaretakerLinkAsync_PersistsRepoint()
+    {
+        var options = Options("Wp22_Repoint");
+        await Seed(options);
+        using (var context = new ApplicationDbContext(options))
+        {
+            var repo = new PatientMergeRepository(context);
+            var links = await repo.GetCaretakerLinksAsync(2);
+            links[0].PatientId = 1;
+            links[0].PrimaryCaretaker = false;
+            await repo.UpdateCaretakerLinkAsync(links[0]);
+        }
+
+        using var verify = new ApplicationDbContext(options);
+        var moved = await verify.Set<PatientCaretaker>().FindAsync(2055);
+        Assert.Equal(1, moved!.PatientId);
+        Assert.False(moved.PrimaryCaretaker);
+    }
+}

--- a/tests/Web.Tests/Authorization/SensitiveCellAuthorizationTests.cs
+++ b/tests/Web.Tests/Authorization/SensitiveCellAuthorizationTests.cs
@@ -84,6 +84,16 @@ public class SensitiveCellAuthorizationTests : IClassFixture<AccessControlTestFa
     // Patients.View (WP-21, F1) — restricted roles hold no granular claims ⇒ locked out.
     [InlineData("GET", "/api/patients/session-history", "CARETAKER")]
     [InlineData("GET", "/api/patients/1/sessions", "CARETAKER")]
+    // Patients.Merge (WP-22, F2) — EMPTY grants row: only the SYSADMIN wildcard satisfies it,
+    // so every granular operator role is denied.
+    [InlineData("POST", "/api/patients/merge/preview", "MGR")]
+    [InlineData("POST", "/api/patients/merge/preview", "OWN")]
+    [InlineData("POST", "/api/patients/merge", "MGR")]
+    [InlineData("POST", "/api/patients/merge", "AM")]
+    [InlineData("POST", "/api/patients/merge", "FD")]
+    [InlineData("POST", "/api/patients/merge", "OWN")]
+    [InlineData("POST", "/api/patients/merge", "ACCT")]
+    [InlineData("POST", "/api/patients/merge", "CARETAKER")]
     public async Task RoleWithoutClaim_Is403(string method, string route, string role)
     {
         var response = await SendAsync(method, route, TokenFor(role));
@@ -140,6 +150,9 @@ public class SensitiveCellAuthorizationTests : IClassFixture<AccessControlTestFa
     [InlineData("GET", "/api/patients/session-history", "SYSADMIN")]
     [InlineData("GET", "/api/patients/1/sessions", "ACCT")]
     [InlineData("GET", "/api/patients/1/sessions", "FD")]
+    // Patients.Merge (WP-22, F2) — SYSADMIN reaches both actions via the wildcard (no seed).
+    [InlineData("POST", "/api/patients/merge/preview", "SYSADMIN")]
+    [InlineData("POST", "/api/patients/merge", "SYSADMIN")]
     public async Task RoleWithClaim_IsNotBlocked(string method, string route, string role)
     {
         var response = await SendAsync(method, route, TokenFor(role));
@@ -156,6 +169,8 @@ public class SensitiveCellAuthorizationTests : IClassFixture<AccessControlTestFa
     [InlineData("GET", "/api/caretakers/1/statement")]
     [InlineData("GET", "/api/patients/pastdue")]
     [InlineData("GET", "/api/patients/session-history")]
+    [InlineData("POST", "/api/patients/merge/preview")]
+    [InlineData("POST", "/api/patients/merge")]
     public async Task NoToken_Is401(string method, string route)
     {
         var response = await SendAsync(method, route, token: null);

--- a/tests/Web.Tests/GlobalExceptionHandlerTests.cs
+++ b/tests/Web.Tests/GlobalExceptionHandlerTests.cs
@@ -15,6 +15,8 @@ public class GlobalExceptionHandlerTests
         new object[] { new ArgumentException("bad input"), StatusCodes.Status400BadRequest, "Bad Request" },
         new object[] { new ArgumentNullException("param"), StatusCodes.Status400BadRequest, "Bad Request" },
         new object[] { new NotFoundException("Session", 5), StatusCodes.Status404NotFound, "Not Found" },
+        // WP-22: domain-state conflicts (merge blockers) map to 409 with the message intact.
+        new object[] { new ConflictException("merge blocked"), StatusCodes.Status409Conflict, "Conflict" },
         new object[] { new InvalidOperationException("boom"), StatusCodes.Status500InternalServerError, "An unexpected error occurred." },
     };
 

--- a/tests/Web.Tests/PatientsControllerTests.cs
+++ b/tests/Web.Tests/PatientsControllerTests.cs
@@ -21,6 +21,7 @@ public class PatientsControllerTests
     private readonly Mock<IPatientProfileService> _mockPatientProfileService;
     private readonly Mock<IHandleSessionEvent> _mockSessionEventHandler;
     private readonly Mock<ISessionEventRepository> _mockSessionEventRepository;
+    private readonly Mock<IPatientMergeService> _mockPatientMergeService;
     private readonly PatientsController _controller;
 
     public PatientsControllerTests()
@@ -29,7 +30,8 @@ public class PatientsControllerTests
         _mockPatientProfileService = new Mock<IPatientProfileService>();
         _mockSessionEventHandler = new Mock<IHandleSessionEvent>();
         _mockSessionEventRepository = new Mock<ISessionEventRepository>();
-        _controller = new PatientsController(fakeLogger, _mockPatientProfileService.Object, _mockSessionEventHandler.Object, _mockSessionEventRepository.Object);
+        _mockPatientMergeService = new Mock<IPatientMergeService>();
+        _controller = new PatientsController(fakeLogger, _mockPatientProfileService.Object, _mockSessionEventHandler.Object, _mockSessionEventRepository.Object, _mockPatientMergeService.Object);
     }
 
     [Fact]
@@ -261,5 +263,36 @@ public class PatientsControllerTests
         patientInfo.AmountPaidSoFar.Should().BeGreaterOrEqualTo(0);
         patientInfo.Delinquency.Should().NotBeNull()
             .And.HaveCount(0);
-    }    
+    }
+
+    // ── WP-22 (F2): duplicate-patient merge ───────────────────────────────────────────
+
+    [Fact]
+    public async Task PreviewPatientMerge_ReturnsOk_WithServicePreview()
+    {
+        var request = new PatientMergeRequest { SurvivorPatientId = 1, EliminatedPatientId = 2 };
+        var preview = new PatientMergePreview { Blockers = new List<string> { "blocked" } };
+        _mockPatientMergeService.Setup(s => s.PreviewAsync(request)).ReturnsAsync(preview);
+
+        var result = await _controller.PreviewPatientMerge(request);
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        okResult.Value.Should().BeSameAs(preview);
+        _mockPatientMergeService.Verify(s => s.PreviewAsync(request), Times.Once);
+        _mockPatientMergeService.Verify(s => s.MergeAsync(It.IsAny<PatientMergeRequest>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task MergePatients_ReturnsOk_WithServiceResult()
+    {
+        var request = new PatientMergeRequest { SurvivorPatientId = 1, EliminatedPatientId = 2 };
+        var mergeResult = new PatientMergeResult { SurvivorPatientId = 1, EliminatedPatientId = 2, MergeLogId = 42 };
+        _mockPatientMergeService.Setup(s => s.MergeAsync(request)).ReturnsAsync(mergeResult);
+
+        var result = await _controller.MergePatients(request);
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        okResult.Value.Should().BeSameAs(mergeResult);
+        _mockPatientMergeService.Verify(s => s.MergeAsync(request), Times.Once);
+    }
 }


### PR DESCRIPTION
…nly)

POST /api/patients/merge/preview (side-effect-free) + POST /api/patients/merge: one IUnitOfWork transaction that remaps TherapySession/TreatmentPlan (ExecuteUpdate, audit cols stamped explicitly), dedupes/remaps caretaker links (survivor primary wins), retires synthetic -SH (LEGACY) placeholders + their identities, fills survivor blanks (DoB/Cedula/Gender/Notes; eliminated row deleted first so uq_patient_cedula never trips), appends a [MERGED: ...] Notes marker, writes PatientMergeLog, and hard-deletes the eliminated Patient + SystemUser (roles -> claims -> user).

- New PatientMergeService/-Repository (dedicated; existing repos too thin)
- New ConflictException -> 409 arm in GlobalExceptionHandler
- Manifest re-vendored + Permissions.g.cs regenerated + hash anchor 6c42b5362fbc (Patients.Merge = empty grants row; wildcard-only, no RoleClaim seed)
- Tests 385 -> 429: merge service (guards/classification/fill-blanks/ordering/ preview-purity), InMemory repo coverage, controller actions, sensitive-cell rows (all granular roles 403, SYSADMIN not-blocked, no-token 401), 409 handler arm. ExecuteUpdate repoints are MySQL-verified via docs/patient-merge-wp22-verification.md (InMemory cannot run them).

Plan: patient-care-super planning/active/wp-22-merge-duplicate-patients.md