### PR TITLE
WP-23B (F6+F7+F10): specialty default pricing, SENADIS discount floor…

### DIFF
--- a/docs/access-control-matrix.json
+++ b/docs/access-control-matrix.json
@@ -1,9 +1,9 @@
 {
   "_meta": {
-    "generatedAt": "2026-07-11T20:33:41-05:00",
+    "generatedAt": "2026-07-12T08:29:39-05:00",
     "generator": "tools/generate-access-manifest.sh",
     "hashScope": "sha256 (first 12 hex) of canonical JSON {claims:[{claim,grants}]}, claims+grants sorted; wildcard/restricted cells and all metadata excluded",
-    "semanticHash": "6c42b5362fbc",
+    "semanticHash": "10ad6ddcd5dd",
     "source": "access-control-matrix.md"
   },
   "claims": [
@@ -192,6 +192,13 @@
     {
       "claim": "Patients.Merge",
       "grants": []
+    },
+    {
+      "claim": "Patients.SenadisDiscount.Edit",
+      "grants": [
+        "AM",
+        "MGR"
+      ]
     },
     {
       "claim": "Patients.StartDiscovery",

--- a/docs/wp23-booking-money-verification.md
+++ b/docs/wp23-booking-money-verification.md
@@ -1,0 +1,124 @@
+# WP-23B verification — F6 default pricing · F7 SENADIS floor · F10 caretaker guard
+
+Post-deploy curls (run against the deployed API, e.g. `http://neurocorp.k3s:30000`, after
+V026/V027 + the RoleClaim reseed are applied and the API ships this WP). All numbers below are
+examples — substitute real IDs from your environment.
+
+```bash
+API=http://neurocorp.k3s:30000
+```
+
+## 0. Tokens
+
+> ⚠️ The login field is `email`, NOT `username` (binds empty → 401).
+
+```bash
+# SYSADMIN (lookup price editing + everything)
+SA_TOKEN=$(curl -s $API/api/auth/login -H 'Content-Type: application/json' \
+  -d '{"email":"<sysadmin email>","password":"<pwd>"}' | jq -r .accessToken)
+
+# MGR (holds Patients.SenadisDiscount.Edit after the reseed)
+MGR_TOKEN=$(curl -s $API/api/auth/login -H 'Content-Type: application/json' \
+  -d '{"email":"<mgr email>","password":"<pwd>"}' | jq -r .accessToken)
+
+# FD (does NOT hold the gate claim)
+FD_TOKEN=$(curl -s $API/api/auth/login -H 'Content-Type: application/json' \
+  -d '{"email":"<fd email>","password":"<pwd>"}' | jq -r .accessToken)
+```
+
+## 1. F6 — specialty default price (SYSADMIN-only edit, per-type field)
+
+```bash
+# Set a default price on specialty 6 (TL) — expect 204
+curl -s -o /dev/null -w '%{http_code}\n' -X PUT $API/api/lookups/specialty-types/6 \
+  -H "Authorization: Bearer $SA_TOKEN" -H 'Content-Type: application/json' \
+  -d '{"defaultAmount": 65.00}'
+
+# Read it back — expect defaultAmount: 65.00 on TL, null on untouched rows
+curl -s $API/api/lookups/specialty-types -H "Authorization: Bearer $SA_TOKEN" \
+  | jq '.[] | {id, abbreviation, defaultAmount}'
+
+# Per-type isolation: defaultAmount is null on every other lookup table
+curl -s $API/api/lookups/payment-types -H "Authorization: Bearer $SA_TOKEN" \
+  | jq '[.[].defaultAmount] | unique'          # expect [null]
+
+# MGR cannot edit lookup prices (Manage claims are SYSADMIN-only) — expect 403
+curl -s -o /dev/null -w '%{http_code}\n' -X PUT $API/api/lookups/specialty-types/6 \
+  -H "Authorization: Bearer $MGR_TOKEN" -H 'Content-Type: application/json' \
+  -d '{"defaultAmount": 1.00}'
+
+# Validation: negative price — expect 400
+curl -s -o /dev/null -w '%{http_code}\n' -X PUT $API/api/lookups/specialty-types/6 \
+  -H "Authorization: Bearer $SA_TOKEN" -H 'Content-Type: application/json' \
+  -d '{"defaultAmount": -5}'
+```
+
+(The booking-form pre-fill itself is UI behavior — see the WP-23C test scenarios.)
+
+## 2. F7 — SENADIS flag + edit gate
+
+```bash
+# Flag a patient (MGR holds the gate claim) — expect 204
+curl -s -o /dev/null -w '%{http_code}\n' -X PUT $API/api/patients/<patientId> \
+  -H "Authorization: Bearer $MGR_TOKEN" -H 'Content-Type: application/json' \
+  -d '{"hasSenadisDiscount": true}'
+
+# FD tries to CHANGE the flag — expect 403 (field-level gate)
+curl -s -o /dev/null -w '%{http_code}\n' -X PUT $API/api/patients/<patientId> \
+  -H "Authorization: Bearer $FD_TOKEN" -H 'Content-Type: application/json' \
+  -d '{"hasSenadisDiscount": false}'
+
+# FD echoes the UNCHANGED value alongside a phone edit — expect 204 (not a change)
+curl -s -o /dev/null -w '%{http_code}\n' -X PUT $API/api/patients/<patientId> \
+  -H "Authorization: Bearer $FD_TOKEN" -H 'Content-Type: application/json' \
+  -d '{"hasSenadisDiscount": true, "phoneNumber": "555-0199"}'
+
+# Flag visible in the profile
+curl -s $API/api/patients/<patientId> -H "Authorization: Bearer $FD_TOKEN" \
+  | jq '{patientId, hasSenadisDiscount}'
+```
+
+## 3. F7 — SENADIS floor + fee-on-net at booking
+
+```bash
+# Book for the FLAGGED patient with a too-small discount; Amount 100, Discount 5.
+# Expect 201 with discount FLOORED to 20.00 in the created JSON.
+curl -s -X POST $API/api/sessions \
+  -H "Authorization: Bearer $MGR_TOKEN" -H 'Content-Type: application/json' \
+  -d '{"sessionDate":"<future date>","sessionTime":"10:00:00","patientId":<flagged>,
+       "therapistId":<tid>,"specialtyTypeId":6,"duration":60,"amount":100.00,"discount":5.00}' \
+  | jq '{sessionId, amount, discount}'         # discount == 20.00
+
+# Fee-on-net (DB check, %-fee therapist): ProviderAmount = pct × (Amount − Discount),
+# GrossProfit = net − ProviderAmount. For a 0.50-fee therapist on the row above:
+#   ProviderAmount 40.00, GrossProfit 40.00 (pre-WP-23 would have been 50.00 / 30.00).
+mysql ... -e "SELECT Amount, DiscountAmount, ProviderAmount, GrossProfit
+              FROM TherapySession WHERE TherapySessionID = <sessionId>;"
+
+# Unflagged patient, same request — expect discount to stay 5.00
+```
+
+## 4. F10 — caretaker hard block (both create paths)
+
+```bash
+# Patient with NO PatientCaretaker links — expect 400 with the guard message
+curl -s -X POST $API/api/sessions \
+  -H "Authorization: Bearer $MGR_TOKEN" -H 'Content-Type: application/json' \
+  -d '{"sessionDate":"<future date>","sessionTime":"11:00:00","patientId":<caretakerless>,
+       "therapistId":<tid>,"specialtyTypeId":6,"duration":60,"amount":100.00}' \
+  | jq '{status, detail}'   # 400 / "A caretaker must be linked to this patient before booking."
+
+# Bulk path: schedule a plan for the same patient — expect the same 400
+curl -s -X POST $API/api/treatmentplans/<planId>/schedule \
+  -H "Authorization: Bearer $MGR_TOKEN" -H 'Content-Type: application/json' \
+  -d '{"startDate":"<future Monday>","siteId":1}' | jq '{status, detail}'
+```
+
+## Suite state
+
+`dotnet test patient-care-api.sln` → **458 green** (Core 152 / Infrastructure 88 / Web 218;
+was 429 pre-WP-23B). New coverage: fee-on-net (pct + flat), SENADIS floor
+(below/at/above/zero/rounding), unflagged untouched, caretaker guard on both paths,
+lookup per-type mapping (read/create/update + non-specialty isolation), controller edit-gate
+(Forbid / delegate / wildcard / echo / omit), and end-to-end SensitiveCell rows
+(FD+ACCT 403 on flag change; MGR/AM/SYSADMIN pass; FD echo passes).

--- a/src/Core/BusinessObjects/Lookups/LookupCreateRequest.cs
+++ b/src/Core/BusinessObjects/Lookups/LookupCreateRequest.cs
@@ -16,4 +16,8 @@ public class LookupCreateRequest
     public string? Description { get; set; }
 
     public int SortOrder { get; set; } = 0;
+
+    // WP-23 (F6): accepted only for specialty-types; ignored for every other table.
+    [Range(0, 99999999.99)]
+    public decimal? DefaultAmount { get; set; }
 }

--- a/src/Core/BusinessObjects/Lookups/LookupItem.cs
+++ b/src/Core/BusinessObjects/Lookups/LookupItem.cs
@@ -7,6 +7,8 @@ public class LookupItem
     public string Name { get; set; } = string.Empty;
     public string? Description { get; set; }
     public int SortOrder { get; set; }
+    // WP-23 (F6): per-type field — populated only for specialty-types; null for every other table.
+    public decimal? DefaultAmount { get; set; }
     public DateTime CreatedTimestamp { get; set; }
     public DateTime LastUpdatedTimestamp { get; set; }
 }

--- a/src/Core/BusinessObjects/Lookups/LookupUpdateRequest.cs
+++ b/src/Core/BusinessObjects/Lookups/LookupUpdateRequest.cs
@@ -14,4 +14,9 @@ public class LookupUpdateRequest
     public string? Description { get; set; }
 
     public int? SortOrder { get; set; }
+
+    // WP-23 (F6): accepted only for specialty-types (null = unchanged; clearing to NULL is out of
+    // scope — 0 is a legal price, not a sentinel); ignored for every other table.
+    [Range(0, 99999999.99)]
+    public decimal? DefaultAmount { get; set; }
 }

--- a/src/Core/BusinessObjects/Patients/PatientProfile.cs
+++ b/src/Core/BusinessObjects/Patients/PatientProfile.cs
@@ -20,6 +20,8 @@ public class PatientProfile : IProfile
     public DateTime CreatedTimestamp { get; set; }
     public string? Gender { get; set; }
     public bool IsActive { get; set; }
+    // WP-23 (F7): statutory SENADIS 20% discount flag; edit gated by Patients.SenadisDiscount.Edit.
+    public bool HasSenadisDiscount { get; set; }
     public bool? HasCompletedDiscovery { get; set; }
     public List<PatientCaretakerSummary> Caretakers { get; set; } = new();
 

--- a/src/Core/BusinessObjects/Patients/PatientProfileRequest.cs
+++ b/src/Core/BusinessObjects/Patients/PatientProfileRequest.cs
@@ -33,4 +33,6 @@ public class PatientProfileRequest
     [Required]
     [AllowedValues("Male", "Female", "Other")]
     public string Gender { get; set; }
+    // WP-23 (F7): settable at create by any patient-creating role (Questionnaire E gates edits only).
+    public bool HasSenadisDiscount { get; set; }
 }

--- a/src/Core/BusinessObjects/Patients/PatientProfileUpdateRequest.cs
+++ b/src/Core/BusinessObjects/Patients/PatientProfileUpdateRequest.cs
@@ -29,6 +29,9 @@ public class PatientProfileUpdateRequest
     public bool ActiveStatus { get; set; }
     public string? MedicalRecordNumber { get; set; }
     public string? Cedula { get; set; }
+    // WP-23 (F7): omitted/null = unchanged. Changing the stored value requires the
+    // Patients.SenadisDiscount.Edit claim (gate enforced in PatientsController.UpdatePatient).
+    public bool? HasSenadisDiscount { get; set; }
 
     public override string ToString()
     {

--- a/src/Core/Entities/Patient.cs
+++ b/src/Core/Entities/Patient.cs
@@ -16,6 +16,9 @@ public class Patient : PersonBase
     // markers). Deliberately NOT surfaced in any DTO/endpoint/UI — the property exists so the
     // entity stays conformant with the DB schema (V021) for /audit-db-api.
     public string? Notes { get; set; }
+    // WP-23 (F7): statutory SENADIS 20% discount — both session-create paths apply a
+    // 20%-of-Amount discount floor when set.
+    public bool HasSenadisDiscount { get; set; }
     public ICollection<PatientCaretaker>? Caretakers { get; set; }
 
     public bool HasTemporaryMrn()

--- a/src/Core/Entities/SpecialtyType.cs
+++ b/src/Core/Entities/SpecialtyType.cs
@@ -3,4 +3,6 @@ namespace Neurocorp.Api.Core.Entities;
 public class SpecialtyType : LookupEntityBase
 {
     public bool IsDiscovery { get; set; }
+    // WP-23 (F6): default session price pre-filled at booking; NULL = no default.
+    public decimal? DefaultAmount { get; set; }
 }

--- a/src/Core/Services/BulkSchedulingService.cs
+++ b/src/Core/Services/BulkSchedulingService.cs
@@ -18,19 +18,25 @@ public class BulkSchedulingService : IBulkSchedulingService
     private readonly ITherapySessionRepository _sessionRepository;
     private readonly ITherapistRepository _therapistRepository;
     private readonly ITherapistSpecialtyRepository _specialtyRepository;
+    private readonly IPatientCaretakerRepository _patientCaretakerRepository;
+    private readonly IPatientProfileService _patientService;
 
     public BulkSchedulingService(
         ILogger<BulkSchedulingService> logger,
         ITreatmentPlanRepository planRepository,
         ITherapySessionRepository sessionRepository,
         ITherapistRepository therapistRepository,
-        ITherapistSpecialtyRepository specialtyRepository)
+        ITherapistSpecialtyRepository specialtyRepository,
+        IPatientCaretakerRepository patientCaretakerRepository,
+        IPatientProfileService patientService)
     {
         _logger = logger;
         _planRepository = planRepository;
         _sessionRepository = sessionRepository;
         _therapistRepository = therapistRepository;
         _specialtyRepository = specialtyRepository;
+        _patientCaretakerRepository = patientCaretakerRepository;
+        _patientService = patientService;
     }
 
     public async Task<BulkScheduleResult> ScheduleAsync(int planId, BulkScheduleRequest request)
@@ -45,6 +51,16 @@ public class BulkSchedulingService : IBulkSchedulingService
 
         if (await _sessionRepository.HasSessionsForPlanAsync(planId))
             throw new ArgumentException("This plan already has scheduled sessions. Cancel existing sessions before re-scheduling.");
+
+        // WP-23 (F10): hard block — no caretaker on file, no booking (same guard as the
+        // single-session path; synthetic placeholders count). ArgumentException → 400.
+        var caretakerLinks = await _patientCaretakerRepository.GetByPatientIdAsync(plan.PatientId);
+        if (!caretakerLinks.Any())
+            throw new ArgumentException("A caretaker must be linked to this patient before booking.");
+
+        // WP-23 (F7): SENADIS patients get a per-line discount floor of 20% of Amount.
+        var patientProfile = await _patientService.GetByIdAsync(plan.PatientId);
+        var hasSenadisDiscount = patientProfile?.HasSenadisDiscount ?? false;
 
         // Build effective lines (plan lines merged with overrides)
         var overrideMap = request.LineOverrides.ToDictionary(o => o.TreatmentPlanLineId);
@@ -161,6 +177,9 @@ public class BulkSchedulingService : IBulkSchedulingService
                 // Compute financials
                 var amount = Math.Round(HourlyRate * line.Duration / 60m, 2);
                 var discountAmount = Math.Min(line.DiscountAmount, amount);
+                // WP-23 (F7): statutory SENADIS floor — staff may grant more, never less.
+                if (hasSenadisDiscount)
+                    discountAmount = Math.Max(discountAmount, Math.Round(0.20m * amount, 2));
                 var netAmount = amount - discountAmount;
                 var providerAmount = ComputeProviderAmount(assignedTherapistId.Value, netAmount, therapistMap);
                 var grossProfit = netAmount - providerAmount;

--- a/src/Core/Services/LookupService.cs
+++ b/src/Core/Services/LookupService.cs
@@ -109,6 +109,13 @@ public class LookupService : ILookupService
             LastUpdatedTimestamp = now,
         };
 
+        // WP-23 (F6): DefaultAmount is a per-type field — honored only for SpecialtyType,
+        // silently ignored for every other lookup table (their schema has no such column).
+        if (entity is SpecialtyType specialty && request.DefaultAmount.HasValue)
+        {
+            specialty.DefaultAmount = request.DefaultAmount;
+        }
+
         var repository = _serviceProvider.GetRequiredService<IRepository<T>>();
         var created = await repository.AddAsync(entity);
         _logger.LogInformation("Created {EntityType} with ID: {Id}", typeof(T).Name, created.Id);
@@ -128,6 +135,11 @@ public class LookupService : ILookupService
         if (request.Name != null) entity.Name = request.Name;
         if (request.Description != null) entity.Description = request.Description;
         if (request.SortOrder != null) entity.SortOrder = (short)request.SortOrder.Value;
+        // WP-23 (F6): per-type field — SpecialtyType only; null = unchanged (0 is a legal price).
+        if (entity is SpecialtyType specialty && request.DefaultAmount.HasValue)
+        {
+            specialty.DefaultAmount = request.DefaultAmount;
+        }
         entity.LastUpdatedTimestamp = DateTime.UtcNow;
 
         await repository.UpdateAsync(entity);
@@ -144,6 +156,8 @@ public class LookupService : ILookupService
             Name = entity.Name,
             Description = entity.Description,
             SortOrder = entity.SortOrder,
+            // WP-23 (F6): per-type field — populated only for SpecialtyType, null elsewhere.
+            DefaultAmount = (entity as SpecialtyType)?.DefaultAmount,
             CreatedTimestamp = entity.CreatedTimestamp,
             LastUpdatedTimestamp = entity.LastUpdatedTimestamp,
         };

--- a/src/Core/Services/PatientProfileService.cs
+++ b/src/Core/Services/PatientProfileService.cs
@@ -101,6 +101,7 @@ public class PatientProfileService : IPatientProfileService
             PatientName = $"{newUser.LastName}, {newUser.FirstName} {newUser.MiddleName}".Trim(),
             MedicalRecordNumber = newPatient.MedicalRecordNumber,
             Cedula = newPatient.Cedula,
+            HasSenadisDiscount = newPatient.HasSenadisDiscount,
             DateOfBirth = newPatient.DateOfBirth ?? DateTime.MinValue,
             Email = newUser.Email,
             PhoneNumber = newUser.PhoneNumber,
@@ -184,7 +185,8 @@ public class PatientProfileService : IPatientProfileService
             MedicalRecordNumber = string.IsNullOrWhiteSpace(patientRequest.MedicalRecordNumber)
                 ? null
                 : patientRequest.MedicalRecordNumber,
-            Cedula = string.IsNullOrWhiteSpace(patientRequest.Cedula) ? null : patientRequest.Cedula
+            Cedula = string.IsNullOrWhiteSpace(patientRequest.Cedula) ? null : patientRequest.Cedula,
+            HasSenadisDiscount = patientRequest.HasSenadisDiscount
         };
     }
 

--- a/src/Core/Services/SessionEventHandler.cs
+++ b/src/Core/Services/SessionEventHandler.cs
@@ -18,8 +18,9 @@ public class SessionEventHandler : IHandleSessionEvent
     private readonly ITherapistProfileService _therapistService;
     private readonly IRepository<SpecialtyType> _specialtyTypeRepository;
     private readonly ITherapistSpecialtyRepository _therapistSpecialtyRepository;
+    private readonly IPatientCaretakerRepository _patientCaretakerRepository;
 
-    public SessionEventHandler(ILogger<SessionEventHandler> logger, ISessionEventRepository repo, ITherapySessionRepository therapySessionRepo, ITherapistProfileService therapistSvc, IPatientProfileService patientSvc, IRepository<SpecialtyType> specialtyTypeRepo, ITherapistSpecialtyRepository therapistSpecialtyRepo)
+    public SessionEventHandler(ILogger<SessionEventHandler> logger, ISessionEventRepository repo, ITherapySessionRepository therapySessionRepo, ITherapistProfileService therapistSvc, IPatientProfileService patientSvc, IRepository<SpecialtyType> specialtyTypeRepo, ITherapistSpecialtyRepository therapistSpecialtyRepo, IPatientCaretakerRepository patientCaretakerRepo)
     {
         _logger = logger;
         _repository = repo;
@@ -28,6 +29,7 @@ public class SessionEventHandler : IHandleSessionEvent
         _therapistService = therapistSvc;
         _specialtyTypeRepository = specialtyTypeRepo;
         _therapistSpecialtyRepository = therapistSpecialtyRepo;
+        _patientCaretakerRepository = patientCaretakerRepo;
     }
 
     public async Task<IEnumerable<SessionEvent>> GetAllAsync()
@@ -131,6 +133,23 @@ public class SessionEventHandler : IHandleSessionEvent
     {
         _logger.LogInformation("Started creating a new therapy session from request.");
         var (pProfile, tProfile) = await FetchTargetPartiesAsync(request);
+
+        // WP-23 (F10): hard block — no caretaker on file, no booking (owner ruling: synthetic
+        // placeholders satisfy the rule; they are PatientCaretaker links like any other).
+        // ArgumentException → 400 via GlobalExceptionHandler.
+        var caretakerLinks = await _patientCaretakerRepository.GetByPatientIdAsync(request.PatientId);
+        if (!caretakerLinks.Any())
+        {
+            throw new ArgumentException("A caretaker must be linked to this patient before booking.");
+        }
+
+        // WP-23 (F7): statutory SENADIS discount FLOOR — 20% of Amount, staff may grant more,
+        // never less. (A pending "no stacking" customer ruling would tighten this to exactly-20%.)
+        if (pProfile!.HasSenadisDiscount)
+        {
+            request.Discount = Math.Max(request.Discount, Math.Round(0.20m * request.Amount, 2));
+        }
+
         var specialty = await ResolveSpecialtyAsync(request);
 
         // Discovery-first enforcement: treatment specialties require a completed discovery session
@@ -212,8 +231,11 @@ public class SessionEventHandler : IHandleSessionEvent
 
     private static TherapySession MapToNewSessionEvent(PatientProfile pProfile, TherapistProfile tProfile, SessionEventRequest req, SpecialtyType? specialty)
     {
-        var calcProviderAmt = tProfile.CalculateFee(req.Amount);
-        var calcGrossProfit = CalculateGrossProfit(tProfile, req);
+        // WP-23 (Questionnaire E ruling): the therapist fee applies to the NET amount — after
+        // discounts — matching BulkSchedulingService. Flat fees are unaffected by the base.
+        var netAmount = req.Amount - req.Discount;
+        var calcProviderAmt = tProfile.CalculateFee(netAmount);
+        var calcGrossProfit = netAmount - calcProviderAmt;
         // When SpecialtyTypeId is provided, populate TherapyTypes from specialty for backward compat
         var therapyTypes = specialty != null ? specialty.Abbreviation : req.TherapyType;
         return new TherapySession()
@@ -233,11 +255,6 @@ public class SessionEventHandler : IHandleSessionEvent
             SiteId = req.SiteId,
             SpecialtyTypeId = specialty?.Id ?? req.SpecialtyTypeId,
         };
-    }
-
-    private static decimal CalculateGrossProfit(TherapistProfile tProfile, SessionEventRequest request)
-    {
-        return request.Amount - request.Discount - tProfile.CalculateFee(request.Amount);
     }
 
     private async Task<SpecialtyType?> ResolveSpecialtyAsync(SessionEventRequest request)

--- a/src/Infrastructure/Data/Configurations/ReferenceConfigurations.cs
+++ b/src/Infrastructure/Data/Configurations/ReferenceConfigurations.cs
@@ -32,6 +32,7 @@ public class SpecialtyTypeConfiguration : IEntityTypeConfiguration<SpecialtyType
         builder.Property(e => e.Abbreviation).HasColumnName("SpecialtyAbbreviation");
         builder.Property(e => e.Name).HasColumnName("SpecialtyName");
         builder.Property(e => e.Description).HasColumnName("SpecialtyDescription");
+        builder.Property(e => e.DefaultAmount).HasPrecision(10, 2);
     }
 }
 

--- a/src/Infrastructure/Repositories/PatientProfileRepository.cs
+++ b/src/Infrastructure/Repositories/PatientProfileRepository.cs
@@ -147,6 +147,11 @@ public class PatientProfileRepository(ApplicationDbContext dbContext) :
                 ? null
                 : patientRequest.Cedula;
         }
+        // WP-23 (F7): null = unchanged; the claim gate ran in the controller before we get here.
+        if (patientRequest.HasSenadisDiscount.HasValue)
+        {
+            patientOnFile.HasSenadisDiscount = patientRequest.HasSenadisDiscount.Value;
+        }
 
         return patientOnFile;
     }
@@ -178,6 +183,7 @@ public class PatientProfileRepository(ApplicationDbContext dbContext) :
             PatientName = $"{p.User.LastName}, {p.User.FirstName} {p.User.MiddleName}".Trim(),
             MedicalRecordNumber = p.MedicalRecordNumber,
             Cedula = p.Cedula,
+            HasSenadisDiscount = p.HasSenadisDiscount,
             Gender = p.Gender,
             DateOfBirth = p.DateOfBirth ?? DateTime.MinValue,
             Email = p.User.Email,

--- a/src/Web/Authorization/AccessControlManifest.cs
+++ b/src/Web/Authorization/AccessControlManifest.cs
@@ -18,5 +18,5 @@ namespace Neurocorp.Api.Web.Authorization;
 public static class AccessControlManifest
 {
     /// <summary>First 12 hex chars of SHA-256 over the manifest's canonical grant tuples.</summary>
-    public const string SemanticHash = "6c42b5362fbc";
+    public const string SemanticHash = "10ad6ddcd5dd";
 }

--- a/src/Web/Authorization/Permissions.g.cs
+++ b/src/Web/Authorization/Permissions.g.cs
@@ -7,7 +7,7 @@
 //   (patient-care-super/tools/generate-access-manifest.sh), re-vendor
 //   docs/access-control-matrix.json, then re-run tools/generate-permissions.sh.
 //
-//   Access-control manifest semantic hash: 6c42b5362fbc
+//   Access-control manifest semantic hash: 10ad6ddcd5dd
 // </auto-generated>
 
 namespace Neurocorp.Api.Web.Authorization;
@@ -49,6 +49,7 @@ public static class Permissions
     public const string PatientsEdit = "Patients.Edit";
     public const string PatientsLinkCaretaker = "Patients.LinkCaretaker";
     public const string PatientsMerge = "Patients.Merge";
+    public const string PatientsSenadisDiscountEdit = "Patients.SenadisDiscount.Edit";
     public const string PatientsStartDiscovery = "Patients.StartDiscovery";
     public const string PatientsView = "Patients.View";
     public const string PaymentsAdjust = "Payments.Adjust";

--- a/src/Web/Controllers/PatientsController.cs
+++ b/src/Web/Controllers/PatientsController.cs
@@ -151,11 +151,24 @@ public class PatientsController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
     public async Task<IActionResult> UpdatePatient(int id, [FromBody] PatientProfileUpdateRequest patientRequest)
     {
-        if (!await _patientProfileService.VerifyRequestAsync(id))
+        var patientOnFile = await _patientProfileService.GetByIdAsync(id);
+        if (patientOnFile is null)
         {
             return Problem(statusCode: StatusCodes.Status400BadRequest,
                 detail: $"The update request is not valid for patient {id}.", title: "Bad Request");
         }
+
+        // WP-23 (F7): field-level WRITE gate — the platform's first (read-side precedent:
+        // ProviderAmountResultFilter). Changing the SENADIS flag needs its own claim (MGR/AM by
+        // Questionnaire E); present-but-unchanged passes so clients that echo the full profile
+        // keep working for FD. Nothing is applied on the Forbid path.
+        if (patientRequest.HasSenadisDiscount.HasValue
+            && patientRequest.HasSenadisDiscount.Value != patientOnFile.HasSenadisDiscount
+            && !User.HasPermission(Permissions.PatientsSenadisDiscountEdit))
+        {
+            return Forbid();
+        }
+
         try
         {
             if (!await _patientProfileService.UpdateAsync(id, patientRequest))

--- a/tests/Core.Tests/BulkSchedulingServiceTests.cs
+++ b/tests/Core.Tests/BulkSchedulingServiceTests.cs
@@ -1,9 +1,11 @@
 using Moq;
 using Microsoft.Extensions.Logging;
 using Neurocorp.Api.Core.Services;
+using Neurocorp.Api.Core.BusinessObjects.Patients;
 using Neurocorp.Api.Core.BusinessObjects.TreatmentPlans;
 using Neurocorp.Api.Core.Entities;
 using Neurocorp.Api.Core.Interfaces.Repositories;
+using Neurocorp.Api.Core.Interfaces.Services;
 
 namespace Core.Tests;
 
@@ -13,6 +15,8 @@ public class BulkSchedulingServiceTests
     private readonly Mock<ITherapySessionRepository> _mockSessionRepo;
     private readonly Mock<ITherapistRepository> _mockTherapistRepo;
     private readonly Mock<ITherapistSpecialtyRepository> _mockSpecialtyRepo;
+    private readonly Mock<IPatientCaretakerRepository> _mockPatientCaretakerRepo;
+    private readonly Mock<IPatientProfileService> _mockPatientService;
     private readonly BulkSchedulingService _sut;
 
     public BulkSchedulingServiceTests()
@@ -22,12 +26,24 @@ public class BulkSchedulingServiceTests
         _mockSessionRepo = new Mock<ITherapySessionRepository>();
         _mockTherapistRepo = new Mock<ITherapistRepository>();
         _mockSpecialtyRepo = new Mock<ITherapistSpecialtyRepository>();
+        _mockPatientCaretakerRepo = new Mock<IPatientCaretakerRepository>();
+        _mockPatientService = new Mock<IPatientProfileService>();
+        // WP-23 defaults: patient has a caretaker link and no SENADIS flag, so the
+        // pre-existing scheduling tests run unchanged.
+        _mockPatientCaretakerRepo
+            .Setup(r => r.GetByPatientIdAsync(It.IsAny<int>()))
+            .ReturnsAsync(new List<PatientCaretaker> { new() { PatientId = 1, CaretakerId = 1 } });
+        _mockPatientService
+            .Setup(s => s.GetByIdAsync(It.IsAny<int>()))
+            .ReturnsAsync(new PatientProfile { PatientId = 1, PatientName = "P" });
         _sut = new BulkSchedulingService(
             logger,
             _mockPlanRepo.Object,
             _mockSessionRepo.Object,
             _mockTherapistRepo.Object,
-            _mockSpecialtyRepo.Object);
+            _mockSpecialtyRepo.Object,
+            _mockPatientCaretakerRepo.Object,
+            _mockPatientService.Object);
     }
 
     private TreatmentPlan CreateActivePlan(int id = 1, int patientId = 1, int weeks = 2, int frequency = 1)
@@ -84,6 +100,70 @@ public class BulkSchedulingServiceTests
             .ReturnsAsync(new List<TherapySession>());
         _mockSessionRepo.Setup(r => r.AddRangeAsync(It.IsAny<IEnumerable<TherapySession>>()))
             .Returns(Task.CompletedTask);
+    }
+
+    // --- WP-23 (F7/F10): SENADIS floor + caretaker guard on the bulk path ---
+
+    [Fact]
+    public async Task ScheduleAsync_PatientWithoutCaretaker_ThrowsArgumentException()
+    {
+        var plan = CreateActivePlan(weeks: 1, frequency: 1);
+        SetupCommonMocks(plan);
+        SetupTherapist(10, "Dr.", "Smith", feePct: 0.40m);
+        _mockSpecialtyRepo.Setup(r => r.GetTherapistIdsBySpecialtyAsync(5)).ReturnsAsync(new List<int> { 10 });
+        _mockPatientCaretakerRepo
+            .Setup(r => r.GetByPatientIdAsync(plan.PatientId))
+            .ReturnsAsync(new List<PatientCaretaker>());
+
+        var ex = await Assert.ThrowsAsync<ArgumentException>(
+            () => _sut.ScheduleAsync(1, new BulkScheduleRequest { StartDate = new DateOnly(2026, 4, 13), SiteId = 1 }));
+
+        Assert.Contains("caretaker must be linked", ex.Message);
+        _mockSessionRepo.Verify(r => r.AddRangeAsync(It.IsAny<IEnumerable<TherapySession>>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ScheduleAsync_SenadisPatient_FloorsEachLineDiscountAtTwentyPercent()
+    {
+        // 60-min line at the 65/h rate → amount 65.00; floor = round(0.20 × 65, 2) = 13.00.
+        var plan = CreateActivePlan(weeks: 1, frequency: 1);
+        SetupCommonMocks(plan);
+        SetupTherapist(10, "Dr.", "Smith", feePct: 0.40m);
+        _mockSpecialtyRepo.Setup(r => r.GetTherapistIdsBySpecialtyAsync(5)).ReturnsAsync(new List<int> { 10 });
+        _mockPatientService
+            .Setup(s => s.GetByIdAsync(plan.PatientId))
+            .ReturnsAsync(new PatientProfile { PatientId = plan.PatientId, PatientName = "P", HasSenadisDiscount = true });
+
+        var result = await _sut.ScheduleAsync(1, new BulkScheduleRequest { StartDate = new DateOnly(2026, 4, 13), SiteId = 1 });
+
+        var session = Assert.Single(result.Sessions);
+        Assert.Equal(65.00m, session.Amount);
+        Assert.Equal(13.00m, session.DiscountAmount);                       // floored from 0
+        Assert.Equal(Math.Round((65.00m - 13.00m) * 0.40m, 2), Math.Round(session.ProviderAmount, 2)); // fee on net
+    }
+
+    [Fact]
+    public async Task ScheduleAsync_SenadisPatient_KeepsLargerRequestedDiscount()
+    {
+        var plan = CreateActivePlan(weeks: 1, frequency: 1);
+        SetupCommonMocks(plan);
+        SetupTherapist(10, "Dr.", "Smith", feePct: 0.40m);
+        _mockSpecialtyRepo.Setup(r => r.GetTherapistIdsBySpecialtyAsync(5)).ReturnsAsync(new List<int> { 10 });
+        _mockPatientService
+            .Setup(s => s.GetByIdAsync(plan.PatientId))
+            .ReturnsAsync(new PatientProfile { PatientId = plan.PatientId, PatientName = "P", HasSenadisDiscount = true });
+
+        var request = new BulkScheduleRequest
+        {
+            StartDate = new DateOnly(2026, 4, 13),
+            SiteId = 1,
+            LineOverrides = [new LineOverride { TreatmentPlanLineId = 1, DiscountAmount = 30m }]
+        };
+
+        var result = await _sut.ScheduleAsync(1, request);
+
+        var session = Assert.Single(result.Sessions);
+        Assert.Equal(30m, session.DiscountAmount); // above the 13.00 floor → kept
     }
 
     [Fact]

--- a/tests/Core.Tests/LookupServiceTests.cs
+++ b/tests/Core.Tests/LookupServiceTests.cs
@@ -179,4 +179,96 @@ public class LookupServiceTests
         // Assert
         Assert.False(result);
     }
+
+    // --- WP-23 (F6): DefaultAmount is a per-type field — SpecialtyType only ---
+
+    private Mock<IRepository<SpecialtyType>> UseSpecialtyRepo()
+    {
+        var mockSpecialtyRepo = new Mock<IRepository<SpecialtyType>>();
+        var mockServiceProvider = new Mock<IServiceProvider>();
+        mockServiceProvider
+            .Setup(sp => sp.GetService(typeof(IRepository<SpecialtyType>)))
+            .Returns(mockSpecialtyRepo.Object);
+        _specialtyService = new LookupService(mockServiceProvider.Object, Mock.Of<ILogger<LookupService>>());
+        return mockSpecialtyRepo;
+    }
+
+    private LookupService _specialtyService = null!;
+
+    [Fact]
+    public async Task GetAllAsync_SpecialtyTypes_PopulatesDefaultAmount()
+    {
+        var repo = UseSpecialtyRepo();
+        repo.Setup(r => r.GetAllAsync()).ReturnsAsync(new List<SpecialtyType>
+        {
+            new() { Id = 1, Abbreviation = "TL", Name = "Language Therapy", DefaultAmount = 65.00m },
+            new() { Id = 2, Abbreviation = "FS", Name = "Physiotherapy", DefaultAmount = null },
+        });
+
+        var items = (await _specialtyService.GetAllAsync("specialty-types")).ToList();
+
+        Assert.Equal(65.00m, items[0].DefaultAmount);
+        Assert.Null(items[1].DefaultAmount);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_NonSpecialtyTable_DefaultAmountIsAlwaysNull()
+    {
+        _mockRepo.Setup(r => r.GetAllAsync()).ReturnsAsync(new List<AppointmentStatus>
+        {
+            new() { Id = 1, Abbreviation = "PROP", Name = "Proposed" },
+        });
+
+        var items = (await _service.GetAllAsync("appointment-statuses")).ToList();
+
+        Assert.Null(items[0].DefaultAmount);
+    }
+
+    [Fact]
+    public async Task CreateAsync_SpecialtyType_HonorsDefaultAmount()
+    {
+        var repo = UseSpecialtyRepo();
+        SpecialtyType? captured = null;
+        repo.Setup(r => r.AddAsync(It.IsAny<SpecialtyType>()))
+            .Callback<SpecialtyType>(e => captured = e)
+            .ReturnsAsync((SpecialtyType e) => e);
+
+        var result = await _specialtyService.CreateAsync("specialty-types",
+            new LookupCreateRequest { Abbreviation = "HYD", Name = "Hydrotherapy", DefaultAmount = 80.50m });
+
+        Assert.Equal(80.50m, captured!.DefaultAmount);
+        Assert.Equal(80.50m, result.DefaultAmount);
+    }
+
+    [Fact]
+    public async Task CreateAsync_NonSpecialtyTable_IgnoresDefaultAmount()
+    {
+        AppointmentStatus? captured = null;
+        _mockRepo.Setup(r => r.AddAsync(It.IsAny<AppointmentStatus>()))
+            .Callback<AppointmentStatus>(e => captured = e)
+            .ReturnsAsync((AppointmentStatus e) => e);
+
+        var result = await _service.CreateAsync("appointment-statuses",
+            new LookupCreateRequest { Abbreviation = "NEW", Name = "NewStatus", DefaultAmount = 99m });
+
+        Assert.NotNull(captured); // entity has no DefaultAmount property to set — nothing to assert on it
+        Assert.Null(result.DefaultAmount);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_SpecialtyType_SetsDefaultAmount_AndNullMeansUnchanged()
+    {
+        var repo = UseSpecialtyRepo();
+        var existing = new SpecialtyType { Id = 1, Abbreviation = "TL", Name = "Language Therapy", DefaultAmount = 65m };
+        repo.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(existing);
+        repo.Setup(r => r.UpdateAsync(It.IsAny<SpecialtyType>())).Returns(Task.CompletedTask);
+
+        // null = unchanged
+        await _specialtyService.UpdateAsync("specialty-types", 1, new LookupUpdateRequest { Name = "Renamed" });
+        Assert.Equal(65m, existing.DefaultAmount);
+
+        // provided = set
+        await _specialtyService.UpdateAsync("specialty-types", 1, new LookupUpdateRequest { DefaultAmount = 70.25m });
+        Assert.Equal(70.25m, existing.DefaultAmount);
+    }
 }

--- a/tests/Core.Tests/SessionEventHandlerTests.cs
+++ b/tests/Core.Tests/SessionEventHandlerTests.cs
@@ -18,6 +18,7 @@ public class SessionEventHandlerTests
     private readonly Mock<ITherapistProfileService> _mockTherapistService;
     private readonly Mock<IRepository<SpecialtyType>> _mockSpecialtyTypeRepository;
     private readonly Mock<ITherapistSpecialtyRepository> _mockTherapistSpecialtyRepository;
+    private readonly Mock<IPatientCaretakerRepository> _mockPatientCaretakerRepository;
     private readonly SessionEventHandler _sut;
 
     public SessionEventHandlerTests()
@@ -29,6 +30,11 @@ public class SessionEventHandlerTests
         _mockTherapistService = new Mock<ITherapistProfileService>();
         _mockSpecialtyTypeRepository = new Mock<IRepository<SpecialtyType>>();
         _mockTherapistSpecialtyRepository = new Mock<ITherapistSpecialtyRepository>();
+        _mockPatientCaretakerRepository = new Mock<IPatientCaretakerRepository>();
+        // WP-23 (F10): default = patient HAS a caretaker link so pre-existing tests book freely.
+        _mockPatientCaretakerRepository
+            .Setup(r => r.GetByPatientIdAsync(It.IsAny<int>()))
+            .ReturnsAsync(new List<PatientCaretaker> { new() { PatientId = 1, CaretakerId = 1 } });
         _sut = new SessionEventHandler(
             fakeLogger,
             _mockRepository.Object,
@@ -36,7 +42,8 @@ public class SessionEventHandlerTests
             _mockTherapistService.Object,
             _mockPatientService.Object,
             _mockSpecialtyTypeRepository.Object,
-            _mockTherapistSpecialtyRepository.Object);
+            _mockTherapistSpecialtyRepository.Object,
+            _mockPatientCaretakerRepository.Object);
     }
 
     [Fact]
@@ -218,6 +225,121 @@ public class SessionEventHandlerTests
         Assert.Null(result.SpecialtyAbbreviation);
         Assert.Null(result.IsDiscovery);
         Assert.Equal("N/A", result.TherapyTypes);
+    }
+
+    // --- WP-23: fee-on-net + SENADIS floor + caretaker guard (F7/F10, Questionnaire E) ---
+
+    private TherapySession? _capturedSession;
+
+    private void SetupCreateAsyncWithCapture(PatientProfile patient, TherapistProfile therapist)
+    {
+        _mockPatientService.Setup(s => s.GetByIdAsync(patient.PatientId)).ReturnsAsync(patient);
+        _mockTherapistService.Setup(s => s.GetByIdAsync(therapist.TherapistId)).ReturnsAsync(therapist);
+        _mockTherapySessionRepository
+            .Setup(r => r.AddAsync(It.IsAny<TherapySession>()))
+            .Callback<TherapySession>(ts => _capturedSession = ts)
+            .ReturnsAsync((TherapySession ts) => ts);
+        _mockTherapySessionRepository
+            .Setup(r => r.HasCompletedDiscoveryAsync(It.IsAny<int>()))
+            .ReturnsAsync(true);
+        _mockTherapistSpecialtyRepository
+            .Setup(r => r.HasTherapistSpecialtyAsync(It.IsAny<int>(), It.IsAny<int>()))
+            .ReturnsAsync(true);
+        _mockSpecialtyTypeRepository.Setup(r => r.GetAllAsync()).ReturnsAsync(new List<SpecialtyType>());
+    }
+
+    private static SessionEventRequest MakeRequest(decimal amount, decimal discount) => new()
+    {
+        PatientId = 1, TherapistId = 1, SessionDate = DateOnly.Parse("2026-07-20"),
+        SessionTime = TimeOnly.Parse("10:00"), Amount = amount, Discount = discount, Duration = 60,
+        TherapyType = "N/A"
+    };
+
+    [Fact]
+    public async Task CreateAsync_PercentFee_ComputesProviderAmountOnNet()
+    {
+        // Questionnaire E ruling (owner 2026-07-12): fee applies AFTER discounts — net, not gross.
+        SetupCreateAsyncWithCapture(
+            new PatientProfile { PatientId = 1, PatientName = "P" },
+            new TherapistProfile { TherapistId = 1, TherapistName = "T", FeePctPerSession = 0.50m });
+
+        await _sut.CreateAsync(MakeRequest(amount: 100m, discount: 20m));
+
+        Assert.NotNull(_capturedSession);
+        Assert.Equal(40m, _capturedSession!.ProviderAmount);  // 0.50 × (100 − 20), was 50 on gross
+        Assert.Equal(40m, _capturedSession.GrossProfit);      // 80 − 40
+    }
+
+    [Fact]
+    public async Task CreateAsync_FlatFee_GrossProfitIsNetMinusFlatFee()
+    {
+        SetupCreateAsyncWithCapture(
+            new PatientProfile { PatientId = 1, PatientName = "P" },
+            new TherapistProfile { TherapistId = 1, TherapistName = "T", FeePerSession = 25m });
+
+        await _sut.CreateAsync(MakeRequest(amount: 100m, discount: 20m));
+
+        Assert.Equal(25m, _capturedSession!.ProviderAmount);  // flat fee unchanged by net
+        Assert.Equal(55m, _capturedSession.GrossProfit);      // (100 − 20) − 25
+    }
+
+    [Theory]
+    [InlineData(100, 5, 20)]    // below the floor → raised to 20% of amount
+    [InlineData(100, 20, 20)]   // exactly at the floor → unchanged
+    [InlineData(100, 30, 30)]   // above the floor → staff discretion kept
+    [InlineData(100, 0, 20)]    // no discount requested → floor applies
+    public async Task CreateAsync_SenadisPatient_FloorsDiscountAtTwentyPercent(
+        decimal amount, decimal requested, decimal expected)
+    {
+        SetupCreateAsyncWithCapture(
+            new PatientProfile { PatientId = 1, PatientName = "P", HasSenadisDiscount = true },
+            new TherapistProfile { TherapistId = 1, TherapistName = "T", FeePctPerSession = 0.50m });
+
+        await _sut.CreateAsync(MakeRequest(amount, requested));
+
+        Assert.Equal(expected, _capturedSession!.DiscountAmount);
+    }
+
+    [Fact]
+    public async Task CreateAsync_SenadisFloor_RoundsToTwoDecimals()
+    {
+        SetupCreateAsyncWithCapture(
+            new PatientProfile { PatientId = 1, PatientName = "P", HasSenadisDiscount = true },
+            new TherapistProfile { TherapistId = 1, TherapistName = "T", FeePerSession = 10m });
+
+        await _sut.CreateAsync(MakeRequest(amount: 33.33m, discount: 0m));
+
+        Assert.Equal(6.67m, _capturedSession!.DiscountAmount); // round(0.20 × 33.33, 2)
+    }
+
+    [Fact]
+    public async Task CreateAsync_UnflaggedPatient_DiscountUntouched()
+    {
+        SetupCreateAsyncWithCapture(
+            new PatientProfile { PatientId = 1, PatientName = "P", HasSenadisDiscount = false },
+            new TherapistProfile { TherapistId = 1, TherapistName = "T", FeePerSession = 10m });
+
+        await _sut.CreateAsync(MakeRequest(amount: 100m, discount: 5m));
+
+        Assert.Equal(5m, _capturedSession!.DiscountAmount);
+    }
+
+    [Fact]
+    public async Task CreateAsync_PatientWithoutCaretaker_ThrowsArgumentException()
+    {
+        // WP-23 (F10): hard block — GlobalExceptionHandler maps ArgumentException → 400.
+        SetupCreateAsyncWithCapture(
+            new PatientProfile { PatientId = 1, PatientName = "P" },
+            new TherapistProfile { TherapistId = 1, TherapistName = "T", FeePerSession = 10m });
+        _mockPatientCaretakerRepository
+            .Setup(r => r.GetByPatientIdAsync(1))
+            .ReturnsAsync(new List<PatientCaretaker>());
+
+        var ex = await Assert.ThrowsAsync<ArgumentException>(
+            () => _sut.CreateAsync(MakeRequest(amount: 100m, discount: 0m)));
+
+        Assert.Contains("caretaker must be linked", ex.Message);
+        _mockTherapySessionRepository.Verify(r => r.AddAsync(It.IsAny<TherapySession>()), Times.Never);
     }
 
     [Fact]

--- a/tests/Web.Tests/Authorization/SensitiveCellAuthorizationTests.cs
+++ b/tests/Web.Tests/Authorization/SensitiveCellAuthorizationTests.cs
@@ -247,6 +247,87 @@ public class SensitiveCellAuthorizationTests : IClassFixture<AccessControlTestFa
             "the secure-by-default fallback policy still requires authentication before the action runs");
     }
 
+    // ── WP-23 (F7): hasSenadisDiscount field-level WRITE gate on PUT /api/patients/{id} ──
+    // The action rides Patients.Edit (FD included); CHANGING the stored flag additionally
+    // requires Patients.SenadisDiscount.Edit [AM,MGR]. Unlike the attribute cells above, the
+    // 403 comes from the imperative in-action check — so these tests create a real patient
+    // first and assert the present-AND-differs semantics end-to-end.
+
+    [Theory]
+    [InlineData("FD")]
+    [InlineData("ACCT")]
+    public async Task SenadisFlagChange_RoleWithoutGateClaim_Is403(string role)
+    {
+        var patientId = await CreatePatientAsync(senadis: false);
+
+        var response = await PutPatientAsync(patientId, TokenFor(role), "{\"hasSenadisDiscount\": true}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            $"{role} holds Patients.Edit-adjacent access but not Patients.SenadisDiscount.Edit");
+    }
+
+    [Theory]
+    [InlineData("MGR")]
+    [InlineData("AM")]
+    [InlineData("SYSADMIN")]
+    public async Task SenadisFlagChange_RoleWithGateClaim_IsNotBlocked(string role)
+    {
+        var patientId = await CreatePatientAsync(senadis: false);
+
+        var response = await PutPatientAsync(patientId, TokenFor(role), "{\"hasSenadisDiscount\": true}");
+
+        response.StatusCode.Should().NotBe(HttpStatusCode.Forbidden,
+            $"{role} may change the SENADIS flag (matrix: MGR/AM + wildcard)");
+        response.StatusCode.Should().NotBe(HttpStatusCode.Unauthorized, "the token is valid");
+    }
+
+    [Fact]
+    public async Task SenadisFlagEchoedUnchanged_FD_Passes()
+    {
+        // FD clients that round-trip the whole profile must keep working: present-but-equal
+        // is not a change and must not 403.
+        var patientId = await CreatePatientAsync(senadis: true);
+
+        var response = await PutPatientAsync(patientId, _factory.MintRoleToken("FD"),
+            "{\"hasSenadisDiscount\": true, \"phoneNumber\": \"555-0199\"}");
+
+        response.StatusCode.Should().NotBe(HttpStatusCode.Forbidden,
+            "echoing the stored value is not a change — the gate keys on present AND differs");
+    }
+
+    private async Task<int> CreatePatientAsync(bool senadis)
+    {
+        var unique = Guid.NewGuid().ToString("N")[..10];
+        var body = $$"""
+            {
+              "firstName": "Wp23", "middleName": "", "lastName": "Gate-{{unique}}",
+              "medicalRecordNumber": "WP23-{{unique}}",
+              "dateOfBirth": "2015-01-01T00:00:00", "email": "wp23-{{unique}}@neurocorp.test",
+              "phoneNumber": "555-0100", "gender": "Other",
+              "hasSenadisDiscount": {{(senadis ? "true" : "false")}}
+            }
+            """;
+        var request = new HttpRequestMessage(HttpMethod.Post, "/api/patients")
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json")
+        };
+        request.Headers.Authorization = new("Bearer", _factory.MintWildcardToken());
+        var response = await _factory.CreateClient().SendAsync(request);
+        response.EnsureSuccessStatusCode();
+        using var doc = System.Text.Json.JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        return doc.RootElement.GetProperty("patientId").GetInt32();
+    }
+
+    private async Task<HttpResponseMessage> PutPatientAsync(int patientId, string token, string jsonBody)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Put, $"/api/patients/{patientId}")
+        {
+            Content = new StringContent(jsonBody, Encoding.UTF8, "application/json")
+        };
+        request.Headers.Authorization = new("Bearer", token);
+        return await _factory.CreateClient().SendAsync(request);
+    }
+
     private string TokenFor(string role) =>
         role == "SYSADMIN" ? _factory.MintWildcardToken() : _factory.MintRoleToken(role);
 

--- a/tests/Web.Tests/PatientsControllerTests.cs
+++ b/tests/Web.Tests/PatientsControllerTests.cs
@@ -11,8 +11,12 @@ using Neurocorp.Api.Core.BusinessObjects.Sessions;
 using Neurocorp.Api.Core.Interfaces.Repositories;
 using FluentAssertions;
 using System.Linq;
+using System.Security.Claims;
 using Castle.Core.Logging;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using Neurocorp.Api.Core.Authorization;
+using Neurocorp.Api.Web.Authorization;
 
 namespace Web.Tests.Controllers;
 
@@ -294,5 +298,105 @@ public class PatientsControllerTests
         var okResult = Assert.IsType<OkObjectResult>(result);
         okResult.Value.Should().BeSameAs(mergeResult);
         _mockPatientMergeService.Verify(s => s.MergeAsync(request), Times.Once);
+    }
+
+    // ── WP-23 (F7): hasSenadisDiscount field-level edit gate on PUT ──────────────────
+    // Changing the stored flag needs Patients.SenadisDiscount.Edit; omitted/null/echoed-
+    // unchanged values pass so FD clients that round-trip the profile keep working.
+
+    private void UseCaller(params (string Type, string Value)[] claims)
+    {
+        var identity = new ClaimsIdentity(
+            claims.Select(c => new Claim(c.Type, c.Value)), authenticationType: "TestAuth");
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = new ClaimsPrincipal(identity) }
+        };
+    }
+
+    private void SetupPatientOnFile(int id, bool hasSenadisDiscount)
+    {
+        _mockPatientProfileService
+            .Setup(s => s.GetByIdAsync(id))
+            .ReturnsAsync(new PatientProfile { PatientId = id, PatientName = "P", HasSenadisDiscount = hasSenadisDiscount });
+        _mockPatientProfileService
+            .Setup(s => s.UpdateAsync(id, It.IsAny<PatientProfileUpdateRequest>()))
+            .ReturnsAsync(true);
+    }
+
+    [Fact]
+    public async Task UpdatePatient_SenadisChanged_WithoutClaim_ReturnsForbid_AndDoesNotUpdate()
+    {
+        SetupPatientOnFile(7, hasSenadisDiscount: false);
+        UseCaller((SystemClaims.PermissionClaimType, Permissions.PatientsEdit)); // FD-like: Edit but not the gate
+
+        var result = await _controller.UpdatePatient(7,
+            new PatientProfileUpdateRequest { HasSenadisDiscount = true });
+
+        Assert.IsType<ForbidResult>(result);
+        _mockPatientProfileService.Verify(
+            s => s.UpdateAsync(It.IsAny<int>(), It.IsAny<PatientProfileUpdateRequest>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UpdatePatient_SenadisChanged_WithClaim_Delegates()
+    {
+        SetupPatientOnFile(7, hasSenadisDiscount: false);
+        UseCaller((SystemClaims.PermissionClaimType, Permissions.PatientsSenadisDiscountEdit));
+
+        var result = await _controller.UpdatePatient(7,
+            new PatientProfileUpdateRequest { HasSenadisDiscount = true });
+
+        Assert.IsType<NoContentResult>(result);
+        _mockPatientProfileService.Verify(
+            s => s.UpdateAsync(7, It.Is<PatientProfileUpdateRequest>(r => r.HasSenadisDiscount == true)), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdatePatient_SenadisChanged_WithWildcard_Delegates()
+    {
+        SetupPatientOnFile(7, hasSenadisDiscount: true);
+        UseCaller((SystemClaims.SystemClaimType, SystemClaims.FullAccessValue)); // SYSADMIN
+
+        var result = await _controller.UpdatePatient(7,
+            new PatientProfileUpdateRequest { HasSenadisDiscount = false });
+
+        Assert.IsType<NoContentResult>(result);
+    }
+
+    [Fact]
+    public async Task UpdatePatient_SenadisEchoedUnchanged_WithoutClaim_Passes()
+    {
+        SetupPatientOnFile(7, hasSenadisDiscount: true);
+        UseCaller((SystemClaims.PermissionClaimType, Permissions.PatientsEdit));
+
+        var result = await _controller.UpdatePatient(7,
+            new PatientProfileUpdateRequest { HasSenadisDiscount = true }); // echo, not a change
+
+        Assert.IsType<NoContentResult>(result);
+    }
+
+    [Fact]
+    public async Task UpdatePatient_SenadisOmitted_WithoutClaim_Passes()
+    {
+        SetupPatientOnFile(7, hasSenadisDiscount: true);
+        UseCaller((SystemClaims.PermissionClaimType, Permissions.PatientsEdit));
+
+        var result = await _controller.UpdatePatient(7,
+            new PatientProfileUpdateRequest { FirstName = "Renamed" }); // null flag = unchanged
+
+        Assert.IsType<NoContentResult>(result);
+    }
+
+    [Fact]
+    public async Task UpdatePatient_UnknownPatient_Returns400()
+    {
+        _mockPatientProfileService.Setup(s => s.GetByIdAsync(99)).ReturnsAsync((PatientProfile?)null);
+        UseCaller((SystemClaims.PermissionClaimType, Permissions.PatientsEdit));
+
+        var result = await _controller.UpdatePatient(99, new PatientProfileUpdateRequest());
+
+        var problem = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(StatusCodes.Status400BadRequest, problem.StatusCode);
     }
 }


### PR DESCRIPTION
… + field-level edit gate, caretaker booking guard, fee-on-net

- F6: SpecialtyType.DefaultAmount threaded through LookupItem/Create/Update (per-type: populated/honored ONLY for specialty-types; Range >= 0); EF HasPrecision(10,2); editing stays SYSADMIN-only via LookupManageAuthorize
- F7: Patient.HasSenadisDiscount threaded WP-18-style (entity + 3 DTOs + 4 mapping sites; update = bool?, null = unchanged); NEW field-level WRITE gate in PatientsController.UpdatePatient - present AND differs AND caller lacks Patients.SenadisDiscount.Edit => Forbid() (read-side precedent: ProviderAmountResultFilter)
- F7 floor: both create paths raise Discount to >= round(0.20 x Amount, 2) for flagged patients (staff may grant more, never less)
- Fee-on-net (Questionnaire E ruling): SessionEventHandler now computes ProviderAmount/GrossProfit on net (Amount - Discount), matching BulkSchedulingService; changes payroll on future discounted bookings only
- F10: IPatientCaretakerRepository guard in SessionEventHandler AND BulkSchedulingService - zero links => ArgumentException -> 400
- Manifest re-vendored 6c42b5362fbc -> 10ad6ddcd5dd; Permissions.g.cs regen (52 claims, + PatientsSenadisDiscountEdit); hash anchor bumped
- Tests red->green: suite 429 -> 458 (Core 152 / Infra 88 / Web 218) incl. SensitiveCell end-to-end rows (FD/ACCT 403 on flag change, MGR/AM/SYSADMIN pass, FD unchanged-echo passes)
- Curls: docs/wp23-booking-money-verification.md