### PR TITLE
WP-24B (F3+F4): Patient.RequiresDiscovery threading + edit gate, disc…

### DIFF
--- a/docs/access-control-matrix.json
+++ b/docs/access-control-matrix.json
@@ -1,9 +1,9 @@
 {
   "_meta": {
-    "generatedAt": "2026-07-12T08:29:39-05:00",
+    "generatedAt": "2026-07-12T15:22:29-05:00",
     "generator": "tools/generate-access-manifest.sh",
     "hashScope": "sha256 (first 12 hex) of canonical JSON {claims:[{claim,grants}]}, claims+grants sorted; wildcard/restricted cells and all metadata excluded",
-    "semanticHash": "10ad6ddcd5dd",
+    "semanticHash": "7ae3aa5e3274",
     "source": "access-control-matrix.md"
   },
   "claims": [
@@ -194,6 +194,13 @@
       "grants": []
     },
     {
+      "claim": "Patients.RequiresDiscovery.Edit",
+      "grants": [
+        "AM",
+        "MGR"
+      ]
+    },
+    {
       "claim": "Patients.SenadisDiscount.Edit",
       "grants": [
         "AM",
@@ -204,6 +211,7 @@
       "claim": "Patients.StartDiscovery",
       "grants": [
         "AM",
+        "FD",
         "MGR"
       ]
     },

--- a/docs/patient-requires-discovery-wp24-verification.md
+++ b/docs/patient-requires-discovery-wp24-verification.md
@@ -1,0 +1,131 @@
+# WP-24B verification — F3/F4 Patient.RequiresDiscovery · Patients.StartDiscovery enforcement (audit F1)
+
+Post-deploy curls (run against the deployed API, e.g. `http://neurocorp.k3s:30000`, after
+**V028 + the RoleClaim reseed** are applied and the API ships this WP — hash `7ae3aa5e3274`).
+All numbers below are examples — substitute real IDs from your environment.
+
+```bash
+API=http://neurocorp.k3s:30000
+```
+
+## 0. Tokens
+
+> ⚠️ The login field is `email`, NOT `username` (binds empty → 401).
+
+```bash
+# MGR (holds Patients.RequiresDiscovery.Edit + Patients.StartDiscovery after the reseed)
+MGR_TOKEN=$(curl -s $API/api/auth/login -H 'Content-Type: application/json' \
+  -d '{"email":"<mgr email>","password":"<pwd>"}' | jq -r .accessToken)
+
+# FD (holds Patients.StartDiscovery post-reseed, but NOT the edit-gate claim)
+FD_TOKEN=$(curl -s $API/api/auth/login -H 'Content-Type: application/json' \
+  -d '{"email":"<fd email>","password":"<pwd>"}' | jq -r .accessToken)
+```
+
+## 1. F3 — create omitting the flag → defaults to `requiresDiscovery: true`
+
+```bash
+curl -s -w '\n%{http_code}\n' -X POST "$API/api/patients" \
+  -H "Authorization: Bearer $FD_TOKEN" -H 'Content-Type: application/json' -d '{
+  "firstName":"Wp24","lastName":"DefaultTrue","middleName":"",
+  "medicalRecordNumber":"WP24-VERIFY-001","cedula":"",
+  "dateOfBirth":"2015-06-01","email":"wp24-default@verify.test",
+  "phoneNumber":"555-0100","gender":"Other"}'
+# expect: 201 + PatientProfile JSON with "requiresDiscovery": true
+```
+
+## 2. F3 — create with the flag explicitly false (any patient-creating role, incl. FD)
+
+```bash
+curl -s -w '\n%{http_code}\n' -X POST "$API/api/patients" \
+  -H "Authorization: Bearer $FD_TOKEN" -H 'Content-Type: application/json' -d '{
+  "firstName":"Wp24","lastName":"Waived","middleName":"",
+  "medicalRecordNumber":"WP24-VERIFY-002","cedula":"",
+  "dateOfBirth":"2015-06-01","email":"wp24-waived@verify.test",
+  "phoneNumber":"555-0100","gender":"Other",
+  "requiresDiscovery":false}'
+# expect: 201 with "requiresDiscovery": false
+# note the returned patientId — used as $WAIVED_ID below; patient 1's id from step 1 = $UNWAIVED_ID
+```
+
+## 3. F4 — PUT flag change as FD → 403 (field-level gate, nothing applied)
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' -X PUT "$API/api/patients/$UNWAIVED_ID" \
+  -H "Authorization: Bearer $FD_TOKEN" -H 'Content-Type: application/json' \
+  -d '{"requiresDiscovery":false}'
+# expect: 403 (FD lacks Patients.RequiresDiscovery.Edit)
+
+# echoed-unchanged still passes for FD (round-tripping clients keep working):
+curl -s -o /dev/null -w '%{http_code}\n' -X PUT "$API/api/patients/$UNWAIVED_ID" \
+  -H "Authorization: Bearer $FD_TOKEN" -H 'Content-Type: application/json' \
+  -d '{"requiresDiscovery":true,"phoneNumber":"555-0199"}'
+# expect: 204
+```
+
+## 4. F4 — PUT flag change as MGR → 204
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' -X PUT "$API/api/patients/$UNWAIVED_ID" \
+  -H "Authorization: Bearer $MGR_TOKEN" -H 'Content-Type: application/json' \
+  -d '{"requiresDiscovery":false}'
+# expect: 204; GET the patient back → "requiresDiscovery": false
+# (flip it back to true with another MGR PUT before running step 6.)
+```
+
+## 5. Audit F1 — POST discovery-specialty session as FD → 201
+
+FD holds `Patients.StartDiscovery` as of `7ae3aa5e3274` — the newly ENFORCED gate lets front
+desk book a new patient's first (discovery) session. Use a discovery specialty id (V012 seeds:
+abbreviations `Obs-*`/`Eval-*`/`Vis-*` — check `GET /api/lookups/specialty-types` and pick one
+with `"isDiscovery": true`). Patient must have a caretaker link (WP-23 F10) — link one first if
+needed.
+
+```bash
+curl -s -w '\n%{http_code}\n' -X POST "$API/api/sessions" \
+  -H "Authorization: Bearer $FD_TOKEN" -H 'Content-Type: application/json' -d '{
+  "patientId": '$UNWAIVED_ID', "therapistId": 3,
+  "sessionDate": "2026-07-20", "sessionTime": "10:00",
+  "duration": 60, "amount": 50.0, "specialtyTypeId": 8}'
+# expect: 201 (would be 403 only for a caller WITHOUT Patients.StartDiscovery —
+#          post-reseed no seeded operator role lacks it while holding Appointments.Book)
+```
+
+## 6. Discovery-first rule still blocks an UNWAIVED patient with no completed discovery
+
+```bash
+# $UNWAIVED_ID has requiresDiscovery=true and no COMPLETED discovery session yet
+# (step 5 created one but it is not in a completed status) — a treatment specialty must 400:
+curl -s -w '\n%{http_code}\n' -X POST "$API/api/sessions" \
+  -H "Authorization: Bearer $FD_TOKEN" -H 'Content-Type: application/json' -d '{
+  "patientId": '$UNWAIVED_ID', "therapistId": 3,
+  "sessionDate": "2026-07-21", "sessionTime": "10:00",
+  "duration": 60, "amount": 50.0, "specialtyTypeId": 5}'
+# expect: 400 "Patient requires a completed discovery session before treatment sessions
+#          can be scheduled."
+```
+
+## 7. F3 payoff — the WAIVED patient books treatment directly → 201
+
+```bash
+# $WAIVED_ID (requiresDiscovery=false, zero discovery sessions) — same treatment specialty:
+curl -s -w '\n%{http_code}\n' -X POST "$API/api/sessions" \
+  -H "Authorization: Bearer $FD_TOKEN" -H 'Content-Type: application/json' -d '{
+  "patientId": '$WAIVED_ID', "therapistId": 3,
+  "sessionDate": "2026-07-21", "sessionTime": "11:00",
+  "duration": 60, "amount": 50.0, "specialtyTypeId": 5}'
+# expect: 201 — this is the legacy-patient unblock (post-backfill, all L24/L25/L26
+#          patients behave like $WAIVED_ID)
+```
+
+## Cleanup
+
+```sql
+-- Remove verification patients (children first). Find them:
+SELECT p.PatientID, p.UserID FROM Patient p JOIN SystemUser su ON su.UserID = p.UserID
+WHERE su.Email LIKE 'wp24-%@verify.test';
+-- Then: DELETE FROM TherapySession WHERE PatientID IN (...);
+--       DELETE FROM PatientCaretaker WHERE PatientID IN (...);
+--       DELETE FROM UserRole WHERE UserID IN (...); DELETE FROM Patient WHERE PatientID IN (...);
+--       DELETE FROM SystemUser WHERE UserID IN (...);
+```

--- a/src/Core/BusinessObjects/Patients/PatientProfile.cs
+++ b/src/Core/BusinessObjects/Patients/PatientProfile.cs
@@ -22,6 +22,9 @@ public class PatientProfile : IProfile
     public bool IsActive { get; set; }
     // WP-23 (F7): statutory SENADIS 20% discount flag; edit gated by Patients.SenadisDiscount.Edit.
     public bool HasSenadisDiscount { get; set; }
+    // WP-24 (F3/F4): discovery-first waiver; false = exempt. Edit gated by
+    // Patients.RequiresDiscovery.Edit.
+    public bool RequiresDiscovery { get; set; }
     public bool? HasCompletedDiscovery { get; set; }
     public List<PatientCaretakerSummary> Caretakers { get; set; } = new();
 

--- a/src/Core/BusinessObjects/Patients/PatientProfileRequest.cs
+++ b/src/Core/BusinessObjects/Patients/PatientProfileRequest.cs
@@ -35,4 +35,8 @@ public class PatientProfileRequest
     public string Gender { get; set; }
     // WP-23 (F7): settable at create by any patient-creating role (Questionnaire E gates edits only).
     public bool HasSenadisDiscount { get; set; }
+    // WP-24 (F3): settable at create by any patient-creating role; DEFAULT TRUE per
+    // Questionnaire C — an omitted JSON field means the new patient must complete a
+    // discovery session before treatment bookings. Later edits are claim-gated.
+    public bool RequiresDiscovery { get; set; } = true;
 }

--- a/src/Core/BusinessObjects/Patients/PatientProfileUpdateRequest.cs
+++ b/src/Core/BusinessObjects/Patients/PatientProfileUpdateRequest.cs
@@ -32,6 +32,9 @@ public class PatientProfileUpdateRequest
     // WP-23 (F7): omitted/null = unchanged. Changing the stored value requires the
     // Patients.SenadisDiscount.Edit claim (gate enforced in PatientsController.UpdatePatient).
     public bool? HasSenadisDiscount { get; set; }
+    // WP-24 (F3/F4): omitted/null = unchanged. Changing the stored value requires the
+    // Patients.RequiresDiscovery.Edit claim (gate enforced in PatientsController.UpdatePatient).
+    public bool? RequiresDiscovery { get; set; }
 
     public override string ToString()
     {

--- a/src/Core/Entities/Patient.cs
+++ b/src/Core/Entities/Patient.cs
@@ -19,6 +19,10 @@ public class Patient : PersonBase
     // WP-23 (F7): statutory SENADIS 20% discount — both session-create paths apply a
     // 20%-of-Amount discount floor when set.
     public bool HasSenadisDiscount { get; set; }
+    // WP-24 (F3/F4): discovery-first waiver — false = exempt from the completed-discovery-
+    // before-treatment rule (e.g. legacy-imported patients). Default TRUE (Questionnaire C),
+    // matching the DB column default (V028).
+    public bool RequiresDiscovery { get; set; } = true;
     public ICollection<PatientCaretaker>? Caretakers { get; set; }
 
     public bool HasTemporaryMrn()

--- a/src/Core/Interfaces/Services/IHandleSessionEvent.cs
+++ b/src/Core/Interfaces/Services/IHandleSessionEvent.cs
@@ -9,6 +9,9 @@ public interface IHandleSessionEvent : IService<SessionEvent>
     public Task<IEnumerable<SessionEvent>> GetAllPastDueAsync();
     public Task<IEnumerable<PatientPastDueInfo>> GetAllPatientsPastDueAsync();
     public Task<SessionEvent> CreateAsync(SessionEventRequest request);
+    // WP-24 (audit F1): true when the request's resolved specialty is a discovery type — backs
+    // the imperative Patients.StartDiscovery gate in SessionsController.CreateSession.
+    public Task<bool> IsDiscoveryRequestAsync(SessionEventRequest request);
     public Task<bool> UpdateAsync(int SessionEventId, SessionEventUpdateRequest request);
     public Task<bool> VerifyRequestAsync(int sessionAggId, SessionEventUpdateRequest request);
     public Task<IEnumerable<DiscoverySessionSummary>> GetCompletedDiscoverySessionsAsync(int patientId);

--- a/src/Core/Services/PatientProfileService.cs
+++ b/src/Core/Services/PatientProfileService.cs
@@ -102,6 +102,7 @@ public class PatientProfileService : IPatientProfileService
             MedicalRecordNumber = newPatient.MedicalRecordNumber,
             Cedula = newPatient.Cedula,
             HasSenadisDiscount = newPatient.HasSenadisDiscount,
+            RequiresDiscovery = newPatient.RequiresDiscovery,
             DateOfBirth = newPatient.DateOfBirth ?? DateTime.MinValue,
             Email = newUser.Email,
             PhoneNumber = newUser.PhoneNumber,
@@ -186,7 +187,8 @@ public class PatientProfileService : IPatientProfileService
                 ? null
                 : patientRequest.MedicalRecordNumber,
             Cedula = string.IsNullOrWhiteSpace(patientRequest.Cedula) ? null : patientRequest.Cedula,
-            HasSenadisDiscount = patientRequest.HasSenadisDiscount
+            HasSenadisDiscount = patientRequest.HasSenadisDiscount,
+            RequiresDiscovery = patientRequest.RequiresDiscovery
         };
     }
 

--- a/src/Core/Services/SessionEventHandler.cs
+++ b/src/Core/Services/SessionEventHandler.cs
@@ -152,8 +152,10 @@ public class SessionEventHandler : IHandleSessionEvent
 
         var specialty = await ResolveSpecialtyAsync(request);
 
-        // Discovery-first enforcement: treatment specialties require a completed discovery session
-        if (specialty != null && !specialty.IsDiscovery)
+        // Discovery-first enforcement: treatment specialties require a completed discovery session.
+        // WP-24 (F3/F4): only when the patient's RequiresDiscovery flag is set — false = waived
+        // (e.g. legacy-imported patients), which skips the check entirely.
+        if (specialty != null && !specialty.IsDiscovery && pProfile!.RequiresDiscovery)
         {
             var hasDiscovery = await _therapySessionRepository.HasCompletedDiscoveryAsync(request.PatientId);
             if (!hasDiscovery)
@@ -198,6 +200,16 @@ public class SessionEventHandler : IHandleSessionEvent
             SpecialtyName = specialty?.Name,
             IsDiscovery = specialty?.IsDiscovery,
         };
+    }
+
+    // WP-24 (audit F1): lets the controller ask "is this a discovery-specialty request?" BEFORE
+    // CreateAsync, so the Patients.StartDiscovery gate can 403 with nothing created. Uses the
+    // same resolution CreateAsync will run — Core stays free of HttpContext; the permission
+    // check itself lives in SessionsController.
+    public async Task<bool> IsDiscoveryRequestAsync(SessionEventRequest request)
+    {
+        var specialty = await ResolveSpecialtyAsync(request);
+        return specialty?.IsDiscovery == true;
     }
 
     public async Task<bool> UpdateAsync(int sessionEventId, SessionEventUpdateRequest request)

--- a/src/Infrastructure/Repositories/PatientProfileRepository.cs
+++ b/src/Infrastructure/Repositories/PatientProfileRepository.cs
@@ -152,6 +152,11 @@ public class PatientProfileRepository(ApplicationDbContext dbContext) :
         {
             patientOnFile.HasSenadisDiscount = patientRequest.HasSenadisDiscount.Value;
         }
+        // WP-24 (F3/F4): null = unchanged; the claim gate ran in the controller before we get here.
+        if (patientRequest.RequiresDiscovery.HasValue)
+        {
+            patientOnFile.RequiresDiscovery = patientRequest.RequiresDiscovery.Value;
+        }
 
         return patientOnFile;
     }
@@ -184,6 +189,7 @@ public class PatientProfileRepository(ApplicationDbContext dbContext) :
             MedicalRecordNumber = p.MedicalRecordNumber,
             Cedula = p.Cedula,
             HasSenadisDiscount = p.HasSenadisDiscount,
+            RequiresDiscovery = p.RequiresDiscovery,
             Gender = p.Gender,
             DateOfBirth = p.DateOfBirth ?? DateTime.MinValue,
             Email = p.User.Email,

--- a/src/Web/Authorization/AccessControlManifest.cs
+++ b/src/Web/Authorization/AccessControlManifest.cs
@@ -18,5 +18,5 @@ namespace Neurocorp.Api.Web.Authorization;
 public static class AccessControlManifest
 {
     /// <summary>First 12 hex chars of SHA-256 over the manifest's canonical grant tuples.</summary>
-    public const string SemanticHash = "10ad6ddcd5dd";
+    public const string SemanticHash = "7ae3aa5e3274";
 }

--- a/src/Web/Authorization/Permissions.g.cs
+++ b/src/Web/Authorization/Permissions.g.cs
@@ -7,7 +7,7 @@
 //   (patient-care-super/tools/generate-access-manifest.sh), re-vendor
 //   docs/access-control-matrix.json, then re-run tools/generate-permissions.sh.
 //
-//   Access-control manifest semantic hash: 10ad6ddcd5dd
+//   Access-control manifest semantic hash: 7ae3aa5e3274
 // </auto-generated>
 
 namespace Neurocorp.Api.Web.Authorization;
@@ -49,6 +49,7 @@ public static class Permissions
     public const string PatientsEdit = "Patients.Edit";
     public const string PatientsLinkCaretaker = "Patients.LinkCaretaker";
     public const string PatientsMerge = "Patients.Merge";
+    public const string PatientsRequiresDiscoveryEdit = "Patients.RequiresDiscovery.Edit";
     public const string PatientsSenadisDiscountEdit = "Patients.SenadisDiscount.Edit";
     public const string PatientsStartDiscovery = "Patients.StartDiscovery";
     public const string PatientsView = "Patients.View";

--- a/src/Web/Controllers/PatientsController.cs
+++ b/src/Web/Controllers/PatientsController.cs
@@ -169,6 +169,16 @@ public class PatientsController : ControllerBase
             return Forbid();
         }
 
+        // WP-24 (F3/F4): same SENADIS-style gate for the discovery-first waiver flag — changing
+        // it needs Patients.RequiresDiscovery.Edit (MGR/AM by Questionnaire C; FD sets it at
+        // create only). Both gates run before any update applies.
+        if (patientRequest.RequiresDiscovery.HasValue
+            && patientRequest.RequiresDiscovery.Value != patientOnFile.RequiresDiscovery
+            && !User.HasPermission(Permissions.PatientsRequiresDiscoveryEdit))
+        {
+            return Forbid();
+        }
+
         try
         {
             if (!await _patientProfileService.UpdateAsync(id, patientRequest))

--- a/src/Web/Controllers/SessionsController.cs
+++ b/src/Web/Controllers/SessionsController.cs
@@ -52,6 +52,17 @@ public class SessionsController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> CreateSession([FromBody] SessionEventRequest sessionRequest)
     {
+        // WP-24 (closes WP-17 audit F1): booking a DISCOVERY-specialty session additionally
+        // requires Patients.StartDiscovery (MGR/AM/FD as of hash 7ae3aa5e3274). Imperative, not
+        // an [Authorize] policy: the endpoint is generic and a static policy can't see the
+        // specialty — it must be resolved from the request first. Nothing is created on the
+        // Forbid path.
+        if (await _sessionEventHandler.IsDiscoveryRequestAsync(sessionRequest)
+            && !User.HasPermission(Permissions.PatientsStartDiscovery))
+        {
+            return Forbid();
+        }
+
         var createdSession = await _sessionEventHandler.CreateAsync(sessionRequest);
         return CreatedAtAction(nameof(CreateSession), new { id = createdSession.SessionId }, createdSession);
     }
@@ -74,8 +85,8 @@ public class SessionsController : ControllerBase
     }
 
     // WP-17 (D-5): completed discovery sessions are a read of appointment data — Appointments.View
-    // (AM/FD/MGR). Not FD-hidden; if discovery should be FD-restricted, switch to
-    // Patients.StartDiscovery (AM/MGR).
+    // (AM/FD/MGR). Discovery-START is separately enforced on CreateSession above via
+    // Patients.StartDiscovery, which FD also holds as of hash 7ae3aa5e3274 (WP-24 closed audit F1).
     [HttpGet("patient/{patientId}/discovery")]
     [Authorize(Policy = AuthPolicy.PermissionPrefix + Permissions.AppointmentsView)]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<DiscoverySessionSummary>))]

--- a/tests/Core.Tests/SessionEventHandlerTests.cs
+++ b/tests/Core.Tests/SessionEventHandlerTests.cs
@@ -342,6 +342,82 @@ public class SessionEventHandlerTests
         _mockTherapySessionRepository.Verify(r => r.AddAsync(It.IsAny<TherapySession>()), Times.Never);
     }
 
+    // --- WP-24 (F3/F4): discovery-first waiver — the completed-discovery check only runs
+    // when the patient's RequiresDiscovery flag is true (false = waived, e.g. legacy import) ---
+
+    private void SetupWaiverScenario(bool requiresDiscovery, bool hasCompletedDiscovery, SpecialtyType specialty)
+    {
+        SetupCreateAsyncWithCapture(
+            new PatientProfile { PatientId = 1, PatientName = "P", RequiresDiscovery = requiresDiscovery },
+            new TherapistProfile { TherapistId = 1, TherapistName = "T", FeePerSession = 10m });
+        _mockTherapySessionRepository
+            .Setup(r => r.HasCompletedDiscoveryAsync(It.IsAny<int>()))
+            .ReturnsAsync(hasCompletedDiscovery);
+        _mockSpecialtyTypeRepository
+            .Setup(r => r.GetByIdAsync(specialty.Id))
+            .ReturnsAsync(specialty);
+    }
+
+    private static SessionEventRequest MakeSpecialtyRequest(int specialtyTypeId) => new()
+    {
+        PatientId = 1, TherapistId = 1, SessionDate = DateOnly.Parse("2026-07-20"),
+        SessionTime = TimeOnly.Parse("10:00"), Amount = 100m, Duration = 60,
+        SpecialtyTypeId = specialtyTypeId
+    };
+
+    [Fact]
+    public async Task CreateAsync_WaivedPatient_TreatmentSpecialty_NoCompletedDiscovery_Creates()
+    {
+        var treatment = new SpecialtyType { Id = 5, Abbreviation = "TC", Name = "Conduct Therapy", IsDiscovery = false };
+        SetupWaiverScenario(requiresDiscovery: false, hasCompletedDiscovery: false, treatment);
+
+        var result = await _sut.CreateAsync(MakeSpecialtyRequest(5));
+
+        Assert.NotNull(_capturedSession);
+        Assert.Equal(5, result.SpecialtyTypeId);
+        // Waived patients skip the check entirely — the repository is never even asked.
+        _mockTherapySessionRepository.Verify(r => r.HasCompletedDiscoveryAsync(It.IsAny<int>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateAsync_UnwaivedPatient_TreatmentSpecialty_NoCompletedDiscovery_Throws()
+    {
+        var treatment = new SpecialtyType { Id = 5, Abbreviation = "TC", Name = "Conduct Therapy", IsDiscovery = false };
+        SetupWaiverScenario(requiresDiscovery: true, hasCompletedDiscovery: false, treatment);
+
+        var ex = await Assert.ThrowsAsync<ArgumentException>(
+            () => _sut.CreateAsync(MakeSpecialtyRequest(5)));
+
+        Assert.Contains("requires a completed discovery", ex.Message);
+        _mockTherapySessionRepository.Verify(r => r.AddAsync(It.IsAny<TherapySession>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateAsync_DiscoverySpecialty_NeverTripsDiscoveryCheck_RegardlessOfFlag()
+    {
+        var discovery = new SpecialtyType { Id = 8, Abbreviation = "Obs-TO", Name = "Observacion TO", IsDiscovery = true };
+        SetupWaiverScenario(requiresDiscovery: true, hasCompletedDiscovery: false, discovery);
+
+        var result = await _sut.CreateAsync(MakeSpecialtyRequest(8));
+
+        Assert.True(result.IsDiscovery);
+        Assert.NotNull(_capturedSession);
+    }
+
+    [Fact]
+    public void PatientProfileRequest_JsonWithoutRequiresDiscovery_DefaultsTrue()
+    {
+        // WP-24 (F3, Questionnaire C): an omitted JSON field must mean "requires discovery" —
+        // the serializer keeps the property initializer when the field is absent.
+        var json = """{"firstName": "New", "lastName": "Patient", "gender": "Other"}""";
+
+        var request = System.Text.Json.JsonSerializer.Deserialize<PatientProfileRequest>(
+            json, new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        Assert.NotNull(request);
+        Assert.True(request!.RequiresDiscovery);
+    }
+
     [Fact]
     public async Task CreateAsync_WhenDiscoverySpecialtyProvided_IsDiscoveryIsTrue()
     {

--- a/tests/Web.Tests/Authorization/SensitiveCellAuthorizationTests.cs
+++ b/tests/Web.Tests/Authorization/SensitiveCellAuthorizationTests.cs
@@ -1,6 +1,9 @@
 using System.Net;
 using System.Text;
 using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Neurocorp.Api.Core.Entities;
+using Neurocorp.Api.Infrastructure.Data;
 
 namespace Neurocorp.Api.Web.Tests.Authorization;
 
@@ -293,6 +296,136 @@ public class SensitiveCellAuthorizationTests : IClassFixture<AccessControlTestFa
 
         response.StatusCode.Should().NotBe(HttpStatusCode.Forbidden,
             "echoing the stored value is not a change — the gate keys on present AND differs");
+    }
+
+    // ── WP-24 (F3/F4): requiresDiscovery field-level WRITE gate on PUT /api/patients/{id} ──
+    // Same imperative mechanism as the SENADIS gate: the action rides Patients.Edit, but
+    // CHANGING the stored waiver flag additionally requires Patients.RequiresDiscovery.Edit
+    // [AM,MGR] (hash 7ae3aa5e3274).
+
+    [Theory]
+    [InlineData("FD")]
+    [InlineData("ACCT")]
+    public async Task RequiresDiscoveryFlagChange_RoleWithoutGateClaim_Is403(string role)
+    {
+        var patientId = await CreatePatientAsync(senadis: false); // created with requiresDiscovery: true (default)
+
+        var response = await PutPatientAsync(patientId, TokenFor(role), "{\"requiresDiscovery\": false}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            $"{role} holds Patients.Edit-adjacent access but not Patients.RequiresDiscovery.Edit");
+    }
+
+    [Theory]
+    [InlineData("MGR")]
+    [InlineData("AM")]
+    [InlineData("SYSADMIN")]
+    public async Task RequiresDiscoveryFlagChange_RoleWithGateClaim_IsNotBlocked(string role)
+    {
+        var patientId = await CreatePatientAsync(senadis: false);
+
+        var response = await PutPatientAsync(patientId, TokenFor(role), "{\"requiresDiscovery\": false}");
+
+        response.StatusCode.Should().NotBe(HttpStatusCode.Forbidden,
+            $"{role} may change the requiresDiscovery flag (matrix: MGR/AM + wildcard)");
+        response.StatusCode.Should().NotBe(HttpStatusCode.Unauthorized, "the token is valid");
+    }
+
+    [Fact]
+    public async Task RequiresDiscoveryFlagEchoedUnchanged_FD_Passes()
+    {
+        // FD clients that round-trip the whole profile must keep working: present-but-equal
+        // is not a change and must not 403.
+        var patientId = await CreatePatientAsync(senadis: false); // stored flag = true (default)
+
+        var response = await PutPatientAsync(patientId, _factory.MintRoleToken("FD"),
+            "{\"requiresDiscovery\": true, \"phoneNumber\": \"555-0199\"}");
+
+        response.StatusCode.Should().NotBe(HttpStatusCode.Forbidden,
+            "echoing the stored value is not a change — the gate keys on present AND differs");
+    }
+
+    // ── WP-24 (audit F1): Patients.StartDiscovery enforced on POST /api/sessions ────────
+    // The endpoint rides Appointments.Book; when the request's RESOLVED specialty is a
+    // discovery type, the caller must additionally hold Patients.StartDiscovery [AM,FD,MGR
+    // as of 7ae3aa5e3274]. Imperative gate (no new [Authorize] policy — the endpoint is
+    // generic and a static policy can't see the specialty), so the 403 fires before any
+    // controller/handler work creates a session. The InMemory host has no seeded lookup
+    // data, so each test seeds its own SpecialtyType row directly into the test DbContext.
+
+    [Fact]
+    public async Task DiscoverySessionCreate_WithoutStartDiscoveryClaim_Is403()
+    {
+        var specialtyId = await SeedSpecialtyAsync(isDiscovery: true);
+        // Appointments.Book alone gets past the endpoint policy but must trip the gate.
+        var token = _factory.MintWithPermissions("Appointments.Book");
+
+        var response = await PostSessionAsync(specialtyId, token);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            "a discovery-specialty booking requires Patients.StartDiscovery (WP-17 audit F1)");
+    }
+
+    [Fact]
+    public async Task DiscoverySessionCreate_FdRole_IsNotBlocked()
+    {
+        // FD holds Patients.StartDiscovery in the manifest as of hash 7ae3aa5e3274 (plan-review
+        // ruling 1) — front desk keeps booking new patients' first (discovery) sessions.
+        var specialtyId = await SeedSpecialtyAsync(isDiscovery: true);
+
+        var response = await PostSessionAsync(specialtyId, _factory.MintRoleToken("FD"));
+
+        response.StatusCode.Should().NotBe(HttpStatusCode.Forbidden,
+            "FD holds Patients.StartDiscovery (hash 7ae3aa5e3274) — the gate must let it through");
+        response.StatusCode.Should().NotBe(HttpStatusCode.Unauthorized, "the token is valid");
+    }
+
+    [Fact]
+    public async Task TreatmentSessionCreate_WithoutStartDiscoveryClaim_IsNotBlockedByGate()
+    {
+        // The gate keys on the resolved specialty being a discovery type — a treatment-specialty
+        // request with only Appointments.Book must NOT 403 (it fails later on validation, not auth).
+        var specialtyId = await SeedSpecialtyAsync(isDiscovery: false);
+        var token = _factory.MintWithPermissions("Appointments.Book");
+
+        var response = await PostSessionAsync(specialtyId, token);
+
+        response.StatusCode.Should().NotBe(HttpStatusCode.Forbidden,
+            "the StartDiscovery gate must only fire for discovery-specialty requests");
+    }
+
+    private async Task<int> SeedSpecialtyAsync(bool isDiscovery)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var unique = Guid.NewGuid().ToString("N")[..6];
+        var specialty = new SpecialtyType
+        {
+            Abbreviation = (isDiscovery ? "Obs-" : "T-") + unique,
+            Name = (isDiscovery ? "Discovery " : "Treatment ") + unique,
+            IsDiscovery = isDiscovery,
+        };
+        db.SpecialtyTypes.Add(specialty);
+        await db.SaveChangesAsync();
+        return specialty.Id;
+    }
+
+    private async Task<HttpResponseMessage> PostSessionAsync(int specialtyTypeId, string token)
+    {
+        var body = $$"""
+            {
+              "sessionDate": "2026-07-20", "sessionTime": "10:00",
+              "patientId": 987654, "therapistId": 987654,
+              "duration": 60, "amount": 50.0,
+              "specialtyTypeId": {{specialtyTypeId}}
+            }
+            """;
+        var request = new HttpRequestMessage(HttpMethod.Post, "/api/sessions")
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json")
+        };
+        request.Headers.Authorization = new("Bearer", token);
+        return await _factory.CreateClient().SendAsync(request);
     }
 
     private async Task<int> CreatePatientAsync(bool senadis)

--- a/tests/Web.Tests/PatientsControllerTests.cs
+++ b/tests/Web.Tests/PatientsControllerTests.cs
@@ -388,6 +388,84 @@ public class PatientsControllerTests
         Assert.IsType<NoContentResult>(result);
     }
 
+    // ── WP-24 (F3/F4): requiresDiscovery field-level edit gate on PUT ─────────────────
+    // Changing the stored waiver flag needs Patients.RequiresDiscovery.Edit; omitted/null/
+    // echoed-unchanged values pass so FD clients that round-trip the profile keep working.
+
+    private void SetupPatientOnFileWithDiscovery(int id, bool requiresDiscovery)
+    {
+        _mockPatientProfileService
+            .Setup(s => s.GetByIdAsync(id))
+            .ReturnsAsync(new PatientProfile { PatientId = id, PatientName = "P", RequiresDiscovery = requiresDiscovery });
+        _mockPatientProfileService
+            .Setup(s => s.UpdateAsync(id, It.IsAny<PatientProfileUpdateRequest>()))
+            .ReturnsAsync(true);
+    }
+
+    [Fact]
+    public async Task UpdatePatient_RequiresDiscoveryChanged_WithoutClaim_ReturnsForbid_AndDoesNotUpdate()
+    {
+        SetupPatientOnFileWithDiscovery(7, requiresDiscovery: true);
+        UseCaller((SystemClaims.PermissionClaimType, Permissions.PatientsEdit)); // FD-like: Edit but not the gate
+
+        var result = await _controller.UpdatePatient(7,
+            new PatientProfileUpdateRequest { RequiresDiscovery = false });
+
+        Assert.IsType<ForbidResult>(result);
+        _mockPatientProfileService.Verify(
+            s => s.UpdateAsync(It.IsAny<int>(), It.IsAny<PatientProfileUpdateRequest>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UpdatePatient_RequiresDiscoveryChanged_WithClaim_Delegates()
+    {
+        SetupPatientOnFileWithDiscovery(7, requiresDiscovery: true);
+        UseCaller((SystemClaims.PermissionClaimType, Permissions.PatientsRequiresDiscoveryEdit));
+
+        var result = await _controller.UpdatePatient(7,
+            new PatientProfileUpdateRequest { RequiresDiscovery = false });
+
+        Assert.IsType<NoContentResult>(result);
+        _mockPatientProfileService.Verify(
+            s => s.UpdateAsync(7, It.Is<PatientProfileUpdateRequest>(r => r.RequiresDiscovery == false)), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdatePatient_RequiresDiscoveryChanged_WithWildcard_Delegates()
+    {
+        SetupPatientOnFileWithDiscovery(7, requiresDiscovery: false);
+        UseCaller((SystemClaims.SystemClaimType, SystemClaims.FullAccessValue)); // SYSADMIN
+
+        var result = await _controller.UpdatePatient(7,
+            new PatientProfileUpdateRequest { RequiresDiscovery = true });
+
+        Assert.IsType<NoContentResult>(result);
+    }
+
+    [Fact]
+    public async Task UpdatePatient_RequiresDiscoveryEchoedUnchanged_WithoutClaim_Passes()
+    {
+        SetupPatientOnFileWithDiscovery(7, requiresDiscovery: true);
+        UseCaller((SystemClaims.PermissionClaimType, Permissions.PatientsEdit));
+
+        var result = await _controller.UpdatePatient(7,
+            new PatientProfileUpdateRequest { RequiresDiscovery = true }); // echo, not a change
+
+        Assert.IsType<NoContentResult>(result);
+    }
+
+    [Fact]
+    public async Task UpdatePatient_RequiresDiscoveryOmitted_WithoutClaim_Passes()
+    {
+        SetupPatientOnFileWithDiscovery(7, requiresDiscovery: false);
+        UseCaller((SystemClaims.PermissionClaimType, Permissions.PatientsEdit));
+
+        var result = await _controller.UpdatePatient(7,
+            new PatientProfileUpdateRequest { FirstName = "Renamed" }); // null flag = unchanged
+
+        Assert.IsType<NoContentResult>(result);
+    }
+
     [Fact]
     public async Task UpdatePatient_UnknownPatient_Returns400()
     {

--- a/tests/Web.Tests/SessionsControllerTests.cs
+++ b/tests/Web.Tests/SessionsControllerTests.cs
@@ -174,9 +174,13 @@ public class SessionsControllerTests
         // Arrange
         var newSession = Mock.Of<SessionEventRequest>();
         var fakeNewSessionId = DateTime.UtcNow.Millisecond;
-        _mockSessionEventHandler        
+        // WP-24 (audit F1): a non-discovery request skips the Patients.StartDiscovery gate.
+        _mockSessionEventHandler
+            .Setup(x => x.IsDiscoveryRequestAsync(newSession))
+            .ReturnsAsync(false);
+        _mockSessionEventHandler
             .Setup(x => x.CreateAsync(newSession))
-            .ReturnsAsync(new SessionEvent(){SessionId = fakeNewSessionId});        
+            .ReturnsAsync(new SessionEvent(){SessionId = fakeNewSessionId});
 
         // Act
         var result = await _controller.CreateSession(newSession);


### PR DESCRIPTION
…overy-first waiver, Patients.StartDiscovery enforcement (audit F1) + manifest re-vendor 7ae3aa5e3274

- F3: Patient.RequiresDiscovery threaded WP-23B-style, default TRUE per Questionnaire C (entity initializer + 3 DTOs + 4 mapping sites; update = bool?, null = unchanged; omitted JSON create field => true)
- F4: SENADIS-clone field-level WRITE gate in PatientsController.UpdatePatient
  - present AND differs AND caller lacks Patients.RequiresDiscovery.Edit => Forbid(); both gates run before any update applies
- Discovery waiver: SessionEventHandler.CreateAsync completed-discovery check now runs only when pProfile.RequiresDiscovery (false = waived, e.g. the ~866 legacy-imported patients post-backfill)
- Audit F1 CLOSED: imperative Patients.StartDiscovery gate on POST /api/sessions - discovery-specialty requests 403 without the claim, nothing created; specialty resolution exposed via IHandleSessionEvent .IsDiscoveryRequestAsync (Core stays HttpContext-free); stale D-5 comment refreshed (FD holds the claim as of 7ae3aa5e3274)
- Manifest re-vendored 10ad6ddcd5dd -> 7ae3aa5e3274 (53 claims); Permissions .g.cs regen (+ PatientsRequiresDiscoveryEdit); conformance-baseline.txt untouched (imperative gate, no new [Authorize] policies)
- Tests red->green: suite 458 -> 476 (Core 156 / Infra 88 / Web 232): 5 SENADIS-shape controller facts, SensitiveCell rows (flag change FD/ACCT 403; MGR/AM/SYSADMIN pass; FD echo passes; discovery-create 403 without claim / FD passes / treatment-create untripped), Core waiver matrix + omitted-field serialization default
- Curls: docs/patient-requires-discovery-wp24-verification.md