### PR TITLE
WP-25B (F5): Cedula | Passport required at create; blank-on-update re…

### DIFF
--- a/docs/patient-cedula-required-wp25-verification.md
+++ b/docs/patient-cedula-required-wp25-verification.md
@@ -1,0 +1,104 @@
+# WP-25B verification — F5 "Cedula | Passport" required at create; blank-on-update rejected
+
+Post-deploy curls (run against the deployed API, e.g. `http://neurocorp.k3s:30000`, once the API
+ships this WP — no DB step, no reseed: the column stays `varchar(50) NULL` for the ~866
+legacy-imported NULL-cedula patients). All IDs/values below are examples — substitute real ones.
+
+```bash
+API=http://neurocorp.k3s:30000
+```
+
+## 0. Token
+
+> ⚠️ The login field is `email`, NOT `username` (binds empty → 401).
+
+```bash
+# Any patient-creating operator role works (FD/AM/MGR) — MGR shown.
+MGR_TOKEN=$(curl -s $API/api/auth/login -H 'Content-Type: application/json' \
+  -d '{"email":"<mgr email>","password":"<pwd>"}' | jq -r .accessToken)
+```
+
+## 1. Create WITHOUT cedula → 400
+
+```bash
+curl -s -w '\n%{http_code}\n' -X POST "$API/api/patients" \
+  -H "Authorization: Bearer $MGR_TOKEN" -H 'Content-Type: application/json' -d '{
+  "firstName":"Wp25","lastName":"NoCedula","middleName":"",
+  "medicalRecordNumber":"WP25-VERIFY-001",
+  "dateOfBirth":"2015-06-01","email":"wp25-nocedula@verify.test",
+  "phoneNumber":"555-0100","gender":"Other"}'
+# expect: 400 — model validation names the Cedula field; NO patient row is created
+```
+
+## 2. Create with BLANK cedula → 400
+
+```bash
+# empty string and whitespace-only both fail [Required] — the pre-WP-25 silent NULL insert is gone
+curl -s -w '\n%{http_code}\n' -X POST "$API/api/patients" \
+  -H "Authorization: Bearer $MGR_TOKEN" -H 'Content-Type: application/json' -d '{
+  "firstName":"Wp25","lastName":"BlankCedula","middleName":"",
+  "medicalRecordNumber":"WP25-VERIFY-002","cedula":"   ",
+  "dateOfBirth":"2015-06-01","email":"wp25-blank@verify.test",
+  "phoneNumber":"555-0100","gender":"Other"}'
+# expect: 400 mentioning Cedula
+```
+
+## 3. Create WITH cedula → 201
+
+```bash
+curl -s -w '\n%{http_code}\n' -X POST "$API/api/patients" \
+  -H "Authorization: Bearer $MGR_TOKEN" -H 'Content-Type: application/json' -d '{
+  "firstName":"Wp25","lastName":"WithCedula","middleName":"",
+  "medicalRecordNumber":"WP25-VERIFY-003","cedula":"WP25-8-999-001",
+  "dateOfBirth":"2015-06-01","email":"wp25-with@verify.test",
+  "phoneNumber":"555-0100","gender":"Other"}'
+# expect: 201 + PatientProfile JSON with "cedula": "WP25-8-999-001"
+# note the returned patientId — used as $PID below
+```
+
+## 4. PUT blank cedula → 400 "cannot be cleared" (erase removed)
+
+```bash
+curl -s -w '\n%{http_code}\n' -X PUT "$API/api/patients/$PID" \
+  -H "Authorization: Bearer $MGR_TOKEN" -H 'Content-Type: application/json' \
+  -d '{"cedula":""}'
+# expect: 400 — "Cedula | Passport cannot be cleared - it is required once on file."
+#         (WP-25 supersedes the WP-18-followup blank-erase; GET the patient back → value intact)
+```
+
+## 5. PUT with cedula OMITTED on a legacy NULL-cedula patient → 204 (tolerant ruling)
+
+```bash
+# Pick any legacy-imported patient with cedula NULL — e.g. an L24/L25/L26 MRN patient:
+#   GET "$API/api/patients" and find one with "cedula": null; use its id as $LEGACY_ID.
+# A quick front-desk fix (phone) that never mentions cedula must still save:
+curl -s -o /dev/null -w '%{http_code}\n' -X PUT "$API/api/patients/$LEGACY_ID" \
+  -H "Authorization: Bearer $MGR_TOKEN" -H 'Content-Type: application/json' \
+  -d '{"phoneNumber":"555-0199"}'
+# expect: 204 — omitted/null = unchanged, ALWAYS (legacy patients stay editable;
+#         the Active toggle path rides this same tolerance)
+```
+
+## 6. Duplicate cedula → 409
+
+```bash
+curl -s -w '\n%{http_code}\n' -X POST "$API/api/patients" \
+  -H "Authorization: Bearer $MGR_TOKEN" -H 'Content-Type: application/json' -d '{
+  "firstName":"Wp25","lastName":"DupCedula","middleName":"",
+  "medicalRecordNumber":"WP25-VERIFY-004","cedula":"WP25-8-999-001",
+  "dateOfBirth":"2015-06-01","email":"wp25-dup@verify.test",
+  "phoneNumber":"555-0100","gender":"Other"}'
+# expect: 409 — "A patient with this Cedula already exists." (uq_patient_cedula)
+```
+
+## Cleanup
+
+```sql
+-- Remove verification patients (children first). Find them:
+SELECT p.PatientID, p.UserID FROM Patient p JOIN SystemUser su ON su.UserID = p.UserID
+WHERE su.Email LIKE 'wp25-%@verify.test';
+-- Then: DELETE FROM PatientCaretaker WHERE PatientID IN (...);
+--       DELETE FROM UserRole WHERE UserID IN (...); DELETE FROM Patient WHERE PatientID IN (...);
+--       DELETE FROM SystemUser WHERE UserID IN (...);
+-- (revert the $LEGACY_ID phone number if it matters)
+```

--- a/src/Core/BusinessObjects/Patients/PatientProfileRequest.cs
+++ b/src/Core/BusinessObjects/Patients/PatientProfileRequest.cs
@@ -22,6 +22,11 @@ public class PatientProfileRequest
     [Required]
     public string LastName { get; set; }
     public string MedicalRecordNumber { get; set; }
+    // WP-25 (F5, Questionnaire D): "Cedula | Passport" is mandatory at create — missing or
+    // blank/whitespace is a 400 at the model-validation layer (was optional in WP-18; blanks
+    // used to insert NULL silently). Legacy-imported NULL rows stay editable via the tolerant
+    // update path in PatientProfileRepository.MapToUpdatedPatient.
+    [Required]
     public string Cedula { get; set; }
     [Required]
     public DateTime DateOfBirth { get; set; }

--- a/src/Infrastructure/Repositories/PatientProfileRepository.cs
+++ b/src/Infrastructure/Repositories/PatientProfileRepository.cs
@@ -139,13 +139,18 @@ public class PatientProfileRepository(ApplicationDbContext dbContext) :
         { patientOnFile.DateOfBirth = patientRequest.DateOfBirth; }
         if (!string.IsNullOrEmpty(patientRequest.MedicalRecordNumber))
         { patientOnFile.MedicalRecordNumber = patientRequest.MedicalRecordNumber; }
-        // Cedula supports an explicit erase (intake 2026-06-29-001 item 3): omitted/null = leave
-        // as-is; present but blank = clear to NULL (unique index allows multiple NULLs); else set.
+        // WP-25 (F5) — supersedes intake 2026-06-29-001 item 3 (blank-erase removed).
+        // Omitted/null = leave as-is: this is the legacy-tolerance keystone that keeps the ~866
+        // legacy-imported NULL-cedula patients editable (and the Active toggle working) — do NOT
+        // touch it. Present-but-blank = rejected clear attempt (→ 400 via GlobalExceptionHandler);
+        // non-blank = set (duplicate → 409 on uq_patient_cedula).
         if (patientRequest.Cedula != null)
         {
-            patientOnFile.Cedula = string.IsNullOrWhiteSpace(patientRequest.Cedula)
-                ? null
-                : patientRequest.Cedula;
+            if (string.IsNullOrWhiteSpace(patientRequest.Cedula))
+            {
+                throw new ArgumentException("Cedula | Passport cannot be cleared - it is required once on file.");
+            }
+            patientOnFile.Cedula = patientRequest.Cedula;
         }
         // WP-23 (F7): null = unchanged; the claim gate ran in the controller before we get here.
         if (patientRequest.HasSenadisDiscount.HasValue)

--- a/tests/Core.Tests/PatientProfileServiceTests.cs
+++ b/tests/Core.Tests/PatientProfileServiceTests.cs
@@ -189,11 +189,12 @@ public class PatientProfileServiceTests
         mockPatientRepo.Verify(r => r.UpdateAsync(It.IsAny<Patient>()), Times.Never);
     }
 
+    // WP-25 (F5): blank/missing cedula is now rejected upstream by [Required] model validation,
+    // so the old blank→NULL theory cases are gone; MapToNewPatient keeps the normalization purely
+    // as defense-in-depth. This test asserts the happy path: the value flows to the new entity.
     [Theory]
     [InlineData("001-1234567-8", "001-1234567-8")] // provided value flows to the new entity
-    [InlineData("", null)]                          // blank normalized to null (avoids unique-constraint clash)
-    [InlineData("   ", null)]                        // whitespace normalized to null
-    public async Task CreateAsync_MapsCedula_NormalizingBlankToNull(string requestCedula, string? expectedCedula)
+    public async Task CreateAsync_MapsCedula_ValueFlowsToNewPatient(string requestCedula, string? expectedCedula)
     {
         // Arrange
         var fakeLogger = Mock.Of<ILogger<PatientProfileService>>();

--- a/tests/Infrastructure.Tests/PatientProfileRepositoryTests.cs
+++ b/tests/Infrastructure.Tests/PatientProfileRepositoryTests.cs
@@ -115,13 +115,14 @@ public class PatientProfileRepositoryTests
         }
     }
 
-    // Regression (intake 2026-06-29-001 item 3): a present-but-blank Cedula in the update request
-    // is an explicit "erase" and must clear the column to NULL. Previously the blank was silently
-    // ignored (same non-empty⇒assign pattern as MRN), so a Cedula could never be removed.
+    // WP-25 (F5) — supersedes intake 2026-06-29-001 item 3 (blank-erase removed): Cedula |
+    // Passport is required once on file, so a present-but-blank value is now a rejected clear
+    // attempt: ArgumentException (→ 400 via GlobalExceptionHandler) and the stored value must
+    // remain untouched. Omitted/null still means "leave as-is" (legacy tolerance, next test).
     [Theory]
     [InlineData("")]
     [InlineData("   ")]
-    public async Task UpdateAsync_BlankCedula_ClearsToNull(string blank)
+    public async Task UpdateAsync_BlankCedula_Throws(string blank)
     {
         // Arrange — patient already has a Cedula on file
         var options = CreateInMemoryOptions($"PatientCedula_Clear_{blank.Length}");
@@ -150,19 +151,17 @@ public class PatientProfileRepositoryTests
                 Cedula = blank
             };
 
-            // Act
-            var result = await repository.UpdateAsync(1, 1, updateRequest);
-
-            // Assert — projection reflects the erase
-            Assert.Null(result.Cedula);
+            // Act + Assert — the clear attempt is rejected before anything is saved
+            var ex = await Assert.ThrowsAsync<ArgumentException>(() => repository.UpdateAsync(1, 1, updateRequest));
+            Assert.Contains("cannot be cleared", ex.Message);
         }
 
-        // Assert — NULL persisted (not the old value, not the blank string)
+        // Assert — the stored value is unchanged (not NULL, not the blank string)
         using (var context = new ApplicationDbContext(options))
         {
             var patient = await context.Patients.FindAsync(1);
             Assert.NotNull(patient);
-            Assert.Null(patient.Cedula);
+            Assert.Equal("001-1234567-8", patient.Cedula);
         }
     }
 

--- a/tests/Web.Tests/Authorization/SensitiveCellAuthorizationTests.cs
+++ b/tests/Web.Tests/Authorization/SensitiveCellAuthorizationTests.cs
@@ -435,6 +435,7 @@ public class SensitiveCellAuthorizationTests : IClassFixture<AccessControlTestFa
             {
               "firstName": "Wp23", "middleName": "", "lastName": "Gate-{{unique}}",
               "medicalRecordNumber": "WP23-{{unique}}",
+              "cedula": "CED-{{unique}}",
               "dateOfBirth": "2015-01-01T00:00:00", "email": "wp23-{{unique}}@neurocorp.test",
               "phoneNumber": "555-0100", "gender": "Other",
               "hasSenadisDiscount": {{(senadis ? "true" : "false")}}

--- a/tests/Web.Tests/PatientCreateValidationTests.cs
+++ b/tests/Web.Tests/PatientCreateValidationTests.cs
@@ -27,18 +27,23 @@ public class PatientCreateValidationTests : IClassFixture<AccessControlTestFacto
         return client;
     }
 
-    private static object CreateBody(string? gender, string suffix) => new
+    private static object CreateBody(string? gender, string suffix, string? cedula) => new
     {
         firstName = "B1",
         lastName = $"Regression-{suffix}",
         middleName = "",
         medicalRecordNumber = $"B1-TEST-{suffix}",
-        cedula = "",
+        cedula,
         dateOfBirth = "2015-06-01",
         email = $"b1-{suffix}@neurocorp.test",
         phoneNumber = "555-0100",
         gender,
     };
+
+    // WP-25 (F5): cedula is required at create, and uq_patient_cedula is UNIQUE — every create
+    // body gets its own value (a shared constant would 409 the second successful create).
+    private static object CreateBody(string? gender, string suffix) =>
+        CreateBody(gender, suffix, $"WP25-{suffix}-{Guid.NewGuid().ToString("N")[..8]}");
 
     [Theory]
     [InlineData("Nonbinary")]
@@ -76,6 +81,34 @@ public class PatientCreateValidationTests : IClassFixture<AccessControlTestFacto
         var response = await client.PostAsJsonAsync("/api/patients", CreateBody(gender, suffix));
 
         response.StatusCode.Should().Be(HttpStatusCode.Created);
+    }
+
+    // WP-25 (F5, Questionnaire D): "Cedula | Passport" is mandatory at create. Missing (null) or
+    // blank/whitespace must be a 400 at the model-validation layer — never a silent NULL insert.
+    [Fact]
+    public async Task Post_WithMissingCedula_Returns400()
+    {
+        var client = CreateMgrClient();
+
+        var response = await client.PostAsJsonAsync("/api/patients", CreateBody("Male", "ced-missing", cedula: null));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("Cedula");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task Post_WithBlankCedula_Returns400(string blankCedula)
+    {
+        var client = CreateMgrClient();
+
+        var response = await client.PostAsJsonAsync("/api/patients", CreateBody("Male", $"ced-blank-{blankCedula.Length}", blankCedula));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("Cedula");
     }
 
     [Fact]


### PR DESCRIPTION
…jected (erase removed); tolerant-for-legacy omitted=unchanged

Claude-Session: https://claude.ai/code/session_01QYyYi9j1odiGeUgfygwTo3